### PR TITLE
tess: filter triangles inside inner-loop holes (issue #26)

### DIFF
--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -9,7 +9,7 @@ use std::f64::consts::PI;
 
 use serde::Serialize;
 
-use kofem_mesh::geom::Point2;
+use kofem_mesh::geom::{point_in_polygon, Point2};
 use kofem_mesh::triangulate::triangulate;
 
 use crate::geom::curve::curve_from_step;
@@ -148,7 +148,37 @@ fn tessellate_face_raw(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> S
         return fan_raw(face);
     }
 
-    let mesh2d = triangulate(&pts2d);
+    // Project each inner loop (hole) onto the same 2D plane.
+    let holes2d: Vec<Vec<Point2>> = face
+        .inner_loops
+        .iter()
+        .filter_map(|inner_edges| {
+            let inner_3d = sample_boundary_3d(inner_edges, file, max_edge_len);
+            if inner_3d.len() < 3 {
+                return None;
+            }
+            Some(
+                inner_3d
+                    .iter()
+                    .map(|&p| {
+                        let d = sub(p, origin);
+                        Point2::new(dot3(d, x_axis), dot3(d, y_axis))
+                    })
+                    .collect(),
+            )
+        })
+        .collect();
+
+    let mut mesh2d = triangulate(&pts2d);
+
+    // Reject triangles whose centroid falls inside a hole polygon.
+    if !holes2d.is_empty() {
+        let pts = mesh2d.points.clone();
+        mesh2d.triangles.retain(|t| {
+            let c = t.centroid(&pts);
+            !holes2d.iter().any(|hole| point_in_polygon(c, hole))
+        });
+    }
 
     let points: Vec<[f64; 3]> = mesh2d
         .points

--- a/crates/kofem-geom/tests/tess.rs
+++ b/crates/kofem-geom/tests/tess.rs
@@ -323,6 +323,93 @@ fn roundtrip_step_bound_t_normals() {
     }
 }
 
+// ── hole tessellation tests ────────────────────────────────────────────────────
+
+/// 1×1 outer square with a 0.2×0.2 inner square hole centred at (0.5, 0.5).
+/// After tessellation no triangle centroid must fall inside the hole region.
+#[test]
+fn square_with_square_hole_excludes_hole_region() {
+    let hole_min = 0.4_f64;
+    let hole_max = 0.6_f64;
+
+    let face = TopoFace {
+        surface_id: 0,
+        same_sense: true,
+        outer_loop_orientation: true,
+        outer_loop: vec![
+            TopoEdge {
+                curve_id: 0,
+                start: [0.0, 0.0, 0.0],
+                end: [1.0, 0.0, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [1.0, 0.0, 0.0],
+                end: [1.0, 1.0, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [1.0, 1.0, 0.0],
+                end: [0.0, 1.0, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [0.0, 1.0, 0.0],
+                end: [0.0, 0.0, 0.0],
+                reversed: false,
+            },
+        ],
+        inner_loops: vec![vec![
+            TopoEdge {
+                curve_id: 0,
+                start: [hole_min, hole_min, 0.0],
+                end: [hole_min, hole_max, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [hole_min, hole_max, 0.0],
+                end: [hole_max, hole_max, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [hole_max, hole_max, 0.0],
+                end: [hole_max, hole_min, 0.0],
+                reversed: false,
+            },
+            TopoEdge {
+                curve_id: 0,
+                start: [hole_max, hole_min, 0.0],
+                end: [hole_min, hole_min, 0.0],
+                reversed: false,
+            },
+        ]],
+    };
+
+    let file = kofem_geom::step::StepFile::new();
+    let brep = kofem_geom::step::BRep { faces: vec![face] };
+    let mesh = tessellate(&brep, &file, TessOptions::default()).unwrap();
+
+    assert!(!mesh.triangles.is_empty(), "mesh must have triangles");
+
+    for &[a, b, c] in &mesh.triangles {
+        let pa = mesh.points[a];
+        let pb = mesh.points[b];
+        let pc = mesh.points[c];
+        let cx = (pa[0] + pb[0] + pc[0]) / 3.0;
+        let cy = (pa[1] + pb[1] + pc[1]) / 3.0;
+        let inside_hole = cx > hole_min && cx < hole_max && cy > hole_min && cy < hole_max;
+        assert!(
+            !inside_hole,
+            "triangle centroid ({cx:.4}, {cy:.4}) is inside the hole [{hole_min},{hole_max}]²"
+        );
+    }
+}
+
 // ── bracket regression tests ───────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Project each inner loop (FACE_BOUND) onto the same 2-D tangent plane as
the outer boundary, then reject any Delaunay triangle whose centroid falls
inside a hole polygon using the existing winding-number point_in_polygon
test.  This is the minimal centroid-filter approach described in the issue;
no CDT changes required.

New test: 1×1 outer square with a 0.2×0.2 inner square hole — asserts that
no triangle centroid lies inside the hole region.

https://claude.ai/code/session_01QXKee3GyAH2JQLMYS27Hcz