### PR TITLE
feat: filter inner-loop holes from tessellated faces (#26)

### DIFF
--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -148,6 +148,21 @@ fn tessellate_face_raw(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> S
         return fan_raw(face);
     }
 
+    // Sample inner loops (holes) and project to the same 2D plane.
+    let holes2d: Vec<Vec<Point2>> = face
+        .inner_loops
+        .iter()
+        .map(|loop_edges| {
+            sample_boundary_3d(loop_edges, file, max_edge_len)
+                .iter()
+                .map(|&p| {
+                    let d = sub(p, origin);
+                    Point2::new(dot3(d, x_axis), dot3(d, y_axis))
+                })
+                .collect()
+        })
+        .collect();
+
     let mesh2d = triangulate(&pts2d);
 
     let points: Vec<[f64; 3]> = mesh2d
@@ -156,7 +171,21 @@ fn tessellate_face_raw(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> S
         .map(|p| add(origin, add(scale(x_axis, p.x), scale(y_axis, p.y))))
         .collect();
 
-    let triangles: Vec<[usize; 3]> = mesh2d.triangles.iter().map(|t| t.v).collect();
+    // Exclude triangles whose centroid falls inside any hole polygon.
+    let triangles: Vec<[usize; 3]> = mesh2d
+        .triangles
+        .iter()
+        .map(|t| t.v)
+        .filter(|&[a, b, c]| {
+            let pa = &mesh2d.points[a];
+            let pb = &mesh2d.points[b];
+            let pc = &mesh2d.points[c];
+            let centroid = Point2::new((pa.x + pb.x + pc.x) / 3.0, (pa.y + pb.y + pc.y) / 3.0);
+            !holes2d
+                .iter()
+                .any(|hole| point_in_polygon_2d(centroid, hole))
+        })
+        .collect();
 
     SurfaceMesh { points, triangles }
 }
@@ -409,6 +438,28 @@ fn polygon_area_2d(pts: &[Point2]) -> f64 {
         area += pts[i].x * pts[j].y - pts[j].x * pts[i].y;
     }
     area / 2.0
+}
+
+/// Ray-casting point-in-polygon test.  Returns `true` when `pt` is strictly
+/// inside `polygon`.  Winding direction does not affect the result.
+fn point_in_polygon_2d(pt: Point2, polygon: &[Point2]) -> bool {
+    if polygon.len() < 3 {
+        return false;
+    }
+    let mut inside = false;
+    let n = polygon.len();
+    let mut j = n - 1;
+    for i in 0..n {
+        let pi = polygon[i];
+        let pj = polygon[j];
+        if ((pi.y > pt.y) != (pj.y > pt.y))
+            && (pt.x < (pj.x - pi.x) * (pt.y - pi.y) / (pj.y - pi.y) + pi.x)
+        {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
 }
 
 // ── Stitching ──────────────────────────────────────────────────────────────────

--- a/crates/kofem-geom/tests/tess.rs
+++ b/crates/kofem-geom/tests/tess.rs
@@ -208,6 +208,67 @@ fn make_square_face_cw_bound_f() -> TopoFace {
     }
 }
 
+/// Unit square with a 0.2×0.2 square hole at its centre (0.4–0.6 in X and Y).
+fn make_square_face_with_hole() -> TopoFace {
+    TopoFace {
+        surface_id: 0,
+        same_sense: true,
+        outer_loop_orientation: true,
+        outer_loop: vec![
+            TopoEdge {
+                curve_id: 0,
+                start: [0.0, 0.0, 0.0],
+                end: [1.0, 0.0, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [1.0, 0.0, 0.0],
+                end: [1.0, 1.0, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [1.0, 1.0, 0.0],
+                end: [0.0, 1.0, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [0.0, 1.0, 0.0],
+                end: [0.0, 0.0, 0.0],
+                reversed: false,
+            },
+        ],
+        inner_loops: vec![vec![
+            TopoEdge {
+                curve_id: 0,
+                start: [0.4, 0.4, 0.0],
+                end: [0.6, 0.4, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [0.6, 0.4, 0.0],
+                end: [0.6, 0.6, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [0.6, 0.6, 0.0],
+                end: [0.4, 0.6, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [0.4, 0.6, 0.0],
+                end: [0.4, 0.4, 0.0],
+                reversed: false,
+            },
+        ]],
+    }
+}
+
 fn load_bracket() -> (kofem_geom::step::StepFile, BRep) {
     let file = parse(include_str!("../../../test_files/new_bracket_2.stp")).unwrap();
     let brep = BRep::extract(&file).unwrap();
@@ -319,6 +380,30 @@ fn roundtrip_step_bound_t_normals() {
         assert!(
             n[2] > 0.9,
             "expected +Z normal (bound.orientation=T), got {n:?}"
+        );
+    }
+}
+
+// ── inner-loop / hole tests ────────────────────────────────────────────────────
+
+/// A 1×1 square with a centred 0.2×0.2 hole must produce no triangles whose
+/// centroid falls inside the hole region.
+#[test]
+fn square_face_with_square_hole_no_triangles_in_hole() {
+    let face = make_square_face_with_hole();
+    let file = kofem_geom::step::StepFile::new();
+    let brep = kofem_geom::step::BRep { faces: vec![face] };
+    let mesh = tessellate(&brep, &file, TessOptions::default()).unwrap();
+    assert!(!mesh.triangles.is_empty(), "mesh must not be empty");
+    for &[a, b, c] in &mesh.triangles {
+        let pa = mesh.points[a];
+        let pb = mesh.points[b];
+        let pc = mesh.points[c];
+        let cx = (pa[0] + pb[0] + pc[0]) / 3.0;
+        let cy = (pa[1] + pb[1] + pc[1]) / 3.0;
+        assert!(
+            !(cx > 0.4 && cx < 0.6 && cy > 0.4 && cy < 0.6),
+            "triangle centroid ({cx:.4}, {cy:.4}) is inside the hole region"
         );
     }
 }


### PR DESCRIPTION
`tessellate_face_raw` now samples every `TopoFace.inner_loop`, projects
each hole boundary to the same 2D plane as the outer loop, and discards
any Delaunay triangle whose centroid falls inside a hole polygon (ray-
casting test).  Adds a test: 1×1 square with a centred 0.2×0.2 hole
produces no triangles inside the hole region.

https://claude.ai/code/session_01Wf2rSmpn6oxthKQwBqWFE2