### PR TITLE
Improve mesh quality testing with area-weighted surface sampling

### DIFF
--- a/crates/kofem-geom/tests/quality.rs
+++ b/crates/kofem-geom/tests/quality.rs
@@ -1,7 +1,7 @@
 //! Mesh quality integration tests: tessellate each supported STEP geometry,
-//! compare against a gmsh reference STL using symmetric chamfer distance on
-//! triangle centroids, and write a JSON report consumed by
-//! `web/scripts/generate-mesh-report.ts`.
+//! compare against a reference STL using symmetric chamfer distance (area-weighted
+//! surface sampling + point-to-triangle distance), and write a JSON report consumed
+//! by `web/scripts/generate-mesh-report.ts`.
 //!
 //! `mesh_quality_report`      — 15 standard geometries (runs by default)
 //! `mesh_quality_report_nist` — 16 NIST geometries     (#[ignore]; run with
@@ -14,12 +14,14 @@ use std::time::Instant;
 use kofem_geom::step::{parse, BRep};
 use kofem_geom::tess::{tessellate, TessOptions};
 
-/// Number of centroids sampled per mesh for chamfer distance (O(N²)).
-const MAX_SAMPLE: usize = 5_000;
+/// Area-weighted surface samples drawn from each mesh for chamfer distance.
+const MAX_SAMPLE: usize = 2_000;
 
-/// Symmetric chamfer threshold (mm). Only catches catastrophic failures.
-/// Tighten per-geometry after baselines are established.
-const CHAMFER_THRESHOLD_MM: f64 = 50.0;
+/// Symmetric chamfer threshold (mm).
+/// With point-to-surface distance and area-weighted sampling, correct meshes
+/// (tessellated at ≤1 mm edge length against a 0.5 mm reference) should be
+/// well under this value.
+const CHAMFER_THRESHOLD_MM: f64 = 1.0;
 
 fn json_out() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../web/test-results/mesh-quality.json")
