### PR TITLE
Add STEP geometry import with tessellation and 3D preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ name = "kofem-geom"
 version = "0.1.0"
 dependencies = [
  "kofem-mesh",
+ "serde",
  "thiserror",
 ]
 
@@ -142,6 +143,7 @@ dependencies = [
  "console_error_panic_hook",
  "js-sys",
  "kofem-core",
+ "kofem-geom",
  "kofem-mesh",
  "serde",
  "serde-wasm-bindgen",

--- a/crates/kofem-geom/Cargo.toml
+++ b/crates/kofem-geom/Cargo.toml
@@ -9,3 +9,4 @@ description = "Geometry import/export for KoFEM (STEP, IGES, STL)"
 [dependencies]
 thiserror = { workspace = true }
 kofem-mesh = { workspace = true }
+serde = { workspace = true }

--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -7,6 +7,8 @@
 
 use std::f64::consts::PI;
 
+use serde::Serialize;
+
 use kofem_mesh::geom::Point2;
 use kofem_mesh::triangulate::triangulate;
 
@@ -19,7 +21,7 @@ use crate::step::topology::{BRep, TopoEdge, TopoFace};
 
 // ── Public types ───────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SurfaceMesh {
     pub points: Vec<[f64; 3]>,
     pub triangles: Vec<[usize; 3]>,

--- a/crates/kofem-wasm/Cargo.toml
+++ b/crates/kofem-wasm/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 kofem-core = { workspace = true, features = ["std", "serde"] }
 kofem-mesh = { workspace = true }
+kofem-geom = { path = "../kofem-geom" }
 wasm-bindgen = "0.2"
 serde = { workspace = true }
 serde-wasm-bindgen = "0.6"
@@ -21,4 +22,4 @@ console_error_panic_hook = "0.1"
 web-sys = { version = "0.3", features = ["console"] }
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Oz", "--enable-mutable-globals"]
+wasm-opt = false

--- a/crates/kofem-wasm/src/lib.rs
+++ b/crates/kofem-wasm/src/lib.rs
@@ -1,3 +1,6 @@
+use kofem_geom::step::parser::parse as parse_step_text;
+use kofem_geom::step::topology::BRep;
+use kofem_geom::tess::{tessellate, TessOptions};
 use kofem_mesh::geom::Point2;
 use kofem_mesh::{extrude, refine, triangulate};
 
@@ -257,6 +260,21 @@ pub fn mesh_polygon(
         );
     }
 
+    serde_json::to_string(&mesh).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Parse and tessellate a STEP file into a surface triangle mesh.
+///
+/// Returns a JSON object `{ points: [[x,y,z], …], triangles: [[a,b,c], …] }`.
+#[wasm_bindgen]
+pub fn tessellate_step(step_text: &str, max_edge_len: f64) -> Result<String, JsError> {
+    let file = parse_step_text(step_text).map_err(|e| JsError::new(&e.to_string()))?;
+    let brep = BRep::extract(&file).map_err(|e| JsError::new(&e.to_string()))?;
+    let opts = TessOptions {
+        max_edge_len,
+        ..TessOptions::default()
+    };
+    let mesh = tessellate(&brep, &file, opts).map_err(|e| JsError::new(&e.to_string()))?;
     serde_json::to_string(&mesh).map_err(|e| JsError::new(&e.to_string()))
 }
 

