### PR TITLE
Add conical surface tessellation support

### DIFF
--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -128,6 +128,9 @@ fn tessellate_face_raw(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> S
     if let Some(mesh) = try_tessellate_cylindrical(face, file, max_edge_len) {
         return mesh;
     }
+    if let Some(mesh) = try_tessellate_conical(face, file, max_edge_len) {
+        return mesh;
+    }
     if let Some(mesh) = try_tessellate_toroidal(face, file, max_edge_len) {
         return mesh;
     }
@@ -284,6 +287,144 @@ fn try_tessellate_cylindrical(
     }
 
     Some(SurfaceMesh { points, triangles })
+}
+
+/// Tessellate a `CONICAL_SURFACE` face directly in UV space (u = angle, v = slant distance)
+/// and lift back to 3D. Returns `None` when the surface is not conical.
+///
+/// Full-revolution cones (detected by a closed-circle boundary edge) generate a u×v grid
+/// spanning u ∈ [0, 2π] with v inferred from the boundary axial extents.
+/// Partial cones (chamfers, tapered transitions that do not wrap fully) invert the boundary
+/// to cone UV, determine the u-range, then generate a UV grid over [u_min, u_max] × [v_min, v_max].
+fn try_tessellate_conical(
+    face: &TopoFace,
+    file: &StepFile,
+    max_edge_len: f64,
+) -> Option<SurfaceMesh> {
+    let e = file.get(&face.surface_id)?;
+    if e.type_name != "CONICAL_SURFACE" {
+        return None;
+    }
+
+    let ax_id = get_ref(e, 1).ok()?;
+    let radius = get_real(e, 2).ok()?;
+    let semi_angle = get_real(e, 3).ok()?;
+    let axis = axis2_placement(file, ax_id).ok()?;
+    let y = axis.y();
+
+    let surface = surface_from_step(face.surface_id, file).ok()?;
+
+    let boundary_3d = sample_boundary_3d(&face.outer_loop, file, max_edge_len);
+    if boundary_3d.len() < 3 {
+        return None;
+    }
+
+    // Full-revolution check: a closed-circle edge has start ≈ end (zero chord).
+    let has_closed_circle = face.outer_loop.iter().any(|edge| {
+        let d = sub(edge.start, edge.end);
+        d[0] * d[0] + d[1] * d[1] + d[2] * d[2] < 1e-16
+    });
+
+    // Degenerate flat cone (φ ≈ ±90°): cos(φ) ≈ 0 means v is undefined.
+    let cos_phi = semi_angle.cos();
+    if cos_phi.abs() < 1e-10 {
+        return None;
+    }
+
+    // Invert boundary points to slant parameter v = axial_projection / cos(φ).
+    let mut v_min = f64::INFINITY;
+    let mut v_max = f64::NEG_INFINITY;
+    for &p in &boundary_3d {
+        let d = sub(p, axis.origin);
+        let v = dot3(d, axis.z) / cos_phi;
+        v_min = v_min.min(v);
+        v_max = v_max.max(v);
+    }
+    if (v_max - v_min).abs() < 1e-10 {
+        return None;
+    }
+
+    // Radius at the midpoint v for density estimation.
+    let v_mid = (v_min + v_max) / 2.0;
+    let r_mid = (radius + v_mid * semi_angle.sin()).abs();
+
+    if has_closed_circle {
+        // Full-revolution cone: u sweeps 0..2π, v derived from axial boundary range.
+        let circumference = 2.0 * PI * r_mid;
+        let n_u = ((circumference / max_edge_len).ceil() as usize).clamp(8, 256);
+        let n_v = (((v_max - v_min).abs() / max_edge_len).ceil() as usize).max(1);
+
+        let mut points = Vec::with_capacity(n_u * (n_v + 1));
+        for j in 0..=n_v {
+            let v = v_min + (v_max - v_min) * j as f64 / n_v as f64;
+            for i in 0..n_u {
+                let u = 2.0 * PI * i as f64 / n_u as f64;
+                points.push(surface.point(u, v));
+            }
+        }
+
+        let mut triangles = Vec::with_capacity(n_u * n_v * 2);
+        for j in 0..n_v {
+            for i in 0..n_u {
+                let ni = (i + 1) % n_u;
+                let a = j * n_u + i;
+                let b = j * n_u + ni;
+                let c = (j + 1) * n_u + i;
+                let d = (j + 1) * n_u + ni;
+                // CCW winding when viewed from outside (outward-radial normal).
+                triangles.push([a, b, d]);
+                triangles.push([a, d, c]);
+            }
+        }
+
+        Some(SurfaceMesh { points, triangles })
+    } else {
+        // Partial cone: invert boundary to find the angular u-range.
+        let raw_u: Vec<f64> = boundary_3d
+            .iter()
+            .map(|&p| {
+                let d = sub(p, axis.origin);
+                f64::atan2(dot3(d, y), dot3(d, axis.x))
+            })
+            .collect();
+        let u_vals = unwrap_angles(raw_u);
+
+        let u_min = u_vals.iter().cloned().fold(f64::INFINITY, f64::min);
+        let u_max = u_vals.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+
+        if (u_max - u_min) < 1e-10 {
+            return None;
+        }
+
+        let arc_u = (u_max - u_min) * r_mid;
+        let arc_v = (v_max - v_min).abs();
+        let n_u = ((arc_u / max_edge_len).ceil() as usize).clamp(2, 256);
+        let n_v = ((arc_v / max_edge_len).ceil() as usize).clamp(1, 256);
+
+        let mut points = Vec::with_capacity((n_u + 1) * (n_v + 1));
+        for j in 0..=n_v {
+            let v = v_min + (v_max - v_min) * j as f64 / n_v as f64;
+            for i in 0..=n_u {
+                let u = u_min + (u_max - u_min) * i as f64 / n_u as f64;
+                points.push(surface.point(u, v));
+            }
+        }
+
+        let n_cols = n_u + 1;
+        let mut triangles = Vec::with_capacity(n_u * n_v * 2);
+        for j in 0..n_v {
+            for i in 0..n_u {
+                let a = j * n_cols + i;
+                let b = j * n_cols + (i + 1);
+                let c = (j + 1) * n_cols + i;
+                let d = (j + 1) * n_cols + (i + 1);
+                triangles.push([a, b, d]);
+                triangles.push([a, d, c]);
+            }
+        }
+
+        Some(SurfaceMesh { points, triangles })
+    }
 }
 
 /// Tessellate a `TOROIDAL_SURFACE` face (blend fillet) directly in UV space

