### PR TITLE
Fix CONICAL_SURFACE semi_angle unit conversion from degrees

### DIFF
--- a/crates/kofem-geom/src/geom/surface.rs
+++ b/crates/kofem-geom/src/geom/surface.rs
@@ -428,10 +428,10 @@ pub fn surface_from_step(id: u64, file: &StepFile) -> Result<Box<dyn Surface>, G
         }
 
         "CONICAL_SURFACE" => {
-            // CONICAL_SURFACE(label, axis2_placement_ref, radius, semi_angle)
+            // CONICAL_SURFACE(label, axis2_placement_ref, radius, semi_angle_deg)
             let ax_id = get_ref(e, 1)?;
             let radius = get_real(e, 2)?;
-            let semi_angle = get_real(e, 3)?;
+            let semi_angle = get_real(e, 3)?.to_radians();
             let axis = axis2_placement(file, ax_id)?;
             Ok(Box::new(ConicalSurface {
                 axis,

--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -308,7 +308,7 @@ fn try_tessellate_conical(
 
     let ax_id = get_ref(e, 1).ok()?;
     let radius = get_real(e, 2).ok()?;
-    let semi_angle = get_real(e, 3).ok()?;
+    let semi_angle = get_real(e, 3).ok()?.to_radians();
     let axis = axis2_placement(file, ax_id).ok()?;
     let y = axis.y();
 

--- a/crates/kofem-geom/tests/tess.rs
+++ b/crates/kofem-geom/tests/tess.rs
@@ -482,7 +482,7 @@ fn cylinder_barrel_has_nonzero_height() {
 // ── cone regression tests ─────────────────────────────────────────────────────
 
 /// Truncated cone: bottom circle radius=10 at z=0, top circle radius=20 at z=30.
-/// The CONICAL_SURFACE has semi_angle = atan(1/3) ≈ 0.32175 rad.
+/// The CONICAL_SURFACE has semi_angle = atan(1/3) ≈ 18.435° (STEP stores degrees).
 /// On the barrel, r(z) = 10 + z/3 (linear taper, tan(φ)=1/3).
 const STEP_CONE: &str = "
 ISO-10303-21;
@@ -537,7 +537,7 @@ DATA;
 #45=DIRECTION('',(0.,0.,1.));
 #46=DIRECTION('',(1.,0.,0.));
 #47=AXIS2_PLACEMENT_3D('',#44,#45,#46);
-#48=CONICAL_SURFACE('',#47,10.,0.32175);
+#48=CONICAL_SURFACE('',#47,10.,18.43495);
 #49=EDGE_LOOP('',(#40,#41,#42,#43));
 #50=FACE_OUTER_BOUND('',#49,.T.);
 #51=ADVANCED_FACE('',(#50),#48,.T.);


### PR DESCRIPTION
## Summary

The STEP file format stores conical surface semi-angles in **degrees**, but the code was treating them as radians. This fix adds explicit unit conversion to radians when parsing CONICAL_SURFACE entities.

## Changes

- **`crates/kofem-geom/src/geom/surface.rs`**: Added `.to_radians()` conversion when reading the semi_angle parameter from CONICAL_SURFACE (line 434)
- **`crates/kofem-geom/src/tess/mod.rs`**: Added `.to_radians()` conversion in the tessellation path for conical surfaces (line 311)
- **`crates/kofem-geom/tests/tess.rs`**: Updated test data and comments to reflect the correct unit:
  - Changed test STEP data from `0.32175` (radians) to `18.43495` (degrees)
  - Updated comment to clarify that STEP stores degrees, not radians

## Implementation Details

The semi-angle parameter in ISO 10303-21 (STEP) format is specified in degrees. The conversion is applied at parse time to ensure internal representation uses radians consistently with the rest of the geometry library. The test case validates a truncated cone with `atan(1/3) ≈ 18.435°`, which correctly converts to the expected radian value for geometric calculations.

https://claude.ai/code/session_01JY6QERGzVHhcswquSWaBqE