### PR TITLE
Support partial cylinders in tessellation

### DIFF
--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -211,10 +211,10 @@ fn tessellate_face_raw(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> S
 /// Tessellate a `CYLINDRICAL_SURFACE` face directly in UV space (u = angle, v = height)
 /// and lift back to 3D. Returns `None` when the surface is not cylindrical.
 ///
-/// The flat 2D-projection path in `tessellate_face_raw` fails for cylinder barrels
-/// because the boundary (two circles + two seam lines) projects to a degenerate 2D
-/// polygon: both circles overlap in XY and the seam lines collapse to a single point,
-/// losing all height information.
+/// Full-revolution barrels (detected by a closed-circle boundary edge) generate a u×v
+/// grid spanning u ∈ [0, 2π] with v inferred from the boundary axial extents.
+/// Partial cylinders (hole walls, fillets, chamfer arcs) invert the boundary to cylinder
+/// UV, determine the u-range, then generate a UV grid over [u_min, u_max] × [v_min, v_max].
 fn try_tessellate_cylindrical(
     face: &TopoFace,
     file: &StepFile,
@@ -225,23 +225,23 @@ fn try_tessellate_cylindrical(
         return None;
     }
 
-    // Only handle full-revolution barrels. A full circle edge has start ≈ end
-    // (closed loop). Partial cylinders (fillets, chamfers) have arc edges where
-    // start ≠ end and must fall through to the flat-projection path.
+    let ax_id = get_ref(e, 1).ok()?;
+    let radius = get_real(e, 2).ok()?;
+    let axis = axis2_placement(file, ax_id).ok()?;
+    let y = axis.y();
+
+    let boundary_3d = sample_boundary_3d(&face.outer_loop, file, max_edge_len);
+    if boundary_3d.len() < 3 {
+        return None;
+    }
+
+    // Full-revolution check: a closed-circle edge has start ≈ end (zero chord).
     let has_closed_circle = face.outer_loop.iter().any(|edge| {
         let d = sub(edge.start, edge.end);
         d[0] * d[0] + d[1] * d[1] + d[2] * d[2] < 1e-16
     });
-    if !has_closed_circle {
-        return None;
-    }
 
-    let ax_id = get_ref(e, 1).ok()?;
-    let radius = get_real(e, 2).ok()?;
-    let axis = axis2_placement(file, ax_id).ok()?;
-
-    // Sample the boundary to determine the height (v) range.
-    let boundary_3d = sample_boundary_3d(&face.outer_loop, file, max_edge_len);
+    // Determine the v (axial) range from boundary points.
     let mut v_min = f64::INFINITY;
     let mut v_max = f64::NEG_INFINITY;
     for &p in &boundary_3d {
@@ -254,39 +254,89 @@ fn try_tessellate_cylindrical(
         return None;
     }
 
-    let circumference = 2.0 * PI * radius;
-    let n_u = ((circumference / max_edge_len).ceil() as usize).clamp(8, 256);
-    let n_v = (((v_max - v_min).abs() / max_edge_len).ceil() as usize).max(1);
+    if has_closed_circle {
+        // Full-revolution barrel: u sweeps 0..2π.
+        let circumference = 2.0 * PI * radius;
+        let n_u = ((circumference / max_edge_len).ceil() as usize).clamp(8, 256);
+        let n_v = (((v_max - v_min).abs() / max_edge_len).ceil() as usize).max(1);
 
-    let y = axis.y();
-    let mut points = Vec::with_capacity(n_u * (n_v + 1));
-    for j in 0..=n_v {
-        let v = v_min + (v_max - v_min) * j as f64 / n_v as f64;
-        for i in 0..n_u {
-            let u = 2.0 * PI * i as f64 / n_u as f64;
-            let radial = add(scale(axis.x, u.cos()), scale(y, u.sin()));
-            points.push(add(
-                axis.origin,
-                add(scale(radial, radius), scale(axis.z, v)),
-            ));
+        let mut points = Vec::with_capacity(n_u * (n_v + 1));
+        for j in 0..=n_v {
+            let v = v_min + (v_max - v_min) * j as f64 / n_v as f64;
+            for i in 0..n_u {
+                let u = 2.0 * PI * i as f64 / n_u as f64;
+                let radial = add(scale(axis.x, u.cos()), scale(y, u.sin()));
+                points.push(add(
+                    axis.origin,
+                    add(scale(radial, radius), scale(axis.z, v)),
+                ));
+            }
         }
-    }
 
-    let mut triangles = Vec::with_capacity(n_u * n_v * 2);
-    for j in 0..n_v {
-        for i in 0..n_u {
-            let ni = (i + 1) % n_u;
-            let a = j * n_u + i;
-            let b = j * n_u + ni;
-            let c = (j + 1) * n_u + i;
-            let d = (j + 1) * n_u + ni;
-            // CCW winding when viewed from outside (outward-radial normal).
-            triangles.push([a, b, d]);
-            triangles.push([a, d, c]);
+        let mut triangles = Vec::with_capacity(n_u * n_v * 2);
+        for j in 0..n_v {
+            for i in 0..n_u {
+                let ni = (i + 1) % n_u;
+                let a = j * n_u + i;
+                let b = j * n_u + ni;
+                let c = (j + 1) * n_u + i;
+                let d = (j + 1) * n_u + ni;
+                // CCW winding when viewed from outside (outward-radial normal).
+                triangles.push([a, b, d]);
+                triangles.push([a, d, c]);
+            }
         }
-    }
 
-    Some(SurfaceMesh { points, triangles })
+        Some(SurfaceMesh { points, triangles })
+    } else {
+        // Partial cylinder: invert boundary to find the angular u-range.
+        let surface = surface_from_step(face.surface_id, file).ok()?;
+
+        let raw_u: Vec<f64> = boundary_3d
+            .iter()
+            .map(|&p| {
+                let d = sub(p, axis.origin);
+                f64::atan2(dot3(d, y), dot3(d, axis.x))
+            })
+            .collect();
+        let u_vals = unwrap_angles(raw_u);
+
+        let u_min = u_vals.iter().cloned().fold(f64::INFINITY, f64::min);
+        let u_max = u_vals.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+
+        if (u_max - u_min) < 1e-10 {
+            return None;
+        }
+
+        let arc_u = (u_max - u_min) * radius;
+        let arc_v = (v_max - v_min).abs();
+        let n_u = ((arc_u / max_edge_len).ceil() as usize).clamp(2, 256);
+        let n_v = ((arc_v / max_edge_len).ceil() as usize).clamp(1, 256);
+
+        let mut points = Vec::with_capacity((n_u + 1) * (n_v + 1));
+        for j in 0..=n_v {
+            let v = v_min + (v_max - v_min) * j as f64 / n_v as f64;
+            for i in 0..=n_u {
+                let u = u_min + (u_max - u_min) * i as f64 / n_u as f64;
+                points.push(surface.point(u, v));
+            }
+        }
+
+        let n_cols = n_u + 1;
+        let mut triangles = Vec::with_capacity(n_u * n_v * 2);
+        for j in 0..n_v {
+            for i in 0..n_u {
+                let a = j * n_cols + i;
+                let b = j * n_cols + (i + 1);
+                let c = (j + 1) * n_cols + i;
+                let d = (j + 1) * n_cols + (i + 1);
+                triangles.push([a, b, d]);
+                triangles.push([a, d, c]);
+            }
+        }
+
+        Some(SurfaceMesh { points, triangles })
+    }
 }
 
 /// Tessellate a `CONICAL_SURFACE` face directly in UV space (u = angle, v = slant distance)

--- a/crates/kofem-geom/tests/tess.rs
+++ b/crates/kofem-geom/tests/tess.rs
@@ -624,6 +624,129 @@ fn cone_mesh_has_triangles() {
     );
 }
 
+// ── partial cylinder tests ────────────────────────────────────────────────────
+
+/// Quarter-cylinder patch: r=5, z in [0,10], u in [0, π/2].
+/// 4 boundary edges: bottom arc, right seam line, top arc (reversed), left seam line.
+/// No closed-circle edge → partial cylinder path must be taken.
+const STEP_QUARTER_CYLINDER: &str = "
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('KoFEM quarter-cylinder test r=5 h=10'));
+ENDSEC;
+DATA;
+#1=CARTESIAN_POINT('',(5.,0.,0.));
+#2=CARTESIAN_POINT('',(0.,5.,0.));
+#3=CARTESIAN_POINT('',(0.,5.,10.));
+#4=CARTESIAN_POINT('',(5.,0.,10.));
+#5=VERTEX_POINT('',#1);
+#6=VERTEX_POINT('',#2);
+#7=VERTEX_POINT('',#3);
+#8=VERTEX_POINT('',#4);
+#10=CARTESIAN_POINT('',(0.,0.,0.));
+#11=DIRECTION('',(0.,0.,1.));
+#12=DIRECTION('',(1.,0.,0.));
+#13=AXIS2_PLACEMENT_3D('',#10,#11,#12);
+#14=CIRCLE('',#13,5.);
+#15=EDGE_CURVE('',#5,#6,#14,.T.);
+#20=CARTESIAN_POINT('',(0.,5.,0.));
+#21=DIRECTION('',(0.,0.,1.));
+#22=VECTOR('',#21,10.);
+#23=LINE('',#20,#22);
+#24=EDGE_CURVE('',#6,#7,#23,.T.);
+#30=CARTESIAN_POINT('',(0.,0.,10.));
+#31=DIRECTION('',(0.,0.,1.));
+#32=DIRECTION('',(1.,0.,0.));
+#33=AXIS2_PLACEMENT_3D('',#30,#31,#32);
+#34=CIRCLE('',#33,5.);
+#35=EDGE_CURVE('',#8,#7,#34,.T.);
+#40=CARTESIAN_POINT('',(5.,0.,10.));
+#41=DIRECTION('',(0.,0.,-1.));
+#42=VECTOR('',#41,10.);
+#43=LINE('',#40,#42);
+#44=EDGE_CURVE('',#8,#5,#43,.T.);
+#50=ORIENTED_EDGE('',*,*,#15,.T.);
+#51=ORIENTED_EDGE('',*,*,#24,.T.);
+#52=ORIENTED_EDGE('',*,*,#35,.F.);
+#53=ORIENTED_EDGE('',*,*,#44,.T.);
+#54=EDGE_LOOP('',(#50,#51,#52,#53));
+#55=FACE_OUTER_BOUND('',#54,.T.);
+#60=CARTESIAN_POINT('',(0.,0.,0.));
+#61=DIRECTION('',(0.,0.,1.));
+#62=DIRECTION('',(1.,0.,0.));
+#63=AXIS2_PLACEMENT_3D('',#60,#61,#62);
+#64=CYLINDRICAL_SURFACE('',#63,5.);
+#65=ADVANCED_FACE('',(#55),#64,.T.);
+ENDSEC;
+END-ISO-10303-21;
+";
+
+/// All barrel points on a partial cylinder must lie on the cylinder surface (r ≈ 5).
+#[test]
+fn partial_cylinder_points_lie_on_surface() {
+    let file = parse(STEP_QUARTER_CYLINDER).unwrap();
+    let brep = BRep::extract(&file).unwrap();
+    let opts = TessOptions {
+        max_edge_len: 1.0,
+        ..TessOptions::default()
+    };
+    let mesh = tessellate(&brep, &file, opts).unwrap();
+
+    assert!(!mesh.points.is_empty(), "mesh must have points");
+    assert!(!mesh.triangles.is_empty(), "mesh must have triangles");
+
+    for &[x, y, z] in &mesh.points {
+        let r = (x * x + y * y).sqrt();
+        assert!(
+            (r - 5.0).abs() < 1e-3,
+            "point ({x:.4},{y:.4},{z:.4}) has r={r:.6}, expected 5.0"
+        );
+    }
+}
+
+/// The partial cylinder patch must span the correct z range [0, 10].
+#[test]
+fn partial_cylinder_spans_correct_height() {
+    let file = parse(STEP_QUARTER_CYLINDER).unwrap();
+    let brep = BRep::extract(&file).unwrap();
+    let opts = TessOptions {
+        max_edge_len: 1.0,
+        ..TessOptions::default()
+    };
+    let mesh = tessellate(&brep, &file, opts).unwrap();
+
+    let z_min = mesh.points.iter().map(|p| p[2]).fold(f64::INFINITY, f64::min);
+    let z_max = mesh.points.iter().map(|p| p[2]).fold(f64::NEG_INFINITY, f64::max);
+
+    assert!(
+        (z_min - 0.0).abs() < 1e-6,
+        "z_min should be 0, got {z_min}"
+    );
+    assert!(
+        (z_max - 10.0).abs() < 1e-6,
+        "z_max should be 10, got {z_max}"
+    );
+}
+
+/// The partial cylinder patch must stay within the u ∈ [0, π/2] quarter arc.
+#[test]
+fn partial_cylinder_stays_within_angular_range() {
+    let file = parse(STEP_QUARTER_CYLINDER).unwrap();
+    let brep = BRep::extract(&file).unwrap();
+    let opts = TessOptions {
+        max_edge_len: 1.0,
+        ..TessOptions::default()
+    };
+    let mesh = tessellate(&brep, &file, opts).unwrap();
+
+    for &[x, y, _z] in &mesh.points {
+        assert!(
+            x >= -1e-6 && y >= -1e-6,
+            "point ({x:.4},{y:.4}) is outside the first quadrant"
+        );
+    }
+}
+
 // ── bracket regression tests ───────────────────────────────────────────────────
 
 #[test]

--- a/crates/kofem-geom/tests/tess.rs
+++ b/crates/kofem-geom/tests/tess.rs
@@ -715,13 +715,18 @@ fn partial_cylinder_spans_correct_height() {
     };
     let mesh = tessellate(&brep, &file, opts).unwrap();
 
-    let z_min = mesh.points.iter().map(|p| p[2]).fold(f64::INFINITY, f64::min);
-    let z_max = mesh.points.iter().map(|p| p[2]).fold(f64::NEG_INFINITY, f64::max);
+    let z_min = mesh
+        .points
+        .iter()
+        .map(|p| p[2])
+        .fold(f64::INFINITY, f64::min);
+    let z_max = mesh
+        .points
+        .iter()
+        .map(|p| p[2])
+        .fold(f64::NEG_INFINITY, f64::max);
 
-    assert!(
-        (z_min - 0.0).abs() < 1e-6,
-        "z_min should be 0, got {z_min}"
-    );
+    assert!((z_min - 0.0).abs() < 1e-6, "z_min should be 0, got {z_min}");
     assert!(
         (z_max - 10.0).abs() < 1e-6,
         "z_max should be 10, got {z_max}"


### PR DESCRIPTION
## Summary

Extend cylindrical surface tessellation to handle partial cylinders (hole walls, fillets, chamfer arcs) in addition to full-revolution barrels. Previously, only closed-circle boundary edges were supported; now the code detects partial cylinders by their open boundaries and tessellates them in UV space using angle unwrapping.

## Key Changes

- **Refactored `try_tessellate_cylindrical`** to branch on `has_closed_circle`:
  - **Full-revolution path**: Existing logic for barrels with closed-circle edges; u sweeps [0, 2π]
  - **Partial cylinder path**: New logic for open boundaries; inverts 3D boundary points to cylinder UV coordinates, unwraps angles to find u-range, then generates a grid over [u_min, u_max] × [v_min, v_max]

- **Angle unwrapping**: Introduced `unwrap_angles()` helper to handle angular discontinuities at ±π when converting 3D points to cylindrical u-coordinates via `atan2`

- **Boundary validation**: Added early check that sampled boundary has at least 3 points before proceeding

- **Surface evaluation**: Partial cylinders use `surface.point(u, v)` to lift UV grid points back to 3D, ensuring exact surface compliance

## Implementation Details

- Partial cylinder u-range is computed from boundary point projections: `u = atan2(dot(p - origin, y), dot(p - origin, x))`
- Grid density (n_u, n_v) is scaled by arc length and height respectively, clamped to [2, 256] and [1, 256]
- Triangle winding remains CCW when viewed from outside; partial cylinders use a rectangular grid (n_u+1 × n_v+1 points) rather than the circular topology of full barrels

## Tests Added

Three new test cases validate partial cylinder tessellation:
- `partial_cylinder_points_lie_on_surface`: All mesh points satisfy r ≈ 5 (quarter-cylinder test case)
- `partial_cylinder_spans_correct_height`: Mesh spans z ∈ [0, 10] as expected
- `partial_cylinder_stays_within_angular_range`: All points remain in the first quadrant (u ∈ [0, π/2])

Test data includes a quarter-cylinder STEP file (r=5, h=10, u ∈ [0, π/2]) with 4 boundary edges (two arcs, two seam lines).

https://claude.ai/code/session_01D8F7RKiMdELR2EpYNeXGV6