### PR TITLE
Add volume meshing for imported STEP geometry

### DIFF
--- a/crates/kofem-wasm/src/lib.rs
+++ b/crates/kofem-wasm/src/lib.rs
@@ -343,6 +343,7 @@ pub fn compute_volume_mesh(surface_json: &str) -> Result<String, JsError> {
 
     let out = serde_json::json!({
         "points": pts,
+        "tets": live_tets,
         "edges": edge_set.into_iter().collect::<Vec<_>>()
     });
 

--- a/web/src/components/sidebar/Sidebar.tsx
+++ b/web/src/components/sidebar/Sidebar.tsx
@@ -18,6 +18,7 @@ function GeometrySection() {
   const isMeshing = useModelStore(s => s.isMeshing)
   const nodes = useModelStore(s => s.nodes)
   const elements = useModelStore(s => s.elements)
+  const stepSurface = useModelStore(s => s.stepSurface)
 
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editing, setEditing] = useState<BoxGeometry | null>(null)
@@ -52,6 +53,24 @@ function GeometrySection() {
     const newGeom = store.geometries[store.geometries.length - 1]
     if (newGeom) runMesh(newGeom)
     setDialogOpen(false)
+  }
+
+  async function handleMeshVolume() {
+    if (!stepSurface) return
+    setMeshing(true)
+    try {
+      const { nodes: volNodes, elements: volElements } = await sendToWorker<{
+        nodes: Node[]
+        elements: Element[]
+        points: [number, number, number][]
+        edges: [number, number][]
+      }>('volume_mesh', { surface: stepSurface })
+      applyMeshResult(volNodes, volElements, 'STEP Volume Mesh')
+    } catch (err) {
+      alert(`Volume meshing failed: ${err}`)
+    } finally {
+      setMeshing(false)
+    }
   }
 
   return (
@@ -95,6 +114,17 @@ function GeometrySection() {
           </div>
         </div>
       ))}
+
+      {stepSurface && (
+        <button
+          className={styles.pickBtn}
+          disabled={isMeshing}
+          onClick={handleMeshVolume}
+          title="Volume-mesh the imported STEP geometry and load it into the FEM model"
+        >
+          {isMeshing ? 'Meshing…' : 'Mesh volume'}
+        </button>
+      )}
 
       {dialogOpen && (
         <GeometryDialog

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -54,9 +54,17 @@ self.onmessage = async (event: MessageEvent) => {
       const resultJson = compute_volume_mesh(JSON.stringify(payload.surface))
       const data = JSON.parse(resultJson) as {
         points: [number, number, number][]
+        tets: [number, number, number, number][]
         edges: [number, number][]
       }
-      self.postMessage({ id, ok: true, points: data.points, edges: data.edges })
+      const nodes = data.points.map(([x, y, z], i) => ({ id: i, x, y, z }))
+      const elements = data.tets.map((v, i) => ({
+        id: i,
+        type: 'CTETRA' as const,
+        nodeIds: v,
+        propertyId: 1,
+      }))
+      self.postMessage({ id, ok: true, points: data.points, edges: data.edges, nodes, elements })
 
     } else if (type === 'mesh') {
       const geom = payload as BoxGeometry


### PR DESCRIPTION
## Summary
Adds support for volume meshing of imported STEP geometry files. Users can now mesh a loaded STEP surface into a tetrahedral volume mesh and load it directly into the FEM model.

## Key Changes
- **Frontend (Sidebar.tsx):**
  - Added `stepSurface` state selector from model store
  - Implemented `handleMeshVolume()` async handler that sends the surface to the worker and applies the resulting tetrahedral mesh
  - Added "Mesh volume" button that appears when a STEP surface is loaded; button is disabled during meshing

- **Worker (solver.worker.ts):**
  - Extended `volume_mesh` message handler to parse tetrahedral elements from the Rust output
  - Transforms raw points and tetrahedra into `Node` and `Element` objects with proper CTETRA type and property IDs
  - Returns both nodes and elements to the frontend for model integration

- **Rust WASM (kofem-wasm/src/lib.rs):**
  - Modified `compute_volume_mesh()` to include `tets` (tetrahedral connectivity) in the JSON output alongside points and edges

## Implementation Details
- Volume meshing is performed asynchronously in the Web Worker to avoid blocking the UI
- The tetrahedral mesh uses CTETRA element type with property ID 1
- Error handling displays user-friendly alert on meshing failure
- Button state reflects meshing progress with "Meshing…" label during operation

https://claude.ai/code/session_01C25CQDyXPjBNEe8CGMYGWu