### PR TITLE
feat: implement beam global coordinate transformation

### DIFF
--- a/crates/kofem-core/src/elements/beam.rs
+++ b/crates/kofem-core/src/elements/beam.rs
@@ -4,13 +4,15 @@
 //!
 //! CBAR: 2-node simple beam, Euler-Bernoulli formulation.
 //!       Local stiffness is analytical (no integration needed).
-//!       Global transform via 3D rotation matrix is TODO.
+//!       Global transform via 3D rotation matrix R:
+//!         K_global = Tᵀ K_local T
+//!       where T is the 12×12 block-diagonal [R, R, R, R].
 //! CBEAM: general beam — uses same formulation as CBAR here;
 //!        warping and non-uniform section extend this.
 
 use super::Element;
 use crate::material::IsotropicElastic;
-use nalgebra::DMatrix;
+use nalgebra::{DMatrix, Matrix3};
 
 /// CBAR / CBEAM with PBAR property — 2 nodes, 12 DOF.
 pub struct CbarElement {
@@ -23,6 +25,62 @@ pub struct CbarElement {
     pub i2: f64,
     /// Torsional constant J
     pub j_torsion: f64,
+    /// Orientation vector defining the local x-z plane (Nastran V-vector).
+    /// If None, defaults to global Z (or Y if beam is vertical).
+    pub orientation: Option<[f64; 3]>,
+}
+
+impl CbarElement {
+    /// Compute the 3×3 rotation matrix from local to global coordinates.
+    ///
+    /// Local axes:
+    ///   x: along beam axis (node 0 → node 1)
+    ///   z: in plane defined by beam axis and orientation vector, perpendicular to x
+    ///   y: completes right-handed system (z × x)
+    fn rotation_matrix(&self, nodes: &[[f64; 3]]) -> Matrix3<f64> {
+        let dx = nodes[1][0] - nodes[0][0];
+        let dy = nodes[1][1] - nodes[0][1];
+        let dz = nodes[1][2] - nodes[0][2];
+        let l = (dx * dx + dy * dy + dz * dz).sqrt();
+
+        // Local x-axis (beam axis direction)
+        let lx = [dx / l, dy / l, dz / l];
+
+        // Orientation vector for defining the local x-z plane
+        let v = match self.orientation {
+            Some(v) => v,
+            None => {
+                // Default: use global Z unless beam is nearly vertical
+                if lx[0].abs() < 0.99 && lx[1].abs() < 0.99 {
+                    [0.0, 0.0, 1.0]
+                } else {
+                    [0.0, 1.0, 0.0]
+                }
+            }
+        };
+
+        // Local y-axis: perpendicular to both beam axis and orientation vector
+        // ly = v × lx (normalized)
+        let ly_raw = [
+            v[1] * lx[2] - v[2] * lx[1],
+            v[2] * lx[0] - v[0] * lx[2],
+            v[0] * lx[1] - v[1] * lx[0],
+        ];
+        let ly_mag = (ly_raw[0] * ly_raw[0] + ly_raw[1] * ly_raw[1] + ly_raw[2] * ly_raw[2]).sqrt();
+        let ly = [ly_raw[0] / ly_mag, ly_raw[1] / ly_mag, ly_raw[2] / ly_mag];
+
+        // Local z-axis: lz = lx × ly
+        let lz = [
+            lx[1] * ly[2] - lx[2] * ly[1],
+            lx[2] * ly[0] - lx[0] * ly[2],
+            lx[0] * ly[1] - lx[1] * ly[0],
+        ];
+
+        // R transforms local to global: columns are local axes in global coords
+        Matrix3::new(
+            lx[0], ly[0], lz[0], lx[1], ly[1], lz[1], lx[2], ly[2], lz[2],
+        )
+    }
 }
 
 impl Element for CbarElement {
@@ -85,8 +143,9 @@ impl Element for CbarElement {
             }
         }
 
-        // TODO: transform to global frame via 3D rotation matrix R:
-        // K_global = Tᵀ K_local T  where T is the 12×12 block-diagonal rotation.
+        // Transform to global frame: K_global = Tᵀ K_local T
+        let r = self.rotation_matrix(nodes);
+        transform_12x12(&mut k, &r);
         k
     }
 
@@ -114,4 +173,20 @@ fn bending_coefficients(ei_l3: f64, l: f64) -> [f64; 4] {
     let c = 4.0 * ei_l3 * l * l;
     let d = 2.0 * ei_l3 * l * l;
     [a, b, c, d]
+}
+
+/// Transform 12×12 element matrix from local to global: K = Tᵀ K T
+/// T is block-diagonal with four 3×3 rotation matrices R.
+fn transform_12x12(k: &mut DMatrix<f64>, r: &Matrix3<f64>) {
+    let mut t = DMatrix::<f64>::zeros(12, 12);
+    for block in 0..4 {
+        let offset = block * 3;
+        for i in 0..3 {
+            for j in 0..3 {
+                t[(offset + i, offset + j)] = r[(i, j)];
+            }
+        }
+    }
+    let k_global = t.transpose() * &*k * &t;
+    k.copy_from(&k_global);
 }

--- a/crates/kofem-core/src/solver/linear.rs
+++ b/crates/kofem-core/src/solver/linear.rs
@@ -92,6 +92,7 @@ impl LinearStaticSolver {
                         i1,
                         i2,
                         j_torsion: j,
+                        orientation: None,
                     }
                     .stiffness_matrix(&node_coords)
                 }


### PR DESCRIPTION
The CbarElement now transforms its local stiffness matrix to global
coordinates via K_global = Tᵀ K_local T, where T is a 12×12 block-diagonal
matrix with the 3×3 rotation matrix R on each block.

https://claude.ai/code/session_01U6WAqgnv5aZHApmLgshsd5