### PR TITLE
Support B-spline surfaces in complex entity instances

### DIFF
--- a/crates/kofem-geom/src/geom/surface.rs
+++ b/crates/kofem-geom/src/geom/surface.rs
@@ -2,8 +2,8 @@ use std::f64::consts::PI;
 
 use super::curve::{curve_from_step, Curve};
 use super::{
-    add, arg_as_ref, axis1_placement, axis2_placement, cross, de_boor_1d, expand_knots, get_arg,
-    get_entity, get_list, get_real, get_ref, normalize, point3, rodrigues, scale, sub, Axis1,
+    add, arg_as_ref, axis1_placement, axis2_placement, cross, de_boor_1d, expand_knots,
+    get_entity, get_real, get_ref, normalize, point3, rodrigues, scale, sub, Axis1,
     Axis2, GeomError,
 };
 use crate::step::parser::{Arg, StepFile};
@@ -322,8 +322,88 @@ impl Surface for SurfaceOfRevolution {
 
 // ── from_step builder ─────────────────────────────────────────────────────────
 
+/// Parse a B_SPLINE_SURFACE_WITH_KNOTS from a raw arg slice.
+///
+/// Works for both a standalone entity (where `args` = `entity.args`) and a
+/// TypedValue component inside a complex entity instance.
+fn bspline_surface_from_args(
+    id: u64,
+    args: &[Arg],
+    file: &StepFile,
+) -> Result<Box<dyn Surface>, GeomError> {
+    let bad = |idx| GeomError::BadArg(id, idx);
+
+    let u_degree = match args.get(1) {
+        Some(Arg::Integer(v)) => *v as usize,
+        _ => return Err(bad(1)),
+    };
+    let v_degree = match args.get(2) {
+        Some(Arg::Integer(v)) => *v as usize,
+        _ => return Err(bad(2)),
+    };
+    let rows_arg = match args.get(3) {
+        Some(Arg::List(v)) => v,
+        _ => return Err(bad(3)),
+    };
+    let mut control_points: Vec<Vec<[f64; 3]>> = Vec::with_capacity(rows_arg.len());
+    for row_arg in rows_arg {
+        let col_list = match row_arg {
+            Arg::List(v) => v,
+            _ => return Err(bad(3)),
+        };
+        let mut row: Vec<[f64; 3]> = Vec::with_capacity(col_list.len());
+        for a in col_list {
+            let cp_id = arg_as_ref(a, id)?;
+            row.push(point3(file, cp_id)?);
+        }
+        control_points.push(row);
+    }
+    let u_mults = match args.get(8) {
+        Some(Arg::List(v)) => v,
+        _ => return Err(bad(8)),
+    };
+    let v_mults = match args.get(9) {
+        Some(Arg::List(v)) => v,
+        _ => return Err(bad(9)),
+    };
+    let u_knot_vals = match args.get(10) {
+        Some(Arg::List(v)) => v,
+        _ => return Err(bad(10)),
+    };
+    let v_knot_vals = match args.get(11) {
+        Some(Arg::List(v)) => v,
+        _ => return Err(bad(11)),
+    };
+    let u_knots = expand_knots(u_mults, u_knot_vals, id)?;
+    let v_knots = expand_knots(v_mults, v_knot_vals, id)?;
+    Ok(Box::new(BSplineSurfaceWithKnots {
+        u_degree,
+        v_degree,
+        control_points,
+        u_knots,
+        v_knots,
+    }))
+}
+
 pub fn surface_from_step(id: u64, file: &StepFile) -> Result<Box<dyn Surface>, GeomError> {
     let e = get_entity(file, id)?;
+
+    // Complex entity instance: type_name is empty, args are TypedValue components.
+    // Scan for a recognised surface type among them.
+    if e.type_name.is_empty() {
+        for arg in &e.args {
+            if let Arg::TypedValue { name, args: sub_args } = arg {
+                if name == "B_SPLINE_SURFACE_WITH_KNOTS" {
+                    return bspline_surface_from_args(id, sub_args, file);
+                }
+            }
+        }
+        return Err(GeomError::Unsupported(
+            "complex entity with no recognised surface component".to_string(),
+            id,
+        ));
+    }
+
     match e.type_name.as_str() {
         "PLANE" => {
             // PLANE(label, axis2_placement_ref)
@@ -378,46 +458,7 @@ pub fn surface_from_step(id: u64, file: &StepFile) -> Result<Box<dyn Surface>, G
             Ok(Box::new(SphericalSurface { axis, radius }))
         }
 
-        "B_SPLINE_SURFACE_WITH_KNOTS" => {
-            // B_SPLINE_SURFACE_WITH_KNOTS(name, u_degree, v_degree,
-            //   ((cp_refs)), surface_form, u_closed, v_closed, self_intersect,
-            //   u_multiplicities, v_multiplicities, u_knots, v_knots, knot_spec)
-            let u_degree = match get_arg(e, 1)? {
-                Arg::Integer(v) => *v as usize,
-                _ => return Err(GeomError::BadArg(id, 1)),
-            };
-            let v_degree = match get_arg(e, 2)? {
-                Arg::Integer(v) => *v as usize,
-                _ => return Err(GeomError::BadArg(id, 2)),
-            };
-            let rows_arg = get_list(e, 3)?;
-            let mut control_points: Vec<Vec<[f64; 3]>> = Vec::with_capacity(rows_arg.len());
-            for row_arg in rows_arg {
-                let col_list = match row_arg {
-                    Arg::List(v) => v,
-                    _ => return Err(GeomError::BadArg(id, 3)),
-                };
-                let mut row: Vec<[f64; 3]> = Vec::with_capacity(col_list.len());
-                for a in col_list {
-                    let cp_id = arg_as_ref(a, id)?;
-                    row.push(point3(file, cp_id)?);
-                }
-                control_points.push(row);
-            }
-            let u_mults = get_list(e, 8)?;
-            let v_mults = get_list(e, 9)?;
-            let u_knot_vals = get_list(e, 10)?;
-            let v_knot_vals = get_list(e, 11)?;
-            let u_knots = expand_knots(u_mults, u_knot_vals, id)?;
-            let v_knots = expand_knots(v_mults, v_knot_vals, id)?;
-            Ok(Box::new(BSplineSurfaceWithKnots {
-                u_degree,
-                v_degree,
-                control_points,
-                u_knots,
-                v_knots,
-            }))
-        }
+        "B_SPLINE_SURFACE_WITH_KNOTS" => bspline_surface_from_args(id, &e.args, file),
 
         "SURFACE_OF_LINEAR_EXTRUSION" => {
             // SURFACE_OF_LINEAR_EXTRUSION(label, swept_curve_ref, extrusion_axis_ref)
@@ -597,5 +638,56 @@ mod tests {
                 assert!((r - 5.).abs() < 1e-12, "radius at u={}, v={}: {}", u, v, r);
             }
         }
+    }
+
+    /// Verify that `surface_from_step` can build a B-spline surface from a
+    /// STEP complex entity instance (empty `type_name`, args are TypedValues).
+    ///
+    /// The surface is a 3×3 quadratic B-spline tent: all control points have
+    /// z=0 except the centre point at z=1.  At u=v=0.5 the surface evaluates
+    /// to z ≈ 0.25 (tensor-product basis).
+    #[test]
+    fn bspline_from_complex_entity() {
+        use crate::step::parser::{parse, StepFile};
+
+        // Build a minimal STEP file where the B-spline surface is stored as a
+        // complex entity instance:  #100=(BOUNDED_SURFACE()B_SPLINE_SURFACE_WITH_KNOTS(...))
+        let step_text = "
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('test'));
+ENDSEC;
+DATA;
+#1=CARTESIAN_POINT('',(0.,0.,0.));
+#2=CARTESIAN_POINT('',(0.5,0.,0.));
+#3=CARTESIAN_POINT('',(1.,0.,0.));
+#4=CARTESIAN_POINT('',(0.,0.5,0.));
+#5=CARTESIAN_POINT('',(0.5,0.5,1.));
+#6=CARTESIAN_POINT('',(1.,0.5,0.));
+#7=CARTESIAN_POINT('',(0.,1.,0.));
+#8=CARTESIAN_POINT('',(0.5,1.,0.));
+#9=CARTESIAN_POINT('',(1.,1.,0.));
+#100=(BOUNDED_SURFACE()B_SPLINE_SURFACE_WITH_KNOTS('',2,2,((#1,#2,#3),(#4,#5,#6),(#7,#8,#9)),.UNSPECIFIED.,.F.,.F.,.F.,(3,3),(3,3),(0.,1.),(0.,1.),.UNSPECIFIED.));
+ENDSEC;
+END-ISO-10303-21;
+";
+        let file: StepFile = parse(step_text).unwrap();
+        let surface = surface_from_step(100, &file).expect("should parse complex B-spline entity");
+
+        // At (u=0, v=0) the surface must be at the corner control point (0,0,0).
+        let p00 = surface.point(0.0, 0.0);
+        assert!(
+            p00[2].abs() < 1e-10,
+            "corner z should be 0, got {:.6}",
+            p00[2]
+        );
+
+        // At the centre the tent peaks at z=0.25 (quadratic tensor-product blend).
+        let p_mid = surface.point(0.5, 0.5);
+        assert!(
+            (p_mid[2] - 0.25).abs() < 1e-6,
+            "centre z should be 0.25, got {:.6}",
+            p_mid[2]
+        );
     }
 }

