### PR TITLE
Add fit-to-view camera control with isometric framing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,4 @@ jobs:
       - run: cd web && bunx playwright install --with-deps chromium
       - run: cd web && bun run build
       - run: cd web && bun run test
-      - run: cd web && bun run upload:slack || echo "Slack upload skipped"
+      - run: cd web && bun run upload:slack

--- a/web/scripts/upload-to-slack.ts
+++ b/web/scripts/upload-to-slack.ts
@@ -145,9 +145,9 @@ async function main() {
     }
   } else {
     // Look for screenshot directly
-    const screenshotPath = path.resolve(__dirname, '../screenshots/solve-result.png')
+    const screenshotPath = path.resolve(__dirname, '../screenshots/step-fit-view.png')
     if (!fs.existsSync(screenshotPath)) {
-      console.error('No screenshot found at screenshots/solve-result.png')
+      console.error('No screenshot found at screenshots/step-fit-view.png')
       console.error('Run the screenshot test first: bun run test:screenshot')
       process.exit(1)
     }

--- a/web/src/components/toolbar/Toolbar.tsx
+++ b/web/src/components/toolbar/Toolbar.tsx
@@ -12,6 +12,7 @@ export function Toolbar() {
   const setResult = useModelStore(s => s.setResult)
   const loadModel = useModelStore(s => s.loadModel)
   const setStepSurface = useModelStore(s => s.setStepSurface)
+  const triggerFitView = useModelStore(s => s.triggerFitView)
 
   const [isParsing, setIsParsing] = useState(false)
   const [isImportingStep, setIsImportingStep] = useState(false)
@@ -103,6 +104,9 @@ export function Toolbar() {
       </button>
       <button className={styles.btn} title="Export results" disabled>
         Export
+      </button>
+      <button className={styles.btn} onClick={triggerFitView} title="Fit all geometry into view (isometric)">
+        Fit View
       </button>
       <span className={styles.modelName}>{modelName}</span>
       <div className={styles.divider} />

--- a/web/src/components/viewport/FitCamera.tsx
+++ b/web/src/components/viewport/FitCamera.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react'
+import { useThree } from '@react-three/fiber'
+import * as THREE from 'three'
+import { useModelStore } from '../../store/modelStore'
+
+// [1,1,1] normalized — standard isometric direction
+const ISO_DIR = new THREE.Vector3(1, 1, 1).normalize()
+
+export function FitCamera() {
+  const { camera, controls } = useThree()
+  const fitViewTrigger = useModelStore(s => s.fitViewTrigger)
+  const mounted = useRef(false)
+
+  useEffect(() => {
+    // Skip the initial mount so the default camera position is preserved
+    if (!mounted.current) {
+      mounted.current = true
+      return
+    }
+
+    const { nodes, stepSurface } = useModelStore.getState()
+
+    const pts: [number, number, number][] = []
+    for (const n of nodes) pts.push([n.x, n.y, n.z])
+    if (stepSurface) {
+      for (const p of stepSurface.points) pts.push(p)
+    }
+    if (pts.length === 0) return
+
+    let minX = Infinity, maxX = -Infinity
+    let minY = Infinity, maxY = -Infinity
+    let minZ = Infinity, maxZ = -Infinity
+    for (const [x, y, z] of pts) {
+      if (x < minX) minX = x; if (x > maxX) maxX = x
+      if (y < minY) minY = y; if (y > maxY) maxY = y
+      if (z < minZ) minZ = z; if (z > maxZ) maxZ = z
+    }
+
+    const center = new THREE.Vector3(
+      (minX + maxX) / 2,
+      (minY + maxY) / 2,
+      (minZ + maxZ) / 2,
+    )
+    const diagonal = Math.sqrt(
+      (maxX - minX) ** 2 + (maxY - minY) ** 2 + (maxZ - minZ) ** 2,
+    )
+    const radius = Math.max(diagonal / 2, 1e-6)
+
+    const fovRad = ((camera as THREE.PerspectiveCamera).fov * Math.PI) / 180
+    // Extra 1.5× padding so geometry sits comfortably inside the frustum
+    const distance = (radius / Math.tan(fovRad / 2)) * 1.5
+
+    camera.position.copy(center).addScaledVector(ISO_DIR, distance)
+    const cam = camera as THREE.PerspectiveCamera
+    cam.near = Math.max(distance * 0.001, 1e-4)
+    cam.far = distance * 100
+    cam.updateProjectionMatrix()
+
+    if (controls) {
+      // OrbitControls registered via makeDefault
+      const oc = controls as unknown as { target: THREE.Vector3; update(): void }
+      oc.target.copy(center)
+      oc.update()
+    }
+  }, [fitViewTrigger]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return null
+}

--- a/web/src/components/viewport/Viewport.tsx
+++ b/web/src/components/viewport/Viewport.tsx
@@ -1,6 +1,7 @@
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Grid, GizmoHelper, GizmoViewport } from '@react-three/drei'
 import { MeshScene } from './MeshScene'
+import { FitCamera } from './FitCamera'
 import { useModelStore } from '../../store/modelStore'
 
 export function Viewport() {
@@ -24,6 +25,7 @@ export function Viewport() {
         sectionColor="#4a4a80"
       />
       <OrbitControls makeDefault enabled={!pickMode} />
+      <FitCamera />
       <GizmoHelper alignment="bottom-right" margin={[72, 72]}>
         <GizmoViewport labelColor="white" axisHeadScale={1} />
       </GizmoHelper>

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -212,6 +212,10 @@ interface ModelState extends ModelSnapshot {
   applyLoadToFace(nodeIds: number[], dof: number, totalForce: number): void
   clearConstraints(): void
   clearLoads(): void
+
+  // Viewport
+  fitViewTrigger: number
+  triggerFitView(): void
 }
 
 // ── Store ─────────────────────────────────────────────────────────────────────
@@ -229,8 +233,10 @@ export const useModelStore = create<ModelState>()(
     nextMatId: 2,
     pickMode: null,
     selectedFace: null,
+    fitViewTrigger: 0,
 
-    setStepSurface: (mesh) => set(s => { s.stepSurface = mesh }),
+    setStepSurface: (mesh) => set(s => { s.stepSurface = mesh; if (mesh) s.fitViewTrigger++ }),
+    triggerFitView: () => set(s => { s.fitViewTrigger++ }),
 
     addNode: (node) => set(s => { s.nodes.push(node) }),
     addElement: (el) => set(s => { s.elements.push(el) }),
@@ -249,6 +255,7 @@ export const useModelStore = create<ModelState>()(
       s.selectedFace = null
       s.pickMode = null
       s.modelName = name
+      s.fitViewTrigger++
       if (!s.properties.find(p => p.type === 'PSOLID')) {
         const matId = s.materials[0]?.id ?? 1
         s.properties = [{ id: 1, type: 'PSOLID', materialId: matId }]
@@ -267,6 +274,7 @@ export const useModelStore = create<ModelState>()(
       s.geometries = []
       s.selectedFace = null
       s.pickMode = null
+      s.fitViewTrigger++
     }),
 
     reset: () => set(s => {

--- a/web/tests/screenshot.spec.ts
+++ b/web/tests/screenshot.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test'
 import path from 'path'
 
-const STEP_FILE = path.join(__dirname, '../../test_files/new_bracket_2.stp')
+// Playwright is invoked from web/, so cwd is web/ and the STEP file lives one level up
+const STEP_FILE = path.resolve('..', 'test_files', 'new_bracket_2.stp')
 
 test('capture app after loading STEP file with fit view', async ({ page }) => {
   await page.goto('/')

--- a/web/tests/screenshot.spec.ts
+++ b/web/tests/screenshot.spec.ts
@@ -1,20 +1,23 @@
 import { test, expect } from '@playwright/test'
+import path from 'path'
 
-test('capture app after solving', async ({ page }) => {
+const STEP_FILE = path.join(__dirname, '../../test_files/new_bracket_2.stp')
+
+test('capture app after loading STEP file with fit view', async ({ page }) => {
   await page.goto('/')
-  await expect(page.getByRole('button', { name: 'Solve' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Import STEP' })).toBeVisible()
 
-  // Solve the default model
-  const solveBtn = page.getByRole('button', { name: /Solve|Solving/ })
-  await expect(solveBtn).toBeEnabled()
-  await solveBtn.click()
+  // Upload the example STEP file via the hidden file input
+  await page.locator('input[type="file"][accept=".stp,.step"]').setInputFiles(STEP_FILE)
 
-  // Wait for solve to complete
-  await expect(page.getByRole('button', { name: 'Solve' })).toBeEnabled({ timeout: 60_000 })
+  // Wait for import to finish — button returns to its default label
+  await expect(page.getByRole('button', { name: 'Import STEP' })).toBeEnabled({ timeout: 30_000 })
 
-  // Wait for results to render
+  // Fit all loaded geometry into the isometric view
+  await page.getByRole('button', { name: 'Fit View' }).click()
+
+  // Allow the camera reposition and a render frame to settle
   await page.waitForTimeout(500)
 
-  // Take screenshot - Playwright handles the path
-  await page.screenshot({ path: 'screenshots/solve-result.png', fullPage: true })
+  await page.screenshot({ path: 'screenshots/step-fit-view.png', fullPage: true })
 })


### PR DESCRIPTION
## Summary
Adds a "Fit View" button to the toolbar that automatically frames all geometry (nodes and step surface) into the viewport using an isometric camera angle. The camera position, near/far planes, and orbit controls target are all computed to ensure the entire model fits comfortably within the frustum.

## Key Changes

- **New `FitCamera` component** (`web/src/components/viewport/FitCamera.tsx`)
  - Listens to `fitViewTrigger` state changes to recompute camera framing
  - Calculates bounding box of all nodes and step surface points
  - Positions camera along the `[1,1,1]` isometric direction at a distance that fits the geometry with 1.5× padding
  - Adjusts near/far planes dynamically based on model size
  - Updates OrbitControls target to the bounding box center

- **Extended `ModelState`** (`web/src/store/modelStore.ts`)
  - Added `fitViewTrigger: number` counter to trigger camera updates
  - Added `triggerFitView()` action to increment the trigger
  - Auto-trigger fit view when loading a model or setting step surface

- **Toolbar button** (`web/src/components/toolbar/Toolbar.tsx`)
  - New "Fit View" button that calls `triggerFitView()` on click

- **Viewport integration** (`web/src/components/viewport/Viewport.tsx`)
  - Mounted `<FitCamera />` component in the canvas

## Implementation Details

- Uses a ref to skip the initial mount, preserving the default camera position until explicitly triggered
- Computes the bounding box diagonal and uses the camera's FOV to determine the required distance
- Applies 1.5× padding factor so geometry sits comfortably inside the frustum without touching edges
- Clamps near plane to avoid z-fighting and far plane to 100× the camera distance for numerical stability
- Works with both perspective cameras and OrbitControls (via `makeDefault`)

https://claude.ai/code/session_013WyYmcuB42rkQkDFrYVLJ6