@@ -220,11 +222,9 @@ static NIST_GEOMETRIES: &[GeomSpec] = &[
 
 // ── STL parsing ───────────────────────────────────────────────────────────────
 
-/// Parse an ASCII STL file (the text-based format gmsh produces by default).
-fn parse_stl_centroids_ascii(text: &str) -> Result<Vec<[f32; 3]>, String> {
-    let mut centroids = Vec::new();
+fn parse_stl_triangles_ascii(text: &str) -> Result<Vec<[[f32; 3]; 3]>, String> {
+    let mut tris = Vec::new();
     let mut verts: Vec<[f32; 3]> = Vec::with_capacity(3);
-
     for line in text.lines() {
         let t = line.trim();
         if let Some(rest) = t.strip_prefix("vertex ") {
@@ -234,25 +234,19 @@ fn parse_stl_centroids_ascii(text: &str) -> Result<Vec<[f32; 3]>, String> {
             let z: f32 = nums.next().and_then(|s| s.parse().ok()).unwrap_or(0.0);
             verts.push([x, y, z]);
             if verts.len() == 3 {
-                centroids.push([
-                    (verts[0][0] + verts[1][0] + verts[2][0]) / 3.0,
-                    (verts[0][1] + verts[1][1] + verts[2][1]) / 3.0,
-                    (verts[0][2] + verts[1][2] + verts[2][2]) / 3.0,
-                ]);
+                tris.push([verts[0], verts[1], verts[2]]);
                 verts.clear();
             }
         }
     }
-
-    if centroids.is_empty() {
+    if tris.is_empty() {
         Err("no triangles found in ASCII STL".to_string())
     } else {
-        Ok(centroids)
+        Ok(tris)
     }
 }
 
-/// Parse a binary STL file.
-fn parse_stl_centroids_binary(data: &[u8]) -> Result<Vec<[f32; 3]>, String> {
+fn parse_stl_triangles_binary(data: &[u8]) -> Result<Vec<[[f32; 3]; 3]>, String> {
     if data.len() < 84 {
         return Err(format!("binary STL too short: {} bytes", data.len()));
     }
@@ -269,28 +263,23 @@ fn parse_stl_centroids_binary(data: &[u8]) -> Result<Vec<[f32; 3]>, String> {
     if tri_count == 0 {
         return Err("binary STL has zero triangles".to_string());
     }
-    let mut centroids = Vec::with_capacity(tri_count);
+    let mut tris = Vec::with_capacity(tri_count);
     for i in 0..tri_count {
         let base = 84 + i * 50 + 12; // skip 80B header + 4B count + 12B normal
-        let mut cx = 0.0f32;
-        let mut cy = 0.0f32;
-        let mut cz = 0.0f32;
+        let mut tri = [[0.0f32; 3]; 3];
         for v in 0..3 {
             let off = base + v * 12;
-            cx += f32::from_le_bytes(data[off..off + 4].try_into().unwrap());
-            cy += f32::from_le_bytes(data[off + 4..off + 8].try_into().unwrap());
-            cz += f32::from_le_bytes(data[off + 8..off + 12].try_into().unwrap());
+            tri[v][0] = f32::from_le_bytes(data[off..off + 4].try_into().unwrap());
+            tri[v][1] = f32::from_le_bytes(data[off + 4..off + 8].try_into().unwrap());
+            tri[v][2] = f32::from_le_bytes(data[off + 8..off + 12].try_into().unwrap());
         }
-        centroids.push([cx / 3.0, cy / 3.0, cz / 3.0]);
+        tris.push(tri);
     }
-    Ok(centroids)
+    Ok(tris)
 }
 
 /// Auto-detect ASCII vs binary and parse accordingly.
-fn parse_stl_centroids(data: &[u8]) -> Result<Vec<[f32; 3]>, String> {
-    // Binary STL: size is exactly 84 + n*50 for some n > 0.
-    // ASCII STL: starts with "solid" and contains "vertex" keywords.
-    // Heuristic: if the file starts with "solid" and is not the right size for binary, use ASCII.
+fn parse_stl_triangles(data: &[u8]) -> Result<Vec<[[f32; 3]; 3]>, String> {
     let looks_ascii = data.starts_with(b"solid");
     let binary_tri_count = if data.len() >= 84 {
         u32::from_le_bytes(data[80..84].try_into().unwrap()) as usize
@@ -298,20 +287,19 @@ fn parse_stl_centroids(data: &[u8]) -> Result<Vec<[f32; 3]>, String> {
         0
     };
     let correct_binary_size = data.len() == 84 + binary_tri_count * 50;
-
     if looks_ascii && !correct_binary_size {
         match std::str::from_utf8(data) {
-            Ok(text) => parse_stl_centroids_ascii(text),
+            Ok(text) => parse_stl_triangles_ascii(text),
             Err(e) => Err(format!("STL not valid UTF-8: {e}")),
         }
     } else {
-        parse_stl_centroids_binary(data)
+        parse_stl_triangles_binary(data)
     }
 }
 
 // ── chamfer distance ──────────────────────────────────────────────────────────
 
-fn surface_mesh_centroids(mesh: &kofem_geom::tess::SurfaceMesh) -> Vec<[f32; 3]> {
+fn extract_triangles(mesh: &kofem_geom::tess::SurfaceMesh) -> Vec<[[f32; 3]; 3]> {
     mesh.triangles
         .iter()
         .map(|&[a, b, c]| {
@@ -319,38 +307,165 @@ fn surface_mesh_centroids(mesh: &kofem_geom::tess::SurfaceMesh) -> Vec<[f32; 3]>
             let pb = mesh.points[b];
             let pc = mesh.points[c];
             [
-                ((pa[0] + pb[0] + pc[0]) / 3.0) as f32,
-                ((pa[1] + pb[1] + pc[1]) / 3.0) as f32,
-                ((pa[2] + pb[2] + pc[2]) / 3.0) as f32,
+                [pa[0] as f32, pa[1] as f32, pa[2] as f32],
+                [pb[0] as f32, pb[1] as f32, pb[2] as f32],
+                [pc[0] as f32, pc[1] as f32, pc[2] as f32],
             ]
         })
         .collect()
 }
 
-/// Evenly-spaced subsample (reproducible — no RNG dependency).
-fn subsample(v: &[[f32; 3]], max: usize) -> Vec<[f32; 3]> {
-    if v.len() <= max {
-        return v.to_vec();
-    }
-    let step = v.len() / max;
-    (0..max).map(|i| v[i * step]).collect()
+#[inline]
+fn sub3(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
 }
 
-/// One-sided: mean and max nearest-neighbour distance from `from` into `to`.
-fn one_sided(from: &[[f32; 3]], to: &[[f32; 3]]) -> (f64, f64) {
+#[inline]
+fn dot3(a: [f32; 3], b: [f32; 3]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+#[inline]
+fn len2(v: [f32; 3]) -> f32 {
+    dot3(v, v)
+}
+
+/// Squared distance from `p` to the closest point on triangle `t`.
+/// Christer Ericson, "Real-Time Collision Detection" §5.1.5.
+fn point_to_tri_dist2(p: [f32; 3], t: &[[f32; 3]; 3]) -> f32 {
+    let (a, b, c) = (t[0], t[1], t[2]);
+    let ab = sub3(b, a);
+    let ac = sub3(c, a);
+    let ap = sub3(p, a);
+    let d1 = dot3(ab, ap);
+    let d2 = dot3(ac, ap);
+    if d1 <= 0.0 && d2 <= 0.0 {
+        return len2(ap); // vertex A
+    }
+    let bp = sub3(p, b);
+    let d3 = dot3(ab, bp);
+    let d4 = dot3(ac, bp);
+    if d3 >= 0.0 && d4 <= d3 {
+        return len2(bp); // vertex B
+    }
+    let vc = d1 * d4 - d3 * d2;
+    if vc <= 0.0 && d1 >= 0.0 && d3 <= 0.0 {
+        let v = d1 / (d1 - d3);
+        return len2(sub3(ap, [v * ab[0], v * ab[1], v * ab[2]])); // edge AB
+    }
+    let cp = sub3(p, c);
+    let d5 = dot3(ab, cp);
+    let d6 = dot3(ac, cp);
+    if d6 >= 0.0 && d5 <= d6 {
+        return len2(cp); // vertex C
+    }
+    let vb = d5 * d2 - d1 * d6;
+    if vb <= 0.0 && d2 >= 0.0 && d6 <= 0.0 {
+        let w = d2 / (d2 - d6);
+        return len2(sub3(ap, [w * ac[0], w * ac[1], w * ac[2]])); // edge AC
+    }
+    let va = d3 * d6 - d5 * d4;
+    if va <= 0.0 && (d4 - d3) >= 0.0 && (d5 - d6) >= 0.0 {
+        let bc = sub3(c, b);
+        let w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+        return len2(sub3(bp, [w * bc[0], w * bc[1], w * bc[2]])); // edge BC
+    }
+    let denom = 1.0 / (va + vb + vc);
+    let v = vb * denom;
+    let w = vc * denom;
+    let proj = [
+        a[0] + v * ab[0] + w * ac[0],
+        a[1] + v * ab[1] + w * ac[1],
+        a[2] + v * ab[2] + w * ac[2],
+    ];
+    len2(sub3(p, proj))
+}
+
+/// Van der Corput low-discrepancy sequence in the given base.
+fn van_der_corput(mut n: usize, base: usize) -> f32 {
+    let mut r = 0.0f32;
+    let mut f = 1.0f32 / base as f32;
+    while n > 0 {
+        r += f * (n % base) as f32;
+        n /= base;
+        f /= base as f32;
+    }
+    r
+}
+
+/// Sample `n` points uniformly over a triangle mesh, weighted by triangle area.
+/// Deterministic — uses a 3D Halton sequence (bases 2, 3, 5).
+fn sample_surface_uniform(tris: &[[[f32; 3]; 3]], n: usize) -> Vec<[f32; 3]> {
+    if tris.is_empty() || n == 0 {
+        return Vec::new();
+    }
+    let areas: Vec<f32> = tris
+        .iter()
+        .map(|t| {
+            let ab = sub3(t[1], t[0]);
+            let ac = sub3(t[2], t[0]);
+            let cx = ab[1] * ac[2] - ab[2] * ac[1];
+            let cy = ab[2] * ac[0] - ab[0] * ac[2];
+            let cz = ab[0] * ac[1] - ab[1] * ac[0];
+            (cx * cx + cy * cy + cz * cz).sqrt() * 0.5
+        })
+        .collect();
+    let total: f32 = areas.iter().sum();
+    if total == 0.0 {
+        return tris
+            .iter()
+            .take(n)
+            .map(|t| {
+                [
+                    (t[0][0] + t[1][0] + t[2][0]) / 3.0,
+                    (t[0][1] + t[1][1] + t[2][1]) / 3.0,
+                    (t[0][2] + t[1][2] + t[2][2]) / 3.0,
+                ]
+            })
+            .collect();
+    }
+    let mut prefix = Vec::with_capacity(tris.len() + 1);
+    prefix.push(0.0f32);
+    for &a in &areas {
+        prefix.push(prefix.last().unwrap() + a);
+    }
+    (0..n)
+        .map(|i| {
+            // Triangle selection: Halton base-2 stratifies over area CDF.
+            let t_val = van_der_corput(i + 1, 2) * total;
+            let tri_idx = prefix
+                .partition_point(|&p| p < t_val)
+                .saturating_sub(1)
+                .min(tris.len() - 1);
+            let tri = &tris[tri_idx];
+            // Barycentric coords: independent Halton dimensions (bases 3 and 5).
+            let mut u = van_der_corput(i + 1, 3);
+            let mut v = van_der_corput(i + 1, 5);
+            if u + v > 1.0 {
+                u = 1.0 - u;
+                v = 1.0 - v;
+            }
+            let w = 1.0 - u - v;
+            [
+                w * tri[0][0] + u * tri[1][0] + v * tri[2][0],
+                w * tri[0][1] + u * tri[1][1] + v * tri[2][1],
+                w * tri[0][2] + u * tri[1][2] + v * tri[2][2],
+            ]
+        })
+        .collect()
+}
+
+/// One-sided: mean and max point-to-surface distance from `from` sample points
+/// to the triangle mesh `to`.
+fn one_sided(from: &[[f32; 3]], to: &[[[f32; 3]; 3]]) -> (f64, f64) {
     let mut sum = 0.0f64;
     let mut max_d = 0.0f64;
-    for p in from {
+    for &p in from {
         let min_d2 = to
             .iter()
-            .map(|q| {
-                let dx = (p[0] - q[0]) as f64;
-                let dy = (p[1] - q[1]) as f64;
-                let dz = (p[2] - q[2]) as f64;
-                dx * dx + dy * dy + dz * dz
-            })
-            .fold(f64::INFINITY, f64::min);
-        let d = min_d2.sqrt();
+            .map(|tri| point_to_tri_dist2(p, tri))
+            .fold(f32::MAX, f32::min);
+        let d = (min_d2 as f64).sqrt();
         sum += d;
         if d > max_d {
             max_d = d;
@@ -360,11 +475,14 @@ fn one_sided(from: &[[f32; 3]], to: &[[f32; 3]]) -> (f64, f64) {
 }
 
 /// Symmetric chamfer distance → (mean_mm, max_mm).
-fn chamfer_distance(kofem: &[[f32; 3]], reference: &[[f32; 3]]) -> (f64, f64) {
-    let a = subsample(kofem, MAX_SAMPLE);
-    let b = subsample(reference, MAX_SAMPLE);
-    let (mean_ab, max_ab) = one_sided(&a, &b);
-    let (mean_ba, max_ba) = one_sided(&b, &a);
+///
+/// Draws `MAX_SAMPLE` area-weighted surface points from each mesh, then
+/// measures point-to-surface (not point-to-centroid) distance in both directions.
+fn chamfer_distance(kofem: &[[[f32; 3]; 3]], reference: &[[[f32; 3]; 3]]) -> (f64, f64) {
+    let a = sample_surface_uniform(kofem, MAX_SAMPLE);
+    let b = sample_surface_uniform(reference, MAX_SAMPLE);
+    let (mean_ab, max_ab) = one_sided(&a, reference);
+    let (mean_ba, max_ba) = one_sided(&b, kofem);
     ((mean_ab + mean_ba) / 2.0, f64::max(max_ab, max_ba))
 }
 
@@ -444,7 +562,7 @@ fn run_geometry(spec: &GeomSpec, idx: usize, total: usize) -> (QualityResult, bo
     };
     let tess_ms = ms() as u64;
     let kofem_tris = mesh.triangles.len();
-    let kofem_centroids = surface_mesh_centroids(&mesh);
+    let kofem_tris_data = extract_triangles(&mesh);
     eprintln!("{tag}  tessellated → {kofem_tris} tris ({tess_ms}ms); reading ref STL...");
 
     let ref_data = match fs::read(spec.ref_stl) {
@@ -453,17 +571,17 @@ fn run_geometry(spec: &GeomSpec, idx: usize, total: usize) -> (QualityResult, bo
     };
     eprintln!("{tag}  ref STL {} bytes; parsing...", ref_data.len());
 
-    let ref_centroids = match parse_stl_centroids(&ref_data) {
-        Ok(c) => c,
+    let ref_tris_data = match parse_stl_triangles(&ref_data) {
+        Ok(t) => t,
         Err(e) => fail!(format!("parse ref STL: {e}")),
     };
-    let ref_tris = ref_centroids.len();
+    let ref_tris = ref_tris_data.len();
     eprintln!(
-        "{tag}  ref={ref_tris} tris; computing chamfer (sample≤{MAX_SAMPLE}, {}ms)...",
+        "{tag}  ref={ref_tris} tris; computing chamfer (n_samples={MAX_SAMPLE}, {}ms)...",
         ms()
     );
 
-    let (mean_mm, max_mm) = chamfer_distance(&kofem_centroids, &ref_centroids);
+    let (mean_mm, max_mm) = chamfer_distance(&kofem_tris_data, &ref_tris_data);
     let total_ms = ms() as u64;
     let pass = mean_mm < CHAMFER_THRESHOLD_MM;
 

--- a/crates/kofem-geom/tests/quality.rs
+++ b/crates/kofem-geom/tests/quality.rs
@@ -267,11 +267,11 @@ fn parse_stl_triangles_binary(data: &[u8]) -> Result<Vec<[[f32; 3]; 3]>, String>
     for i in 0..tri_count {
         let base = 84 + i * 50 + 12; // skip 80B header + 4B count + 12B normal
         let mut tri = [[0.0f32; 3]; 3];
-        for v in 0..3 {
+        for (v, vertex) in tri.iter_mut().enumerate() {
             let off = base + v * 12;
-            tri[v][0] = f32::from_le_bytes(data[off..off + 4].try_into().unwrap());
-            tri[v][1] = f32::from_le_bytes(data[off + 4..off + 8].try_into().unwrap());
-            tri[v][2] = f32::from_le_bytes(data[off + 8..off + 12].try_into().unwrap());
+            vertex[0] = f32::from_le_bytes(data[off..off + 4].try_into().unwrap());
+            vertex[1] = f32::from_le_bytes(data[off + 4..off + 8].try_into().unwrap());
+            vertex[2] = f32::from_le_bytes(data[off + 8..off + 12].try_into().unwrap());
         }
         tris.push(tri);
     }


### PR DESCRIPTION
## Summary

Replaces centroid-based chamfer distance with a more rigorous point-to-surface distance metric using area-weighted surface sampling. This enables tighter quality thresholds and more accurate mesh validation against reference STLs.

## Key Changes

- **Surface sampling strategy**: Replaced simple centroid extraction with deterministic area-weighted sampling using a 3D Halton sequence (bases 2, 3, 5). Samples are drawn uniformly over triangle surfaces, not just at centroids.

- **Distance metric**: Implemented point-to-triangle distance calculation (Ericson's algorithm) instead of point-to-point nearest-neighbor. This measures actual surface-to-surface deviation rather than discrete point distances.

- **STL parsing**: Refactored `parse_stl_centroids_*` → `parse_stl_triangles_*` to preserve full triangle geometry (all three vertices) rather than computing and discarding centroids.

- **Quality threshold tightening**: Reduced `CHAMFER_THRESHOLD_MM` from 50.0 to 1.0 mm. With point-to-surface distance and area-weighted sampling, correctly tessellated meshes (≤1 mm edge length against 0.5 mm reference) should comfortably pass this stricter threshold.

- **Sample count adjustment**: Reduced `MAX_SAMPLE` from 5,000 to 2,000 points per mesh (still deterministic, no RNG dependency).

## Implementation Details

- **Halton sequence**: Van der Corput low-discrepancy sequence provides deterministic, reproducible sampling without random number generation.
- **Triangle area weighting**: Prefix sum over triangle areas enables stratified selection; barycentric coordinates ensure uniform distribution within each triangle.
- **Symmetric chamfer**: Measures both directions (kofem→reference and reference→kofem) to catch one-sided errors.

The new approach is more physically meaningful: it validates that the tessellated surface actually matches the reference surface geometry, not just that sampled points happen to be nearby.

https://claude.ai/code/session_01Dm4LK3TMhSVoLpzRxv2ZbL