--- a/crates/kofem-geom/src/geom/surface.rs
+++ b/crates/kofem-geom/src/geom/surface.rs
@@ -2,9 +2,8 @@ use std::f64::consts::PI;
 
 use super::curve::{curve_from_step, Curve};
 use super::{
-    add, arg_as_ref, axis1_placement, axis2_placement, cross, de_boor_1d, expand_knots,
-    get_entity, get_real, get_ref, normalize, point3, rodrigues, scale, sub, Axis1,
-    Axis2, GeomError,
+    add, arg_as_ref, axis1_placement, axis2_placement, cross, de_boor_1d, expand_knots, get_entity,
+    get_real, get_ref, normalize, point3, rodrigues, scale, sub, Axis1, Axis2, GeomError,
 };
 use crate::step::parser::{Arg, StepFile};
 
@@ -392,7 +391,11 @@ pub fn surface_from_step(id: u64, file: &StepFile) -> Result<Box<dyn Surface>, G
     // Scan for a recognised surface type among them.
     if e.type_name.is_empty() {
         for arg in &e.args {
-            if let Arg::TypedValue { name, args: sub_args } = arg {
+            if let Arg::TypedValue {
+                name,
+                args: sub_args,
+            } = arg
+            {
                 if name == "B_SPLINE_SURFACE_WITH_KNOTS" {
                     return bspline_surface_from_args(id, sub_args, file);
                 }

--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -13,11 +13,12 @@ use kofem_mesh::geom::{point_in_polygon, Point2};
 use kofem_mesh::triangulate::triangulate;
 
 use crate::geom::curve::curve_from_step;
+use crate::geom::surface::surface_from_step;
 use crate::geom::{
     add, axis2_placement, cross, get_entity, get_real, get_ref, normalize, point3, scale, sub,
     GeomError,
 };
-use crate::step::parser::StepFile;
+use crate::step::parser::{Arg, StepFile};
 use crate::step::topology::{BRep, TopoEdge, TopoFace};
 
 // ── Public types ───────────────────────────────────────────────────────────────
@@ -125,6 +126,9 @@ fn tessellate_face(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> Surfa
 
 fn tessellate_face_raw(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> SurfaceMesh {
     if let Some(mesh) = try_tessellate_cylindrical(face, file, max_edge_len) {
+        return mesh;
+    }
+    if let Some(mesh) = try_tessellate_bspline(face, file, max_edge_len) {
         return mesh;
     }
 
@@ -277,6 +281,90 @@ fn try_tessellate_cylindrical(
     }
 
     Some(SurfaceMesh { points, triangles })
+}
+
+/// Tessellate a B-spline surface face by sampling its UV parameter domain
+/// uniformly and evaluating `surface.point(u, v)` at each grid node.
+///
+/// Handles both direct `B_SPLINE_SURFACE_WITH_KNOTS` entities and complex entity
+/// instances (empty `type_name`) that contain a `B_SPLINE_SURFACE_WITH_KNOTS`
+/// component.  Returns `None` when the surface is not a B-spline or its UV
+/// bounds are not finite.
+fn try_tessellate_bspline(
+    face: &TopoFace,
+    file: &StepFile,
+    max_edge_len: f64,
+) -> Option<SurfaceMesh> {
+    let e = file.get(&face.surface_id)?;
+
+    let is_bspline = e.type_name == "B_SPLINE_SURFACE_WITH_KNOTS"
+        || (e.type_name.is_empty()
+            && e.args.iter().any(|a| {
+                matches!(a, Arg::TypedValue { name, .. } if name == "B_SPLINE_SURFACE_WITH_KNOTS")
+            }));
+
+    if !is_bspline {
+        return None;
+    }
+
+    let surface = surface_from_step(face.surface_id, file).ok()?;
+
+    let (u0, u1) = surface.u_bounds();
+    let (v0, v1) = surface.v_bounds();
+    if !u0.is_finite() || !u1.is_finite() || !v0.is_finite() || !v1.is_finite() {
+        return None;
+    }
+
+    // Estimate spatial arc lengths at mid-parameter to choose sample density.
+    let u_mid = (u0 + u1) / 2.0;
+    let v_mid = (v0 + v1) / 2.0;
+    let arc_u = sample_arc_length(|t| surface.point(t, v_mid), u0, u1, 32);
+    let arc_v = sample_arc_length(|t| surface.point(u_mid, t), v0, v1, 32);
+
+    if arc_u < 1e-10 || arc_v < 1e-10 {
+        return None;
+    }
+
+    let n_u = ((arc_u / max_edge_len).ceil() as usize).clamp(2, 256) + 1;
+    let n_v = ((arc_v / max_edge_len).ceil() as usize).clamp(2, 256) + 1;
+
+    let mut points = Vec::with_capacity(n_u * n_v);
+    for j in 0..n_v {
+        let v = v0 + (v1 - v0) * j as f64 / (n_v - 1) as f64;
+        for i in 0..n_u {
+            let u = u0 + (u1 - u0) * i as f64 / (n_u - 1) as f64;
+            points.push(surface.point(u, v));
+        }
+    }
+
+    let mut triangles = Vec::with_capacity((n_u - 1) * (n_v - 1) * 2);
+    for j in 0..(n_v - 1) {
+        for i in 0..(n_u - 1) {
+            let a = j * n_u + i;
+            let b = j * n_u + (i + 1);
+            let c = (j + 1) * n_u + i;
+            let d = (j + 1) * n_u + (i + 1);
+            triangles.push([a, b, d]);
+            triangles.push([a, d, c]);
+        }
+    }
+
+    Some(SurfaceMesh { points, triangles })
+}
+
+/// Approximate arc length of a parametric curve `f(t)` over `[t0, t1]`
+/// by sampling at `n` uniform intervals.
+fn sample_arc_length<F: Fn(f64) -> [f64; 3]>(f: F, t0: f64, t1: f64, n: usize) -> f64 {
+    let mut len = 0.0_f64;
+    let mut prev = f(t0);
+    for i in 1..=n {
+        let t = t0 + (t1 - t0) * i as f64 / n as f64;
+        let curr = f(t);
+        let d = sub(curr, prev);
+        len += (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt();
+        prev = curr;
+    }
+    len
 }
 
 // ── Boundary sampling ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Extend B-spline surface parsing to handle STEP complex entity instances (where `type_name` is empty and surface components are stored as `TypedValue` arguments), and add tessellation support for B-spline surfaces in the mesh generation pipeline.

## Key Changes

- **Refactor B-spline parsing:** Extract `B_SPLINE_SURFACE_WITH_KNOTS` parsing logic into a new `bspline_surface_from_args()` helper function that works with both standalone entities and complex entity components.

- **Complex entity detection:** Update `surface_from_step()` to detect and parse complex entity instances by scanning for recognized surface type names in the `TypedValue` arguments before falling back to direct type matching.

- **B-spline tessellation:** Implement `try_tessellate_bspline()` in the tessellation pipeline to handle B-spline surface faces by:
  - Sampling the UV parameter domain uniformly
  - Estimating spatial arc lengths along U and V directions to determine grid density
  - Clamping sample counts to [2, 256] per dimension
  - Generating triangles from the sampled grid

- **Arc length estimation:** Add `sample_arc_length()` helper to approximate parametric curve length via 32-point uniform sampling, used to scale tessellation density relative to `max_edge_len`.

- **Test coverage:** Add `bspline_from_complex_entity()` test that verifies parsing and evaluation of a 3×3 quadratic B-spline tent surface from a complex entity instance.

- **Import cleanup:** Remove unused `get_arg` and `get_list` imports from the geometry module.

## Implementation Details

- Complex entity detection checks both the entity's `type_name` and scans `args` for `TypedValue` components with matching surface type names.
- B-spline tessellation gracefully returns `None` if UV bounds are not finite, allowing fallback to boundary-based tessellation.
- Grid density is clamped to prevent excessive memory use while maintaining reasonable approximation quality.

https://claude.ai/code/session_01UrHcVT4ERQY4EWJSMoSDR2