--- a/crates/kofem-geom/tests/tess.rs
+++ b/crates/kofem-geom/tests/tess.rs
@@ -582,7 +582,10 @@ fn cone_barrel_points_lie_on_cone_surface() {
             has_barrel = true;
         }
     }
-    assert!(has_barrel, "no intermediate barrel points found — cone may have been tessellated flat");
+    assert!(
+        has_barrel,
+        "no intermediate barrel points found — cone may have been tessellated flat"
+    );
 }
 
 /// Height range of the merged cone mesh must span [0, 30].
@@ -603,7 +606,10 @@ fn cone_mesh_spans_correct_height() {
     }
 
     assert!((z_min - 0.0).abs() < 1e-4, "z_min should be 0, got {z_min}");
-    assert!((z_max - 30.0).abs() < 1e-4, "z_max should be 30, got {z_max}");
+    assert!(
+        (z_max - 30.0).abs() < 1e-4,
+        "z_max should be 30, got {z_max}"
+    );
 }
 
 /// Tessellation must produce triangles (non-degenerate mesh).

--- a/crates/kofem-geom/tests/tess.rs
+++ b/crates/kofem-geom/tests/tess.rs
@@ -479,6 +479,145 @@ fn cylinder_barrel_has_nonzero_height() {
     );
 }
 
