### PR TITLE
Stage 5.1: Volume module scaffold

### DIFF
--- a/crates/kofem-mesh/src/lib.rs
+++ b/crates/kofem-mesh/src/lib.rs
@@ -6,11 +6,13 @@
 //! 2. [`triangulate`] produces a coarse Delaunay [`Mesh2D`].
 //! 3. [`refine`] improves minimum angles via Ruppert's algorithm.
 //! 4. [`extrude`] sweeps the 2-D mesh into a 3-D [`Mesh3D`] of tetrahedra.
+//! 5. [`volume::volume_mesh`] fills a closed [`volume::SurfaceMesh`] with quality tetrahedra.
 
 pub mod extrude;
 pub mod geom;
 pub mod quality;
 pub mod triangulate;
+pub mod volume;
 
 // ── Convenient re-exports ─────────────────────────────────────────────────────
 
@@ -18,3 +20,7 @@ pub use extrude::{extrude, Mesh3D, Tet};
 pub use geom::{Point2, Point3};
 pub use quality::refine;
 pub use triangulate::{triangulate, Mesh2D, Triangle};
+pub use volume::{
+    icosphere, tet_circumsphere, tet_signed_volume, tet_signed_volume_mesh, volume_mesh, MeshError,
+    SurfaceMesh, VolumeMeshOptions,
+};

