### PR TITLE
fix(ci): redirect Playwright outputDir away from test-results/

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests',
+  outputDir: './playwright-results',
   timeout: 30_000,
   use: {
     baseURL: 'http://localhost:4173',

--- a/web/scripts/generate-mesh-report.ts
+++ b/web/scripts/generate-mesh-report.ts
@@ -16,7 +16,7 @@ import fs from 'fs'
 import path from 'path'
 
 const JSON_IN = path.join('test-results', 'mesh-quality.json')
-const SCREENSHOTS_DIR = path.join('screenshots', 'report')
+const SCREENSHOTS_DIR = path.join('playwright-results', 'screenshots', 'report')
 const DEFAULT_CHANNEL = 'product-showcases'
 
 interface QualityResult {

--- a/web/tests/mesh-report.spec.ts
+++ b/web/tests/mesh-report.spec.ts
@@ -51,7 +51,7 @@ const NIST_GEOMETRIES: Geom[] = [
 const ALL_GEOMETRIES: Geom[] = [...GEOMETRIES, ...NIST_GEOMETRIES]
 
 const STEP_FILES_DIR = path.resolve('..', 'test_files')
-const OUT_DIR = path.join('screenshots', 'report')
+const OUT_DIR = path.join('playwright-results', 'screenshots', 'report')
 
 test.describe('Mesh capabilities report', () => {
   test.beforeAll(() => {


### PR DESCRIPTION
Playwright wipes its outputDir at the start of every run. The default
is test-results/, which is also where the Rust mesh_quality_report test
writes mesh-quality.json. Setting outputDir to playwright-results/ keeps
the two outputs from colliding so the Slack report step finds its JSON.

https://claude.ai/code/session_01DZJDxYhkQBJhKn7CvtHLcG