+// ── cone regression tests ─────────────────────────────────────────────────────
+
+/// Truncated cone: bottom circle radius=10 at z=0, top circle radius=20 at z=30.
+/// The CONICAL_SURFACE has semi_angle = atan(1/3) ≈ 0.32175 rad.
+/// On the barrel, r(z) = 10 + z/3 (linear taper, tan(φ)=1/3).
+const STEP_CONE: &str = "
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('KoFEM test cone R_bot=10 R_top=20 H=30'));
+ENDSEC;
+DATA;
+#1=CARTESIAN_POINT('',(10.,0.,0.));
+#2=VERTEX_POINT('',#1);
+#3=CARTESIAN_POINT('',(20.,0.,30.));
+#4=VERTEX_POINT('',#3);
+#5=CARTESIAN_POINT('',(10.,0.,0.));
+#6=DIRECTION('',(0.31623,0.,0.94868));
+#7=VECTOR('',#6,31.62278);
+#8=LINE('',#5,#7);
+#9=EDGE_CURVE('',#2,#4,#8,.T.);
+#10=CARTESIAN_POINT('',(0.,0.,0.));
+#11=DIRECTION('',(0.,0.,-1.));
+#12=DIRECTION('',(1.,0.,0.));
+#13=AXIS2_PLACEMENT_3D('',#10,#11,#12);
+#14=CIRCLE('',#13,10.);
+#15=EDGE_CURVE('',#2,#2,#14,.T.);
+#16=CARTESIAN_POINT('',(0.,0.,30.));
+#17=DIRECTION('',(0.,0.,1.));
+#18=DIRECTION('',(1.,0.,0.));
+#19=AXIS2_PLACEMENT_3D('',#16,#17,#18);
+#20=CIRCLE('',#19,20.);
+#21=EDGE_CURVE('',#4,#4,#20,.T.);
+#22=ORIENTED_EDGE('',*,*,#15,.T.);
+#23=CARTESIAN_POINT('',(0.,0.,0.));
+#24=DIRECTION('',(0.,0.,-1.));
+#25=DIRECTION('',(1.,0.,0.));
+#26=AXIS2_PLACEMENT_3D('',#23,#24,#25);
+#27=PLANE('',#26);
+#28=EDGE_LOOP('',(#22));
+#29=FACE_OUTER_BOUND('',#28,.T.);
+#30=ADVANCED_FACE('',(#29),#27,.T.);
+#31=ORIENTED_EDGE('',*,*,#21,.T.);
+#32=CARTESIAN_POINT('',(0.,0.,30.));
+#33=DIRECTION('',(0.,0.,1.));
+#34=DIRECTION('',(1.,0.,0.));
+#35=AXIS2_PLACEMENT_3D('',#32,#33,#34);
+#36=PLANE('',#35);
+#37=EDGE_LOOP('',(#31));
+#38=FACE_OUTER_BOUND('',#37,.T.);
+#39=ADVANCED_FACE('',(#38),#36,.T.);
+#40=ORIENTED_EDGE('',*,*,#9,.T.);
+#41=ORIENTED_EDGE('',*,*,#21,.T.);
+#42=ORIENTED_EDGE('',*,*,#9,.F.);
+#43=ORIENTED_EDGE('',*,*,#15,.F.);
+#44=CARTESIAN_POINT('',(0.,0.,0.));
+#45=DIRECTION('',(0.,0.,1.));
+#46=DIRECTION('',(1.,0.,0.));
+#47=AXIS2_PLACEMENT_3D('',#44,#45,#46);
+#48=CONICAL_SURFACE('',#47,10.,0.32175);
+#49=EDGE_LOOP('',(#40,#41,#42,#43));
+#50=FACE_OUTER_BOUND('',#49,.T.);
+#51=ADVANCED_FACE('',(#50),#48,.T.);
+#52=CLOSED_SHELL('',(#30,#39,#51));
+#53=MANIFOLD_SOLID_BREP('cone',#52);
+ENDSEC;
+END-ISO-10303-21;
+";
+
+fn load_cone() -> (kofem_geom::step::StepFile, BRep) {
+    let file = parse(STEP_CONE).unwrap();
+    let brep = BRep::extract(&file).unwrap();
+    (file, brep)
+}
+
+/// All barrel points must lie on the cone surface: r(z) = 10 + z/3 (within 0.1%).
+/// Before the fix, conical faces fell through to the flat-projection path and
+/// produced only z=0 barrel points.
+#[test]
+fn cone_barrel_points_lie_on_cone_surface() {
+    let (file, brep) = load_cone();
+    let opts = TessOptions {
+        max_edge_len: 2.0,
+        ..TessOptions::default()
+    };
+    let mesh = tessellate(&brep, &file, opts).unwrap();
+
+    assert!(!mesh.points.is_empty());
+
+    let mut has_barrel = false;
+    for &[x, y, z] in &mesh.points {
+        // Points on either flat cap lie exactly in z=0 or z=30 planes; skip them.
+        let r = (x * x + y * y).sqrt();
+        let r_expected = 10.0 + z / 3.0;
+        // Only check barrel points (those clearly not on the cap discs).
+        if r > 1e-3 && z > 1e-3 && z < 30.0 - 1e-3 {
+            let err = (r - r_expected).abs() / r_expected;
+            assert!(
+                err < 1e-3,
+                "barrel point ({x:.4},{y:.4},{z:.4}) has r={r:.6}, expected {r_expected:.6} (err={err:.2e})"
+            );
+            has_barrel = true;
+        }
+    }
+    assert!(has_barrel, "no intermediate barrel points found — cone may have been tessellated flat");
+}
+
+/// Height range of the merged cone mesh must span [0, 30].
+#[test]
+fn cone_mesh_spans_correct_height() {
+    let (file, brep) = load_cone();
+    let opts = TessOptions {
+        max_edge_len: 5.0,
+        ..TessOptions::default()
+    };
+    let mesh = tessellate(&brep, &file, opts).unwrap();
+
+    let mut z_min = f64::INFINITY;
+    let mut z_max = f64::NEG_INFINITY;
+    for &[_, _, z] in &mesh.points {
+        z_min = z_min.min(z);
+        z_max = z_max.max(z);
+    }
+
+    assert!((z_min - 0.0).abs() < 1e-4, "z_min should be 0, got {z_min}");
+    assert!((z_max - 30.0).abs() < 1e-4, "z_max should be 30, got {z_max}");
+}
+
+/// Tessellation must produce triangles (non-degenerate mesh).
+#[test]
+fn cone_mesh_has_triangles() {
+    let (file, brep) = load_cone();
+    let mesh = tessellate(&brep, &file, TessOptions::default()).unwrap();
+    assert!(
+        mesh.triangles.len() >= 3,
+        "expected at least 3 triangles, got {}",
+        mesh.triangles.len()
+    );
+}
+
 // ── bracket regression tests ───────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Implements direct tessellation of `CONICAL_SURFACE` faces in UV space, enabling accurate mesh generation for truncated cones and tapered transitions. Previously, conical faces fell through to the flat-projection fallback path, producing incorrect geometry.