--- a/crates/kofem-mesh/src/volume.rs
+++ b/crates/kofem-mesh/src/volume.rs
@@ -1,0 +1,292 @@
+//! 3-D Constrained Delaunay Tetrahedralization (volume mesher).
+//!
+//! This module is being built incrementally:
+//! - Stage 5.1 (this file): types, helpers, and test fixtures
+//! - Stage 5.2: 3-D Bowyer-Watson
+//! - Stage 5.3: constrained face recovery
+//! - Stage 5.4: interior/exterior classification
+//! - Stage 5.5: Delaunay refinement
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::extrude::{Mesh3D, Tet};
+use crate::geom::Point3;
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/// A closed, watertight triangulated surface.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SurfaceMesh {
+    pub points: Vec<Point3>,
+    /// Each entry is a triple of indices into `points`.
+    pub triangles: Vec<[usize; 3]>,
+}
+
+/// Error type for volume meshing operations.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MeshError {
+    NotImplemented,
+    DegenerateInput,
+    BudgetExhausted,
+}
+
+impl std::fmt::Display for MeshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MeshError::NotImplemented => write!(f, "not implemented"),
+            MeshError::DegenerateInput => write!(f, "degenerate input"),
+            MeshError::BudgetExhausted => write!(f, "Steiner point budget exhausted"),
+        }
+    }
+}
+
+impl std::error::Error for MeshError {}
+
+/// Options for the volume mesher.
+#[derive(Debug, Clone)]
+pub struct VolumeMeshOptions {
+    /// Circumradius-to-shortest-edge threshold; tets above this are refined.
+    pub quality_ratio: f64,
+    /// Maximum number of Steiner points inserted during refinement.
+    pub max_tets: usize,
+}
+
+impl Default for VolumeMeshOptions {
+    fn default() -> Self {
+        Self {
+            quality_ratio: 2.0,
+            max_tets: 100_000,
+        }
+    }
+}
+
+// ── Entry point (stub) ────────────────────────────────────────────────────────
+
+/// Fill the interior of `surface` with quality tetrahedra.
+///
+/// Not yet implemented — subsequent stages (5.2–5.5) complete this.
+pub fn volume_mesh(_surface: &SurfaceMesh, _opts: VolumeMeshOptions) -> Result<Mesh3D, MeshError> {
+    Err(MeshError::NotImplemented)
+}
+
+// ── Geometric helpers ─────────────────────────────────────────────────────────
+
+/// Signed volume of tetrahedron (v[0], v[1], v[2], v[3]).
+///
+/// V = (1/6) det([b−a, c−a, d−a])
+///
+/// Positive for right-hand oriented tets.
+pub fn tet_signed_volume(pts: &[[f64; 3]], tet: &[usize; 4]) -> f64 {
+    let a = pts[tet[0]];
+    let b = pts[tet[1]];
+    let c = pts[tet[2]];
+    let d = pts[tet[3]];
+    let bma = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    let cma = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+    let dma = [d[0] - a[0], d[1] - a[1], d[2] - a[2]];
+    // scalar triple product: (b−a) · ((c−a) × (d−a))
+    let cross = [
+        cma[1] * dma[2] - cma[2] * dma[1],
+        cma[2] * dma[0] - cma[0] * dma[2],
+        cma[0] * dma[1] - cma[1] * dma[0],
+    ];
+    (bma[0] * cross[0] + bma[1] * cross[1] + bma[2] * cross[2]) / 6.0
+}
+
+/// Convenience wrapper: signed volume using `Mesh3D` point indexing.
+pub fn tet_signed_volume_mesh(mesh: &Mesh3D, tet: &Tet) -> f64 {
+    let pts: Vec<[f64; 3]> = mesh.points.iter().map(|p| [p.x, p.y, p.z]).collect();
+    tet_signed_volume(&pts, &tet.v)
+}
+
+/// Circumsphere of tetrahedron (v[0]..v[3]).
+///
+/// Returns `(center, radius_sq)`.  `radius_sq` is `f64::INFINITY` for degenerate tets.
+pub fn tet_circumsphere(pts: &[[f64; 3]], tet: &[usize; 4]) -> ([f64; 3], f64) {
+    let a = pts[tet[0]];
+    let b = pts[tet[1]];
+    let c = pts[tet[2]];
+    let d = pts[tet[3]];
+
+    // Translate so `a` is at the origin, then solve the 3×3 Cramer system:
+    //   2·[b−a, c−a, d−a]ᵀ · u = [|b−a|², |c−a|², |d−a|²]
+    let b = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    let c = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+    let d = [d[0] - a[0], d[1] - a[1], d[2] - a[2]];
+    let b2 = b[0] * b[0] + b[1] * b[1] + b[2] * b[2];
+    let c2 = c[0] * c[0] + c[1] * c[1] + c[2] * c[2];
+    let d2 = d[0] * d[0] + d[1] * d[1] + d[2] * d[2];
+
+    let det = 2.0
+        * (b[0] * (c[1] * d[2] - c[2] * d[1]) - b[1] * (c[0] * d[2] - c[2] * d[0])
+            + b[2] * (c[0] * d[1] - c[1] * d[0]));
+
+    if det.abs() < 1e-20 {
+        return ([0.0; 3], f64::INFINITY);
+    }
+
+    let ux = (b2 * (c[1] * d[2] - c[2] * d[1]) - b[1] * (c2 * d[2] - c[2] * d2)
+        + b[2] * (c2 * d[1] - c[1] * d2))
+        / det;
+    let uy = (b[0] * (c2 * d[2] - c[2] * d2) - b2 * (c[0] * d[2] - c[2] * d[0])
+        + b[2] * (c[0] * d2 - c2 * d[0]))
+        / det;
+    let uz = (b[0] * (c[1] * d2 - c2 * d[1]) - b[1] * (c[0] * d2 - c2 * d[0])
+        + b2 * (c[0] * d[1] - c[1] * d[0]))
+        / det;
+
+    let center = [a[0] + ux, a[1] + uy, a[2] + uz];
+    let r2 = ux * ux + uy * uy + uz * uz;
+    (center, r2)
+}
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+/// Generate a subdivided icosphere of radius 1, centred at the origin.
+///
+/// `subdivisions = 0` → 20 triangles (icosahedron).
+/// Each subdivision quadruples the triangle count.
+pub fn icosphere(subdivisions: u32) -> SurfaceMesh {
+    let phi = (1.0 + 5.0_f64.sqrt()) / 2.0;
+    // 12 icosahedron vertices (will be normalised to unit sphere)
+    let raw: &[[f64; 3]] = &[
+        [-1.0, phi, 0.0],
+        [1.0, phi, 0.0],
+        [-1.0, -phi, 0.0],
+        [1.0, -phi, 0.0],
+        [0.0, -1.0, phi],
+        [0.0, 1.0, phi],
+        [0.0, -1.0, -phi],
+        [0.0, 1.0, -phi],
+        [phi, 0.0, -1.0],
+        [phi, 0.0, 1.0],
+        [-phi, 0.0, -1.0],
+        [-phi, 0.0, 1.0],
+    ];
+    let mut pts: Vec<[f64; 3]> = raw.iter().map(|p| normalize3(*p)).collect();
+    let mut tris: Vec<[usize; 3]> = vec![
+        [0, 11, 5],
+        [0, 5, 1],
+        [0, 1, 7],
+        [0, 7, 10],
+        [0, 10, 11],
+        [1, 5, 9],
+        [5, 11, 4],
+        [11, 10, 2],
+        [10, 7, 6],
+        [7, 1, 8],
+        [3, 9, 4],
+        [3, 4, 2],
+        [3, 2, 6],
+        [3, 6, 8],
+        [3, 8, 9],
+        [4, 9, 5],
+        [2, 4, 11],
+        [6, 2, 10],
+        [8, 6, 7],
+        [9, 8, 1],
+    ];
+
+    for _ in 0..subdivisions {
+        let mut cache: HashMap<(usize, usize), usize> = HashMap::new();
+        let mut new_tris: Vec<[usize; 3]> = Vec::with_capacity(tris.len() * 4);
+        for tri in &tris {
+            let [a, b, c] = *tri;
+            let ab = midpoint_idx(&mut pts, &mut cache, a, b);
+            let bc = midpoint_idx(&mut pts, &mut cache, b, c);
+            let ca = midpoint_idx(&mut pts, &mut cache, c, a);
+            new_tris.push([a, ab, ca]);
+            new_tris.push([b, bc, ab]);
+            new_tris.push([c, ca, bc]);
+            new_tris.push([ab, bc, ca]);
+        }
+        tris = new_tris;
+    }
+
+    SurfaceMesh {
+        points: pts.iter().map(|p| Point3::new(p[0], p[1], p[2])).collect(),
+        triangles: tris,
+    }
+}
+
+#[inline]
+fn normalize3(p: [f64; 3]) -> [f64; 3] {
+    let len = (p[0] * p[0] + p[1] * p[1] + p[2] * p[2]).sqrt();
+    [p[0] / len, p[1] / len, p[2] / len]
+}
+
+fn midpoint_idx(
+    pts: &mut Vec<[f64; 3]>,
+    cache: &mut HashMap<(usize, usize), usize>,
+    a: usize,
+    b: usize,
+) -> usize {
+    let key = if a < b { (a, b) } else { (b, a) };
+    if let Some(&idx) = cache.get(&key) {
+        return idx;
+    }
+    let pa = pts[a];
+    let pb = pts[b];
+    let mid = normalize3([
+        (pa[0] + pb[0]) * 0.5,
+        (pa[1] + pb[1]) * 0.5,
+        (pa[2] + pb[2]) * 0.5,
+    ]);
+    let idx = pts.len();
+    pts.push(mid);
+    cache.insert(key, idx);
+    idx
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tet_signed_volume_unit_tet() {
+        // Right-angle tet: (0,0,0), (1,0,0), (0,1,0), (0,0,1) → volume = 1/6
+        let pts: Vec<[f64; 3]> = vec![
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ];
+        let v = tet_signed_volume(&pts, &[0, 1, 2, 3]);
+        assert!((v - 1.0 / 6.0).abs() < 1e-14, "expected 1/6, got {v}");
+    }
+
+    #[test]
+    fn tet_circumsphere_unit_tet() {
+        // Regular tet inscribed in unit sphere: circumradius² = 1
+        let s = 1.0_f64 / 3.0_f64.sqrt();
+        let pts: Vec<[f64; 3]> = vec![[s, s, s], [-s, -s, s], [-s, s, -s], [s, -s, -s]];
+        let (_center, r2) = tet_circumsphere(&pts, &[0, 1, 2, 3]);
+        assert!((r2 - 1.0).abs() < 1e-10, "expected r²=1, got {r2}");
+    }
+
+    #[test]
+    fn icosphere_face_counts() {
+        assert_eq!(icosphere(0).triangles.len(), 20);
+        assert_eq!(icosphere(1).triangles.len(), 80);
+        assert_eq!(icosphere(2).triangles.len(), 320);
+    }
+
+    #[test]
+    fn icosphere_unit_radius() {
+        for p in icosphere(2).points {
+            let r = (p.x * p.x + p.y * p.y + p.z * p.z).sqrt();
+            assert!((r - 1.0).abs() < 1e-12, "point not on unit sphere: r={r}");
+        }
+    }
+
+    #[test]
+    fn volume_mesh_stub_returns_err() {
+        let surface = icosphere(1);
+        let result = volume_mesh(&surface, VolumeMeshOptions::default());
+        assert!(matches!(result, Err(MeshError::NotImplemented)));
+    }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements issue #33 — the foundation for the 3D Constrained Delaunay Tetrahedralization pipeline (#13).

- Adds `kofem-mesh::volume` module with `SurfaceMesh`, `MeshError`, `VolumeMeshOptions` types
- `volume_mesh` stub (returns `NotImplemented` until stages 5.2–5.5 are complete)
- `tet_signed_volume` and `tet_circumsphere` geometric helpers used by later stages
- `icosphere(subdivisions)` test fixture generating a subdivided unit sphere surface mesh
- All 5 new tests pass alongside the 8 pre-existing kofem-mesh tests (13 total)

## Test plan

- [ ] `cargo test -p kofem-mesh` passes (13 tests)
- [ ] `tet_signed_volume` returns 1/6 for the unit right-angle tet
- [ ] `tet_circumsphere` returns r²=1 for a regular tet inscribed in the unit sphere
- [ ] `icosphere(0)` → 20 triangles, `icosphere(1)` → 80, `icosphere(2)` → 320
- [ ] All icosphere points lie on the unit sphere (r within 1e-12 of 1.0)
- [ ] `volume_mesh` stub returns `Err(NotImplemented)`

https://claude.ai/code/session_01GfRQEvufRNRTVuFTxxoeGU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfRQEvufRNRTVuFTxxoeGU)_