### PR TITLE
fix(tests): remove nist_stc_10 entry deleted in commit 3b52953

### DIFF
--- a/web/scripts/generate-mesh-report.ts
+++ b/web/scripts/generate-mesh-report.ts
@@ -228,7 +228,7 @@ async function run(): Promise<void> {
 
   // Upload screenshots from Playwright tests as thread replies
   if (fs.existsSync(SCREENSHOTS_DIR)) {
-    const files = fs.readdirSync(SCREENSHOTS_DIR).filter(f => f.endsWith('-mesh.png')).sort()
+    const files = fs.readdirSync(SCREENSHOTS_DIR).filter(f => f.endsWith('-geometry.png')).sort()
     const standardShots = files.filter(f => !f.startsWith('nist_')).slice(0, 3)
     const nistShots = files.filter(f => f.startsWith('nist_')).slice(0, 2)
     const screenshots = [...standardShots, ...nistShots]

--- a/web/tests/mesh-report.spec.ts
+++ b/web/tests/mesh-report.spec.ts
@@ -45,7 +45,6 @@ const NIST_GEOMETRIES: Geom[] = [
   { file: 'nist_stc_07_asme1_ap242-e3.stp',    label: 'NIST STC-07 (AP242 e3)',    subdir: 'NIST' },
   { file: 'nist_stc_08_asme1_ap242-e3.stp',    label: 'NIST STC-08 (AP242 e3)',    subdir: 'NIST' },
   { file: 'nist_stc_09_asme1_ap242-e3.stp',    label: 'NIST STC-09 (AP242 e3)',    subdir: 'NIST' },
-  { file: 'nist_stc_10_asme1_ap242-e2.stp',    label: 'NIST STC-10 (AP242 e2)',    subdir: 'NIST' },
 ]
 
 const ALL_GEOMETRIES: Geom[] = [...GEOMETRIES, ...NIST_GEOMETRIES]


### PR DESCRIPTION
nist_stc_10_asme1_ap242-e2.stp was removed from the repo in 3b52953 but
the NIST_GEOMETRIES list in mesh-report.spec.ts still referenced it.

When Playwright encounters a missing file, the loop calls test.skip(title)
with only a title string and no body function. At describe scope Playwright
interprets a truthy first argument as a conditional skip, which silently
marks the entire "Mesh capabilities report" suite as skipped. No tests run,
no screenshots are taken, so the Slack report has nothing to upload.