## Changes

- **Added `try_tessellate_conical()` function** in `crates/kofem-geom/src/tess/mod.rs`:
  - Detects conical surfaces and extracts axis, base radius, and semi-angle parameters
  - Handles two cases:
    - **Full-revolution cones**: detected by closed-circle boundary edges; generates u×v grid spanning u ∈ [0, 2π] with v inferred from axial extents
    - **Partial cones**: inverts boundary points to cone UV space, determines angular u-range, then generates grid over [u_min, u_max] × [v_min, v_max]
  - Validates non-degenerate geometry (rejects flat cones where cos(φ) ≈ 0)
  - Lifts UV grid points back to 3D using the surface parameterization
  - Generates CCW-wound triangles for correct outward-facing normals

- **Integrated into tessellation pipeline**: added call to `try_tessellate_conical()` in `tessellate_face_raw()` before the toroidal fallback

- **Added comprehensive regression tests** in `crates/kofem-geom/tests/tess.rs`:
  - `cone_barrel_points_lie_on_cone_surface()`: verifies barrel points satisfy r(z) = r₀ + z·tan(φ) within 0.1%
  - `cone_mesh_spans_correct_height()`: confirms z-range covers [0, 30] for test geometry
  - `cone_mesh_has_triangles()`: ensures non-degenerate mesh output
  - Includes full STEP file for a truncated cone (R_bot=10, R_top=20, H=30)

## Implementation Details

- **UV parameterization**: u = azimuthal angle, v = slant distance along generator
- **Density estimation**: uses radius at v_mid to compute grid resolution in both directions
- **Angle unwrapping**: applies `unwrap_angles()` to handle partial cones that may wrap across the u=0 discontinuity
- **Degenerate checks**: rejects cones with v_range < 1e-10 or u_range < 1e-10 to avoid numerical issues

https://claude.ai/code/session_01AmAExyeE8TisM76cNjn7Rn

closes #48 