--- a/web/src/components/toolbar/Toolbar.tsx
+++ b/web/src/components/toolbar/Toolbar.tsx
@@ -11,9 +11,12 @@ export function Toolbar() {
   const setRunning = useModelStore(s => s.setRunning)
   const setResult = useModelStore(s => s.setResult)
   const loadModel = useModelStore(s => s.loadModel)
+  const setStepSurface = useModelStore(s => s.setStepSurface)
 
   const [isParsing, setIsParsing] = useState(false)
-  const fileInputRef = { current: null as HTMLInputElement | null }
+  const [isImportingStep, setIsImportingStep] = useState(false)
+  const inpFileRef = { current: null as HTMLInputElement | null }
+  const stepFileRef = { current: null as HTMLInputElement | null }
 
   const handleSolve = () => {
     const state = useModelStore.getState()
@@ -31,11 +34,10 @@ export function Toolbar() {
       .finally(() => setRunning(false))
   }
 
-  const handleImportClick = () => {
-    fileInputRef.current?.click()
-  }
+  const handleImportInpClick = () => { inpFileRef.current?.click() }
+  const handleImportStepClick = () => { stepFileRef.current?.click() }
 
-  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+  const handleInpFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
     e.target.value = ''
@@ -54,19 +56,50 @@ export function Toolbar() {
       .finally(() => { setIsParsing(false); setRunning(false) })
   }
 
+  const handleStepFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    e.target.value = ''
+    setIsImportingStep(true)
+    setRunning(true)
+    const text = await file.text()
+    sendToWorker<{ points: [number, number, number][]; triangles: [number, number, number][] }>(
+      'parse_step', { text }
+    )
+      .then(({ points, triangles }) => {
+        if (points.length === 0) {
+          alert('No geometry found in STEP file.')
+        } else {
+          setStepSurface({ points, triangles })
+        }
+      })
+      .catch(err => alert(`STEP import error: ${err.message}`))
+      .finally(() => { setIsImportingStep(false); setRunning(false) })
+  }
+
   const busy = isRunning || isMeshing
 
   return (
     <div className={styles.toolbar}>
       <input
-        ref={el => { fileInputRef.current = el }}
+        ref={el => { inpFileRef.current = el }}
         type="file"
         accept=".inp"
         style={{ display: 'none' }}
-        onChange={handleFileChange}
+        onChange={handleInpFileChange}
       />
-      <button className={styles.btn} onClick={handleImportClick} disabled={busy} title="Import Abaqus INP file (*.inp)">
-        {isParsing ? 'Parsing…' : 'Import'}
+      <input
+        ref={el => { stepFileRef.current = el }}
+        type="file"
+        accept=".stp,.step"
+        style={{ display: 'none' }}
+        onChange={handleStepFileChange}
+      />
+      <button className={styles.btn} onClick={handleImportInpClick} disabled={busy} title="Import Abaqus INP file (*.inp)">
+        {isParsing ? 'Parsing…' : 'Import INP'}
+      </button>
+      <button className={styles.btn} onClick={handleImportStepClick} disabled={busy} title="Import STEP geometry file (*.stp, *.step)">
+        {isImportingStep ? 'Importing…' : 'Import STEP'}
       </button>
       <button className={styles.btn} title="Export results" disabled>
         Export
@@ -74,7 +107,7 @@ export function Toolbar() {
       <span className={styles.modelName}>{modelName}</span>
       <div className={styles.divider} />
       <button className={`${styles.btn} ${styles.primary}`} onClick={handleSolve} disabled={busy}>
-        {isRunning && !isParsing ? 'Solving…' : 'Solve'}
+        {isRunning && !isParsing && !isImportingStep ? 'Solving…' : 'Solve'}
       </button>
       <button className={styles.btn} onClick={reset} disabled={busy}>
         Reset

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -78,6 +78,7 @@ export function MeshScene() {
   const constraints = useModelStore(s => s.constraints)
   const loads = useModelStore(s => s.loads)
   const result = useModelStore(s => s.result)
+  const stepSurface = useModelStore(s => s.stepSurface)
   const pickMode = useModelStore(s => s.pickMode)
   const selectedFace = useModelStore(s => s.selectedFace)
   const setSelectedFace = useModelStore(s => s.setSelectedFace)
@@ -277,7 +278,21 @@ export function MeshScene() {
     return n > 0 ? [x / n, y / n, z / n] : null
   }, [loads, nodeMap])
 
-  if (nodes.length === 0) {
+  const stepGeometry = useMemo(() => {
+    if (!stepSurface || stepSurface.triangles.length === 0) return null
+    const { points, triangles } = stepSurface
+    const positions = new Float32Array(triangles.length * 9)
+    let pi = 0
+    for (const [a, b, c] of triangles) {
+      const pa = points[a], pb = points[b], pc = points[c]
+      positions[pi++] = pa[0]; positions[pi++] = pa[1]; positions[pi++] = pa[2]
+      positions[pi++] = pb[0]; positions[pi++] = pb[1]; positions[pi++] = pb[2]
+      positions[pi++] = pc[0]; positions[pi++] = pc[1]; positions[pi++] = pc[2]
+    }
+    return positions
+  }, [stepSurface])
+
+  if (nodes.length === 0 && !stepGeometry) {
     return (
       <mesh>
         <boxGeometry args={[1, 1, 1]} />
@@ -346,6 +361,16 @@ export function MeshScene() {
         <mesh position={loadMarkerPos}>
           <sphereGeometry args={[modelSize * 0.015, 16, 16]} />
           <meshStandardMaterial color="#ffcc00" />
+        </mesh>
+      )}
+
+      {/* STEP surface mesh — grey shaded */}
+      {stepGeometry && (
+        <mesh>
+          <bufferGeometry>
+            <bufferAttribute attach="attributes-position" args={[stepGeometry, 3]} />
+          </bufferGeometry>
+          <meshStandardMaterial color="#8899bb" side={THREE.DoubleSide} />
         </mesh>
       )}
     </group>

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -60,6 +60,11 @@ export interface SolverResult {
   vonMises?: Float64Array
 }
 
+export interface StepSurfaceMesh {
+  points: [number, number, number][]
+  triangles: [number, number, number][]
+}
+
 // ── Geometry ──────────────────────────────────────────────────────────────────
 
 export interface BoxGeometry {
@@ -166,6 +171,7 @@ export interface ModelSnapshot {
 interface ModelState extends ModelSnapshot {
   modelName: string
   result: SolverResult | null
+  stepSurface: StepSurfaceMesh | null
   isRunning: boolean
   isMeshing: boolean
   geometries: BoxGeometry[]
@@ -173,6 +179,8 @@ interface ModelState extends ModelSnapshot {
   nextMatId: number
   pickMode: 'bc' | 'load' | null
   selectedFace: FaceSelection | null
+
+  setStepSurface(mesh: StepSurfaceMesh | null): void
 
   // Solver
   addNode(node: Node): void
@@ -213,6 +221,7 @@ export const useModelStore = create<ModelState>()(
     ...cantilever,
     modelName: 'Cantilever Beam',
     result: null,
+    stepSurface: null,
     isRunning: false,
     isMeshing: false,
     geometries: [DEFAULT_GEOMETRY],
@@ -220,6 +229,8 @@ export const useModelStore = create<ModelState>()(
     nextMatId: 2,
     pickMode: null,
     selectedFace: null,
+
+    setStepSurface: (mesh) => set(s => { s.stepSurface = mesh }),
 
     addNode: (node) => set(s => { s.nodes.push(node) }),
     addElement: (el) => set(s => { s.elements.push(el) }),
@@ -265,6 +276,7 @@ export const useModelStore = create<ModelState>()(
       s.constraints = c.constraints; s.loads = c.loads
       s.modelName = 'Cantilever Beam'
       s.result = null
+      s.stepSurface = null
       s.geometries = [DEFAULT_GEOMETRY]
       s.nextGeomId = 2
       s.nextMatId = 2

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -6,6 +6,7 @@ import init, {
   parse_inp_model,
   mesh_polygon,
   extrude_mesh,
+  tessellate_step,
 } from '../wasm/pkg/kofem_wasm'
 
 let initialized = false
@@ -39,6 +40,14 @@ self.onmessage = async (event: MessageEvent) => {
     } else if (type === 'parse') {
       const modelJson = parse_inp_model(payload.text)
       self.postMessage({ id, ok: true, model: JSON.parse(modelJson) })
+
+    } else if (type === 'parse_step') {
+      const meshJson = tessellate_step(payload.text, payload.maxEdgeLen ?? 5.0)
+      const mesh = JSON.parse(meshJson) as {
+        points: [number, number, number][]
+        triangles: [number, number, number][]
+      }
+      self.postMessage({ id, ok: true, points: mesh.points, triangles: mesh.triangles })
 
     } else if (type === 'mesh') {
       const geom = payload as BoxGeometry

--- a/web/tests/solve.spec.ts
+++ b/web/tests/solve.spec.ts
@@ -7,7 +7,8 @@ test('page loads with toolbar and viewport', async ({ page }) => {
   await page.goto('/')
 
   await expect(page.getByRole('button', { name: 'Solve' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Import' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Import INP' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Import STEP' })).toBeVisible()
   expect(errors).toHaveLength(0)
 })
 


### PR DESCRIPTION
## Summary
Adds support for importing STEP CAD files (`.stp`, `.step`) into the FEM application. The geometry is parsed, tessellated into a surface triangle mesh, and displayed as a shaded preview in the 3D viewport alongside the FEM mesh.

## Key Changes

- **WASM binding** (`kofem-wasm/src/lib.rs`): New `tessellate_step()` function that parses STEP text, extracts B-Rep topology, and tessellates surfaces into triangle meshes using configurable edge length tolerance.

- **Geometry serialization** (`kofem-geom/src/tess/mod.rs`): Added `Serialize` derive to `SurfaceMesh` struct to enable JSON export of tessellated geometry.

- **Store state** (`web/src/store/modelStore.ts`): 
  - New `StepSurfaceMesh` interface for storing point and triangle data
  - New `stepSurface` state field and `setStepSurface()` action
  - Reset clears imported STEP geometry on model reset

- **UI** (`web/src/components/toolbar/Toolbar.tsx`):
  - Separate "Import INP" and "Import STEP" buttons with distinct file inputs
  - New `isImportingStep` state to track STEP import progress
  - Refactored file input refs for clarity (`inpFileRef`, `stepFileRef`)
  - Worker message dispatch for `parse_step` with configurable tessellation tolerance

- **3D Rendering** (`web/src/components/viewport/MeshScene.tsx`):
  - New `stepGeometry` memo that converts STEP surface mesh into Three.js `BufferGeometry`
  - Renders as grey shaded mesh (`#8899bb`) with `DoubleSide` material
  - Scene displays STEP geometry even when no FEM mesh is loaded

- **Worker** (`web/src/workers/solver.worker.ts`): Added `parse_step` message handler that calls WASM tessellation and returns points and triangles.

- **Dependencies** (`crates/kofem-wasm/Cargo.toml`, `crates/kofem-geom/Cargo.toml`):
  - Added `kofem-geom` dependency to WASM crate
  - Added `serde` dependency to geometry crate
  - Disabled `wasm-opt` in release profile to preserve debug symbols during development

## Implementation Details

- STEP parsing and tessellation run in the Web Worker to avoid blocking the UI
- Tessellation uses a default max edge length of 5.0 meters (configurable)
- Surface mesh is stored in the model store and persists until explicitly cleared or model is reset
- Three.js rendering uses flat-shaded grey material to visually distinguish imported geometry from FEM results

https://claude.ai/code/session_01YLKWxfeZxkBQwdziRxgktL