### PR TITLE
Fix face normal orientation via FACE_OUTER_BOUND.orientation flag

### DIFF
--- a/crates/kofem-geom/src/step/topology.rs
+++ b/crates/kofem-geom/src/step/topology.rs
@@ -9,6 +9,9 @@ pub struct BRep {
 pub struct TopoFace {
     pub surface_id: u64,
     pub same_sense: bool,
+    /// `FACE_OUTER_BOUND.orientation` — when `false` the stored loop must be
+    /// traversed in reverse to get the outward-facing CCW winding.
+    pub outer_loop_orientation: bool,
     pub outer_loop: Vec<TopoEdge>,
     pub inner_loops: Vec<Vec<TopoEdge>>,
 }
@@ -107,6 +110,8 @@ fn extract_face(file: &StepFile, face_id: u64) -> Result<TopoFace, TopologyError
     let mut outer_loop: Option<Vec<TopoEdge>> = None;
     let mut inner_loops: Vec<Vec<TopoEdge>> = Vec::new();
 
+    let mut outer_loop_orientation = true;
+
     for b_arg in bounds {
         let bound_id = match b_arg {
             Arg::Ref(id) => *id,
@@ -115,10 +120,12 @@ fn extract_face(file: &StepFile, face_id: u64) -> Result<TopoFace, TopologyError
         let bound = entity(file, bound_id)?;
         // FACE_OUTER_BOUND or FACE_BOUND: (label, edge_loop_ref, orientation)
         let loop_id = ref_arg(bound, 1)?;
+        let orientation = enum_arg(bound, 2).map(|s| s == "T").unwrap_or(true);
         let edges = extract_edge_loop(file, loop_id)?;
 
         if bound.type_name == "FACE_OUTER_BOUND" {
             outer_loop = Some(edges);
+            outer_loop_orientation = orientation;
         } else {
             inner_loops.push(edges);
         }
@@ -128,6 +135,7 @@ fn extract_face(file: &StepFile, face_id: u64) -> Result<TopoFace, TopologyError
     Ok(TopoFace {
         surface_id,
         same_sense,
+        outer_loop_orientation,
         outer_loop,
         inner_loops,
     })

--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -56,6 +56,12 @@ pub enum TessError {
 /// No surface evaluation — just takes the outer-loop start vertices and fans
 /// triangles from vertex 0.  Produces a faceted but always-valid mesh.
 pub fn fan_tessellate(face: &TopoFace) -> SurfaceMesh {
+    let mesh = fan_raw(face);
+    flip_winding_if(mesh, !face.outer_loop_orientation)
+}
+
+/// Raw fan triangulation without orientation correction.
+fn fan_raw(face: &TopoFace) -> SurfaceMesh {
     let points: Vec<[f64; 3]> = face.outer_loop.iter().map(|e| e.start).collect();
     let n = points.len();
     if n < 3 {
@@ -66,6 +72,16 @@ pub fn fan_tessellate(face: &TopoFace) -> SurfaceMesh {
     }
     let triangles = (1..n - 1).map(|i| [0, i, i + 1]).collect();
     SurfaceMesh { points, triangles }
+}
+
+/// Flip `[a,b,c]` → `[a,c,b]` on every triangle when `flip` is true.
+fn flip_winding_if(mut mesh: SurfaceMesh, flip: bool) -> SurfaceMesh {
+    if flip {
+        for tri in &mut mesh.triangles {
+            tri.swap(1, 2);
+        }
+    }
+    mesh
 }
 
 /// Tessellate the complete B-rep into a single (approximately) watertight mesh.
@@ -102,29 +118,34 @@ pub fn tessellate(
 // ── Face tessellation ──────────────────────────────────────────────────────────
 
 fn tessellate_face(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> SurfaceMesh {
+    let raw = tessellate_face_raw(face, file, max_edge_len);
+    flip_winding_if(raw, !face.outer_loop_orientation)
+}
+
+fn tessellate_face_raw(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> SurfaceMesh {
     let boundary = sample_boundary_3d(&face.outer_loop, file, max_edge_len);
 
     if boundary.len() < 3 {
-        return fan_tessellate(face);
+        return fan_raw(face);
     }
 
     let normal = match face_normal(&boundary) {
         Some(n) => n,
-        None => return fan_tessellate(face),
+        None => return fan_raw(face),
     };
 
     let (pts2d, origin, x_axis, y_axis) = project_to_2d(&boundary, normal);
 
     let pts2d = deduplicate_2d(pts2d);
     if pts2d.len() < 3 {
-        return fan_tessellate(face);
+        return fan_raw(face);
     }
 
     let pts2d = ensure_ccw(pts2d);
 
     // Guard: polygon must have non-negligible area.
     if polygon_area_2d(&pts2d).abs() < 1e-20 {
-        return fan_tessellate(face);
+        return fan_raw(face);
     }
 
     let mesh2d = triangulate(&pts2d);

--- a/crates/kofem-geom/tests/tess.rs
+++ b/crates/kofem-geom/tests/tess.rs
@@ -2,10 +2,145 @@ use kofem_geom::step::topology::{TopoEdge, TopoFace};
 use kofem_geom::step::{parse, BRep};
 use kofem_geom::tess::{fan_tessellate, tessellate, TessOptions};
 
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+fn tri_normal(pts: &[[f64; 3]], tri: [usize; 3]) -> [f64; 3] {
+    let a = pts[tri[0]];
+    let b = pts[tri[1]];
+    let c = pts[tri[2]];
+    let ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    let ac = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+    let n = [
+        ab[1] * ac[2] - ab[2] * ac[1],
+        ab[2] * ac[0] - ab[0] * ac[2],
+        ab[0] * ac[1] - ab[1] * ac[0],
+    ];
+    let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+    if len < 1e-15 {
+        return n;
+    }
+    [n[0] / len, n[1] / len, n[2] / len]
+}
+
+fn mesh_area(pts: &[[f64; 3]], tris: &[[usize; 3]]) -> f64 {
+    tris.iter()
+        .map(|&[a, b, c]| {
+            let pa = pts[a];
+            let pb = pts[b];
+            let pc = pts[c];
+            let ab = [pb[0] - pa[0], pb[1] - pa[1], pb[2] - pa[2]];
+            let ac = [pc[0] - pa[0], pc[1] - pa[1], pc[2] - pa[2]];
+            let cross = [
+                ab[1] * ac[2] - ab[2] * ac[1],
+                ab[2] * ac[0] - ab[0] * ac[2],
+                ab[0] * ac[1] - ab[1] * ac[0],
+            ];
+            (cross[0] * cross[0] + cross[1] * cross[1] + cross[2] * cross[2]).sqrt() / 2.0
+        })
+        .sum()
+}
+
+/// Minimal STEP string: unit square in XY, CW stored loop, bound.orientation=F,
+/// same_sense=T.  Matches the convention used by the bracket CAD exporter.
+const STEP_UNIT_SQUARE_BOUND_F: &str = "
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('test'));
+ENDSEC;
+DATA;
+#1=CARTESIAN_POINT('',(0.,0.,0.));
+#2=CARTESIAN_POINT('',(1.,0.,0.));
+#3=CARTESIAN_POINT('',(1.,1.,0.));
+#4=CARTESIAN_POINT('',(0.,1.,0.));
+#5=VERTEX_POINT('',#1);
+#6=VERTEX_POINT('',#2);
+#7=VERTEX_POINT('',#3);
+#8=VERTEX_POINT('',#4);
+#9=DIRECTION('',(0.,1.,0.));
+#10=VECTOR('',#9,1.);
+#11=LINE('',#1,#10);
+#12=EDGE_CURVE('',#5,#8,#11,.T.);
+#13=DIRECTION('',(1.,0.,0.));
+#14=VECTOR('',#13,1.);
+#15=LINE('',#4,#14);
+#16=EDGE_CURVE('',#8,#7,#15,.T.);
+#17=DIRECTION('',(0.,-1.,0.));
+#18=VECTOR('',#17,1.);
+#19=LINE('',#3,#18);
+#20=EDGE_CURVE('',#7,#6,#19,.T.);
+#21=DIRECTION('',(-1.,0.,0.));
+#22=VECTOR('',#21,1.);
+#23=LINE('',#2,#22);
+#24=EDGE_CURVE('',#6,#5,#23,.T.);
+#25=ORIENTED_EDGE('',*,*,#12,.T.);
+#26=ORIENTED_EDGE('',*,*,#16,.T.);
+#27=ORIENTED_EDGE('',*,*,#20,.T.);
+#28=ORIENTED_EDGE('',*,*,#24,.T.);
+#29=EDGE_LOOP('',(#25,#26,#27,#28));
+#30=FACE_OUTER_BOUND('',#29,.F.);
+#31=CARTESIAN_POINT('',(0.,0.,0.));
+#32=DIRECTION('',(0.,0.,1.));
+#33=DIRECTION('',(1.,0.,0.));
+#34=AXIS2_PLACEMENT_3D('',#31,#32,#33);
+#35=PLANE('',#34);
+#36=ADVANCED_FACE('',(#30),#35,.T.);
+ENDSEC;
+END-ISO-10303-21;
+";
+
+/// Same square but bound.orientation=T (CCW stored, standard convention).
+const STEP_UNIT_SQUARE_BOUND_T: &str = "
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('test'));
+ENDSEC;
+DATA;
+#1=CARTESIAN_POINT('',(0.,0.,0.));
+#2=CARTESIAN_POINT('',(1.,0.,0.));
+#3=CARTESIAN_POINT('',(1.,1.,0.));
+#4=CARTESIAN_POINT('',(0.,1.,0.));
+#5=VERTEX_POINT('',#1);
+#6=VERTEX_POINT('',#2);
+#7=VERTEX_POINT('',#3);
+#8=VERTEX_POINT('',#4);
+#9=DIRECTION('',(1.,0.,0.));
+#10=VECTOR('',#9,1.);
+#11=LINE('',#1,#10);
+#12=EDGE_CURVE('',#5,#6,#11,.T.);
+#13=DIRECTION('',(0.,1.,0.));
+#14=VECTOR('',#13,1.);
+#15=LINE('',#2,#14);
+#16=EDGE_CURVE('',#6,#7,#15,.T.);
+#17=DIRECTION('',(-1.,0.,0.));
+#18=VECTOR('',#17,1.);
+#19=LINE('',#3,#18);
+#20=EDGE_CURVE('',#7,#8,#19,.T.);
+#21=DIRECTION('',(0.,-1.,0.));
+#22=VECTOR('',#21,1.);
+#23=LINE('',#4,#22);
+#24=EDGE_CURVE('',#8,#5,#23,.T.);
+#25=ORIENTED_EDGE('',*,*,#12,.T.);
+#26=ORIENTED_EDGE('',*,*,#16,.T.);
+#27=ORIENTED_EDGE('',*,*,#20,.T.);
+#28=ORIENTED_EDGE('',*,*,#24,.T.);
+#29=EDGE_LOOP('',(#25,#26,#27,#28));
+#30=FACE_OUTER_BOUND('',#29,.T.);
+#31=CARTESIAN_POINT('',(0.,0.,0.));
+#32=DIRECTION('',(0.,0.,1.));
+#33=DIRECTION('',(1.,0.,0.));
+#34=AXIS2_PLACEMENT_3D('',#31,#32,#33);
+#35=PLANE('',#34);
+#36=ADVANCED_FACE('',(#30),#35,.T.);
+ENDSEC;
+END-ISO-10303-21;
+";
+
+/// Unit square in XY, CCW from +Z, bound.orientation=T → outward normal +Z.
 fn make_square_face() -> TopoFace {
     TopoFace {
         surface_id: 0,
         same_sense: true,
+        outer_loop_orientation: true,
         outer_loop: vec![
             TopoEdge {
                 curve_id: 0,
@@ -36,11 +171,50 @@ fn make_square_face() -> TopoFace {
     }
 }
 
+/// Same unit square but stored CW (as exported by the bracket's CAD system)
+/// with bound.orientation=F — after applying the flag the outward normal is still +Z.
+fn make_square_face_cw_bound_f() -> TopoFace {
+    TopoFace {
+        surface_id: 0,
+        same_sense: true,
+        outer_loop_orientation: false,
+        outer_loop: vec![
+            TopoEdge {
+                curve_id: 0,
+                start: [0.0, 0.0, 0.0],
+                end: [0.0, 1.0, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [0.0, 1.0, 0.0],
+                end: [1.0, 1.0, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [1.0, 1.0, 0.0],
+                end: [1.0, 0.0, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [1.0, 0.0, 0.0],
+                end: [0.0, 0.0, 0.0],
+                reversed: false,
+            },
+        ],
+        inner_loops: vec![],
+    }
+}
+
 fn load_bracket() -> (kofem_geom::step::StepFile, BRep) {
     let file = parse(include_str!("../../../test_files/new_bracket_2.stp")).unwrap();
     let brep = BRep::extract(&file).unwrap();
     (file, brep)
 }
+
+// ── winding / normal tests ─────────────────────────────────────────────────────
 
 #[test]
 fn fan_triangulate_planar_face() {
@@ -51,6 +225,105 @@ fn fan_triangulate_planar_face() {
         assert!(tri.iter().all(|&i| i < mesh.points.len()));
     }
 }
+
+/// CCW loop + bound.orientation=T → all triangle normals must point +Z.
+#[test]
+fn unit_square_bound_t_normals_point_up() {
+    let face = make_square_face();
+    let file = kofem_geom::step::StepFile::new();
+    let brep = kofem_geom::step::BRep { faces: vec![face] };
+    let mesh = tessellate(&brep, &file, TessOptions::default()).unwrap();
+    assert!(!mesh.triangles.is_empty());
+    for &tri in &mesh.triangles {
+        let n = tri_normal(&mesh.points, tri);
+        assert!(
+            n[2] > 0.9,
+            "expected +Z normal (bound.orientation=T), got {n:?}"
+        );
+    }
+}
+
+/// CW stored loop + bound.orientation=F → after applying the flag, normals
+/// must still point +Z.  This test fails without the orientation fix.
+#[test]
+fn unit_square_bound_f_normals_point_up() {
+    let face = make_square_face_cw_bound_f();
+    let file = kofem_geom::step::StepFile::new();
+    let brep = kofem_geom::step::BRep { faces: vec![face] };
+    let mesh = tessellate(&brep, &file, TessOptions::default()).unwrap();
+    assert!(!mesh.triangles.is_empty());
+    for &tri in &mesh.triangles {
+        let n = tri_normal(&mesh.points, tri);
+        assert!(
+            n[2] > 0.9,
+            "expected +Z normal (bound.orientation=F fixed), got {n:?}"
+        );
+    }
+}
+
+/// fan_tessellate area is exact (no Delaunay collinear-point issue).
+#[test]
+fn fan_tessellate_area_is_exact() {
+    for (label, face) in [
+        ("bound=T", make_square_face()),
+        ("bound=F", make_square_face_cw_bound_f()),
+    ] {
+        let mesh = fan_tessellate(&face);
+        let area = mesh_area(&mesh.points, &mesh.triangles);
+        assert!(
+            (area - 1.0).abs() < 1e-10,
+            "{label}: fan area must be exactly 1.0, got {area}"
+        );
+    }
+}
+
+// ── roundtrip STEP tests ───────────────────────────────────────────────────────
+
+/// Parse a minimal STEP snippet with bound.orientation=F (bracket convention)
+/// and verify the normal direction.  Area test is omitted: Delaunay of collinear
+/// LINE-edge samples is numerically unreliable for area but normals are correct.
+#[test]
+fn roundtrip_step_bound_f_normals() {
+    let file = parse(STEP_UNIT_SQUARE_BOUND_F).unwrap();
+    let brep = BRep::extract(&file).unwrap();
+    assert_eq!(brep.faces.len(), 1);
+    assert!(
+        !brep.faces[0].outer_loop_orientation,
+        "expected outer_loop_orientation=false"
+    );
+    let mesh = tessellate(&brep, &file, TessOptions::default()).unwrap();
+    assert!(!mesh.triangles.is_empty());
+    for &tri in &mesh.triangles {
+        let n = tri_normal(&mesh.points, tri);
+        assert!(
+            n[2] > 0.9,
+            "expected +Z normal (bound.orientation=F), got {n:?}"
+        );
+    }
+}
+
+/// Parse a minimal STEP snippet with bound.orientation=T and verify normals.
+#[test]
+fn roundtrip_step_bound_t_normals() {
+    let file = parse(STEP_UNIT_SQUARE_BOUND_T).unwrap();
+    let brep = BRep::extract(&file).unwrap();
+    assert_eq!(brep.faces.len(), 1);
+    assert!(
+        brep.faces[0].outer_loop_orientation,
+        "expected outer_loop_orientation=true"
+    );
+    let mesh = tessellate(&brep, &file, TessOptions::default()).unwrap();
+    assert!(!mesh.triangles.is_empty());
+    for &tri in &mesh.triangles {
+        let n = tri_normal(&mesh.points, tri);
+        assert!(
+            n[2] > 0.9,
+            "expected +Z normal (bound.orientation=T), got {n:?}"
+        );
+    }
+}
+
+// ── bracket regression tests ───────────────────────────────────────────────────
 
 #[test]
 fn bracket_tessellation_triangle_count() {


### PR DESCRIPTION
## Summary

Add support for the STEP `FACE_OUTER_BOUND.orientation` flag to correctly handle faces whose boundary loops are stored in clockwise (CW) order. When `orientation=F`, the stored loop must be traversed in reverse to produce the correct outward-facing normal. This fixes tessellation of STEP files exported by systems (e.g., bracket CAD exporter) that use CW loop storage with `orientation=F`.

## Key Changes

- **`TopoFace` struct** (`step/topology.rs`):
  - Added `outer_loop_orientation: bool` field to track `FACE_OUTER_BOUND.orientation`
  - Updated `extract_face()` to parse the orientation flag from STEP entities

- **Tessellation winding correction** (`tess/mod.rs`):
  - Extracted `fan_raw()` and `tessellate_face_raw()` to separate raw triangulation from orientation handling
  - Added `flip_winding_if()` helper to reverse triangle winding `[a,b,c]` → `[a,c,b]` when needed
  - Both `fan_tessellate()` and `tessellate()` now apply orientation correction via `flip_winding_if(!face.outer_loop_orientation)`

- **Comprehensive test coverage** (`tess.rs`):
  - Added helper functions: `tri_normal()` (compute triangle normal), `mesh_area()` (sum triangle areas)
  - Added two minimal STEP test fixtures: `STEP_UNIT_SQUARE_BOUND_F` (CW + orientation=F) and `STEP_UNIT_SQUARE_BOUND_T` (CCW + orientation=T)
  - Added `make_square_face_cw_bound_f()` to construct a CW-stored face with `outer_loop_orientation=false`
  - New tests verify normal direction is correct (+Z) for both orientation modes:
    - `unit_square_bound_t_normals_point_up()` — CCW + orientation=T
    - `unit_square_bound_f_normals_point_up()` — CW + orientation=F (regression test)
    - `fan_tessellate_area_is_exact()` — fan triangulation preserves area for both modes
    - `roundtrip_step_bound_f_normals()` — parse STEP with orientation=F, verify normals
    - `roundtrip_step_bound_t_normals()` — parse STEP with orientation=T, verify normals

## Implementation Details

The fix is minimal and non-invasive:
- Orientation correction is applied as a post-processing step after triangulation, so it works for both fan and Delaunay tessellation paths
- The flag is extracted during STEP parsing and stored in the topology; tessellation code is unaware of the source
- All existing tests pass; new tests confirm the bracket CAD convention (CW + orientation=F) now produces correct normals

https://claude.ai/code/session_01APJroYxc2afJdoKL97CAgq