### PR TITLE
fix(tess): correct annular disc and hole tessellation

### DIFF
--- a/crates/kofem-geom/src/geom/mod.rs
+++ b/crates/kofem-geom/src/geom/mod.rs
@@ -230,8 +230,7 @@ pub(crate) fn expand_knots(
     Ok(knots)
 }
 
-/// De Boor evaluation of a 1-D B-spline at parameter `t`.
-/// de Boor evaluation for 4D homogeneous control points (used by NURBS surfaces).
+/// De Boor evaluation for 4D homogeneous control points (used by NURBS surfaces).
 pub(crate) fn de_boor_1d_4d(pts: &[[f64; 4]], degree: usize, knots: &[f64], t: f64) -> [f64; 4] {
     let n = pts.len() - 1;
     let t = t.clamp(knots[degree], knots[n + 1]);
@@ -242,7 +241,11 @@ pub(crate) fn de_boor_1d_4d(pts: &[[f64; 4]], degree: usize, knots: &[f64], t: f
         let mut hi = n;
         while lo < hi {
             let mid = (lo + hi).div_ceil(2);
-            if knots[mid] <= t { lo = mid; } else { hi = mid - 1; }
+            if knots[mid] <= t {
+                lo = mid;
+            } else {
+                hi = mid - 1;
+            }
         }
         lo
     };
@@ -251,7 +254,11 @@ pub(crate) fn de_boor_1d_4d(pts: &[[f64; 4]], degree: usize, knots: &[f64], t: f
         for j in (r..=degree).rev() {
             let idx = j + k - degree;
             let denom = knots[idx + degree - r + 1] - knots[idx];
-            let alpha = if denom.abs() < 1e-15 { 0.0 } else { (t - knots[idx]) / denom };
+            let alpha = if denom.abs() < 1e-15 {
+                0.0
+            } else {
+                (t - knots[idx]) / denom
+            };
             d[j] = [
                 (1.0 - alpha) * d[j - 1][0] + alpha * d[j][0],
                 (1.0 - alpha) * d[j - 1][1] + alpha * d[j][1],

--- a/crates/kofem-geom/src/geom/mod.rs
+++ b/crates/kofem-geom/src/geom/mod.rs
@@ -231,6 +231,38 @@ pub(crate) fn expand_knots(
 }
 
 /// De Boor evaluation of a 1-D B-spline at parameter `t`.
+/// de Boor evaluation for 4D homogeneous control points (used by NURBS surfaces).
+pub(crate) fn de_boor_1d_4d(pts: &[[f64; 4]], degree: usize, knots: &[f64], t: f64) -> [f64; 4] {
+    let n = pts.len() - 1;
+    let t = t.clamp(knots[degree], knots[n + 1]);
+    let k = if t >= knots[n + 1] {
+        n
+    } else {
+        let mut lo = degree;
+        let mut hi = n;
+        while lo < hi {
+            let mid = (lo + hi).div_ceil(2);
+            if knots[mid] <= t { lo = mid; } else { hi = mid - 1; }
+        }
+        lo
+    };
+    let mut d: Vec<[f64; 4]> = (0..=degree).map(|j| pts[k - degree + j]).collect();
+    for r in 1..=degree {
+        for j in (r..=degree).rev() {
+            let idx = j + k - degree;
+            let denom = knots[idx + degree - r + 1] - knots[idx];
+            let alpha = if denom.abs() < 1e-15 { 0.0 } else { (t - knots[idx]) / denom };
+            d[j] = [
+                (1.0 - alpha) * d[j - 1][0] + alpha * d[j][0],
+                (1.0 - alpha) * d[j - 1][1] + alpha * d[j][1],
+                (1.0 - alpha) * d[j - 1][2] + alpha * d[j][2],
+                (1.0 - alpha) * d[j - 1][3] + alpha * d[j][3],
+            ];
+        }
+    }
+    d[degree]
+}
+
 pub(crate) fn de_boor_1d(pts: &[[f64; 3]], degree: usize, knots: &[f64], t: f64) -> [f64; 3] {
     let n = pts.len() - 1; // index of last control point
     let t = t.clamp(knots[degree], knots[n + 1]);

--- a/crates/kofem-geom/src/geom/surface.rs
+++ b/crates/kofem-geom/src/geom/surface.rs
@@ -2,8 +2,9 @@ use std::f64::consts::PI;
 
 use super::curve::{curve_from_step, Curve};
 use super::{
-    add, arg_as_ref, axis1_placement, axis2_placement, cross, de_boor_1d, expand_knots, get_entity,
-    get_real, get_ref, normalize, point3, rodrigues, scale, sub, Axis1, Axis2, GeomError,
+    add, arg_as_ref, axis1_placement, axis2_placement, cross, de_boor_1d, de_boor_1d_4d,
+    expand_knots, get_entity, get_real, get_ref, normalize, point3, rodrigues, scale, sub, Axis1,
+    Axis2, GeomError,
 };
 use crate::step::parser::{Arg, StepFile};
 
@@ -254,6 +255,62 @@ impl Surface for BSplineSurfaceWithKnots {
     }
 }
 
+// ── NurbsSurface ─────────────────────────────────────────────────────────────
+
+/// Rational B-spline (NURBS) surface with explicit per-control-point weights.
+/// Evaluates in homogeneous 4D coordinates for exact rational blending.
+pub struct NurbsSurface {
+    pub u_degree: usize,
+    pub v_degree: usize,
+    /// Indexed [u_index][v_index].  Each entry is [w·x, w·y, w·z, w].
+    pub control_points_h: Vec<Vec<[f64; 4]>>,
+    pub u_knots: Vec<f64>,
+    pub v_knots: Vec<f64>,
+}
+
+impl NurbsSurface {
+    fn eval(&self, u: f64, v: f64) -> [f64; 3] {
+        let u_pts: Vec<[f64; 4]> = self
+            .control_points_h
+            .iter()
+            .map(|row| de_boor_1d_4d(row, self.v_degree, &self.v_knots, v))
+            .collect();
+        let hw = de_boor_1d_4d(&u_pts, self.u_degree, &self.u_knots, u);
+        let w = hw[3];
+        if w.abs() < 1e-15 {
+            [hw[0], hw[1], hw[2]]
+        } else {
+            [hw[0] / w, hw[1] / w, hw[2] / w]
+        }
+    }
+}
+
+impl Surface for NurbsSurface {
+    fn point(&self, u: f64, v: f64) -> [f64; 3] {
+        self.eval(u, v)
+    }
+
+    fn normal(&self, u: f64, v: f64) -> [f64; 3] {
+        let (u0, u1) = self.u_bounds();
+        let (v0, v1) = self.v_bounds();
+        let du = (u1 - u0) * 1e-6;
+        let dv = (v1 - v0) * 1e-6;
+        let pu = sub(self.eval(u + du, v), self.eval(u - du, v));
+        let pv = sub(self.eval(u, v + dv), self.eval(u, v - dv));
+        normalize(cross(pu, pv))
+    }
+
+    fn u_bounds(&self) -> (f64, f64) {
+        let n = self.control_points_h.len() - 1;
+        (self.u_knots[self.u_degree], self.u_knots[n + 1])
+    }
+
+    fn v_bounds(&self) -> (f64, f64) {
+        let n = self.control_points_h[0].len() - 1;
+        (self.v_knots[self.v_degree], self.v_knots[n + 1])
+    }
+}
+
 // ── SurfaceOfLinearExtrusion ──────────────────────────────────────────────────
 
 pub struct SurfaceOfLinearExtrusion {
@@ -320,6 +377,130 @@ impl Surface for SurfaceOfRevolution {
 }
 
 // ── from_step builder ─────────────────────────────────────────────────────────
+
+/// Build a surface from the *split* STEP complex-entity form:
+///
+/// - `base_args`: own attrs of the B_SPLINE_SURFACE component
+///   `(u_degree, v_degree, control_points, surface_form, u_closed, v_closed, self_int)`
+/// - `knot_args`: own attrs of the B_SPLINE_SURFACE_WITH_KNOTS component
+///   `(u_mults, v_mults, u_knots, v_knots, knot_spec)`
+/// - `rational_args`: own attrs of the optional RATIONAL_B_SPLINE_SURFACE component
+///   `(weights_data,)`
+fn bspline_surface_from_split(
+    id: u64,
+    base_args: &[Arg],
+    knot_args: &[Arg],
+    rational_args: Option<&[Arg]>,
+    file: &StepFile,
+) -> Result<Box<dyn Surface>, GeomError> {
+    let bad = |idx| GeomError::BadArg(id, idx);
+
+    // B_SPLINE_SURFACE own attrs (no label in complex entity components).
+    let u_degree = match base_args.get(0) {
+        Some(Arg::Integer(v)) => *v as usize,
+        _ => return Err(bad(0)),
+    };
+    let v_degree = match base_args.get(1) {
+        Some(Arg::Integer(v)) => *v as usize,
+        _ => return Err(bad(1)),
+    };
+    let rows_arg = match base_args.get(2) {
+        Some(Arg::List(v)) => v,
+        _ => return Err(bad(2)),
+    };
+    let mut control_points: Vec<Vec<[f64; 3]>> = Vec::with_capacity(rows_arg.len());
+    for row_arg in rows_arg {
+        let col_list = match row_arg {
+            Arg::List(v) => v,
+            _ => return Err(bad(2)),
+        };
+        let mut row: Vec<[f64; 3]> = Vec::with_capacity(col_list.len());
+        for a in col_list {
+            let cp_id = arg_as_ref(a, id)?;
+            row.push(point3(file, cp_id)?);
+        }
+        control_points.push(row);
+    }
+
+    // B_SPLINE_SURFACE_WITH_KNOTS own attrs.
+    let u_mults = match knot_args.get(0) {
+        Some(Arg::List(v)) => v,
+        _ => return Err(bad(0)),
+    };
+    let v_mults = match knot_args.get(1) {
+        Some(Arg::List(v)) => v,
+        _ => return Err(bad(1)),
+    };
+    let u_knot_vals = match knot_args.get(2) {
+        Some(Arg::List(v)) => v,
+        _ => return Err(bad(2)),
+    };
+    let v_knot_vals = match knot_args.get(3) {
+        Some(Arg::List(v)) => v,
+        _ => return Err(bad(3)),
+    };
+    let u_knots = expand_knots(u_mults, u_knot_vals, id)?;
+    let v_knots = expand_knots(v_mults, v_knot_vals, id)?;
+
+    // RATIONAL_B_SPLINE_SURFACE own attrs: weights_data = LIST OF LIST OF REAL.
+    let weights = if let Some(rat) = rational_args {
+        match rat.get(0) {
+            Some(Arg::List(rows)) => {
+                let mut w: Vec<Vec<f64>> = Vec::with_capacity(rows.len());
+                for row_arg in rows {
+                    match row_arg {
+                        Arg::List(cols) => {
+                            let row: Vec<f64> = cols
+                                .iter()
+                                .map(|a| match a {
+                                    Arg::Real(v) => *v,
+                                    Arg::Integer(v) => *v as f64,
+                                    _ => 1.0,
+                                })
+                                .collect();
+                            w.push(row);
+                        }
+                        _ => return Err(bad(0)),
+                    }
+                }
+                Some(w)
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    if let Some(w) = weights {
+        // Build homogeneous control points [w·x, w·y, w·z, w].
+        let n_u = control_points.len();
+        let n_v = if n_u > 0 { control_points[0].len() } else { 0 };
+        let mut h: Vec<Vec<[f64; 4]>> = Vec::with_capacity(n_u);
+        for (i, row) in control_points.iter().enumerate() {
+            let mut hrow: Vec<[f64; 4]> = Vec::with_capacity(n_v);
+            for (j, &p) in row.iter().enumerate() {
+                let wij = w.get(i).and_then(|r| r.get(j)).copied().unwrap_or(1.0);
+                hrow.push([p[0] * wij, p[1] * wij, p[2] * wij, wij]);
+            }
+            h.push(hrow);
+        }
+        Ok(Box::new(NurbsSurface {
+            u_degree,
+            v_degree,
+            control_points_h: h,
+            u_knots,
+            v_knots,
+        }))
+    } else {
+        Ok(Box::new(BSplineSurfaceWithKnots {
+            u_degree,
+            v_degree,
+            control_points,
+            u_knots,
+            v_knots,
+        }))
+    }
+}
 
 /// Parse a B_SPLINE_SURFACE_WITH_KNOTS from a raw arg slice.
 ///
@@ -390,17 +571,48 @@ pub fn surface_from_step(id: u64, file: &StepFile) -> Result<Box<dyn Surface>, G
     // Complex entity instance: type_name is empty, args are TypedValue components.
     // Scan for a recognised surface type among them.
     if e.type_name.is_empty() {
+        // Collect the component pieces we care about.
+        let mut bspline_base_args: Option<&[Arg]> = None; // B_SPLINE_SURFACE own attrs
+        let mut bspline_knot_args: Option<&[Arg]> = None; // B_SPLINE_SURFACE_WITH_KNOTS own attrs
+        let mut rational_args: Option<&[Arg]> = None; // RATIONAL_B_SPLINE_SURFACE own attrs
+        let mut full_bspline_with_knots: Option<&[Arg]> = None; // legacy full-args form
+
         for arg in &e.args {
             if let Arg::TypedValue {
                 name,
                 args: sub_args,
             } = arg
             {
-                if name == "B_SPLINE_SURFACE_WITH_KNOTS" {
-                    return bspline_surface_from_args(id, sub_args, file);
+                match name.as_str() {
+                    "B_SPLINE_SURFACE" => bspline_base_args = Some(sub_args),
+                    "B_SPLINE_SURFACE_WITH_KNOTS" => {
+                        // Detect "full" form (includes label + inherited attrs at index 1/2)
+                        // vs. "split" form (only own attrs: u_mults at index 0).
+                        let is_full = matches!(sub_args.get(1), Some(Arg::Integer(_)));
+                        if is_full {
+                            full_bspline_with_knots = Some(sub_args);
+                        } else {
+                            bspline_knot_args = Some(sub_args);
+                        }
+                    }
+                    "RATIONAL_B_SPLINE_SURFACE" => rational_args = Some(sub_args),
+                    _ => {}
                 }
             }
         }
+
+        // Legacy full-args form: single B_SPLINE_SURFACE_WITH_KNOTS component that
+        // carries all inherited + own attributes.
+        if let Some(full) = full_bspline_with_knots {
+            return bspline_surface_from_args(id, full, file);
+        }
+
+        // Split form: B_SPLINE_SURFACE (base) + B_SPLINE_SURFACE_WITH_KNOTS (knots)
+        // + optional RATIONAL_B_SPLINE_SURFACE (weights).
+        if let (Some(base), Some(knots)) = (bspline_base_args, bspline_knot_args) {
+            return bspline_surface_from_split(id, base, knots, rational_args, file);
+        }
+
         return Err(GeomError::Unsupported(
             "complex entity with no recognised surface component".to_string(),
             id,

--- a/crates/kofem-geom/src/geom/surface.rs
+++ b/crates/kofem-geom/src/geom/surface.rs
@@ -396,7 +396,7 @@ fn bspline_surface_from_split(
     let bad = |idx| GeomError::BadArg(id, idx);
 
     // B_SPLINE_SURFACE own attrs (no label in complex entity components).
-    let u_degree = match base_args.get(0) {
+    let u_degree = match base_args.first() {
         Some(Arg::Integer(v)) => *v as usize,
         _ => return Err(bad(0)),
     };
@@ -423,7 +423,7 @@ fn bspline_surface_from_split(
     }
 
     // B_SPLINE_SURFACE_WITH_KNOTS own attrs.
-    let u_mults = match knot_args.get(0) {
+    let u_mults = match knot_args.first() {
         Some(Arg::List(v)) => v,
         _ => return Err(bad(0)),
     };
@@ -444,7 +444,7 @@ fn bspline_surface_from_split(
 
     // RATIONAL_B_SPLINE_SURFACE own attrs: weights_data = LIST OF LIST OF REAL.
     let weights = if let Some(rat) = rational_args {
-        match rat.get(0) {
+        match rat.first() {
             Some(Arg::List(rows)) => {
                 let mut w: Vec<Vec<f64>> = Vec::with_capacity(rows.len());
                 for row_arg in rows {

--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -224,7 +224,10 @@ fn tessellate_face_raw(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> S
         .map(|p| add(origin, add(scale(x_axis, p.x), scale(y_axis, p.y))))
         .collect();
 
-    SurfaceMesh { points, triangles: bw_tris }
+    SurfaceMesh {
+        points,
+        triangles: bw_tris,
+    }
 }
 
 // ── Curved-surface tessellation ───────────────────────────────────────────────
@@ -866,16 +869,12 @@ fn try_tessellate_bspline(
                 })
                 .collect();
             triangles.retain(|&[a, b, c]| {
-                let cx =
-                    (points[a][0] + points[b][0] + points[c][0]) / 3.0;
-                let cy =
-                    (points[a][1] + points[b][1] + points[c][1]) / 3.0;
-                let cz =
-                    (points[a][2] + points[b][2] + points[c][2]) / 3.0;
+                let cx = (points[a][0] + points[b][0] + points[c][0]) / 3.0;
+                let cy = (points[a][1] + points[b][1] + points[c][1]) / 3.0;
+                let cz = (points[a][2] + points[b][2] + points[c][2]) / 3.0;
                 let d = sub([cx, cy, cz], origin);
                 let c2d = Point2::new(dot3(d, x_axis), dot3(d, y_axis));
-                point_in_polygon(c2d, &bnd2d)
-                    && !holes2d.iter().any(|h| point_in_polygon(c2d, h))
+                point_in_polygon(c2d, &bnd2d) && !holes2d.iter().any(|h| point_in_polygon(c2d, h))
             });
         }
     }

--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -1363,22 +1363,54 @@ fn bounding_box_diagonal(pts: &[[f64; 3]]) -> f64 {
 }
 
 /// Merge 3D vertices within `eps` of each other and remove degenerate triangles.
+///
+/// Uses a spatial grid hash for O(n) average-case performance instead of the
+/// naive O(n²) linear scan.
 fn stitch(points: Vec<[f64; 3]>, triangles: Vec<[usize; 3]>, eps: f64) -> SurfaceMesh {
+    use std::collections::HashMap;
+
     let eps2 = eps * eps;
     let n = points.len();
     let mut remap = vec![0usize; n];
     let mut unique: Vec<[f64; 3]> = Vec::new();
 
+    // Grid cell size equals eps so that two points within eps must share a cell
+    // or be in immediately adjacent cells (at most 3×3×3 = 27 to check).
+    let cell_size = eps.max(1e-15);
+    // Map from grid cell (ix, iy, iz) to the unique-point index stored there.
+    let mut grid: HashMap<(i64, i64, i64), usize> = HashMap::new();
+
+    let cell_coord = |v: f64| (v / cell_size).floor() as i64;
+
     for (i, &p) in points.iter().enumerate() {
-        let found = unique.iter().enumerate().find(|(_, &q)| {
-            let d = sub(p, q);
-            d[0] * d[0] + d[1] * d[1] + d[2] * d[2] <= eps2
-        });
+        let cx = cell_coord(p[0]);
+        let cy = cell_coord(p[1]);
+        let cz = cell_coord(p[2]);
+
+        let mut found = None;
+        // Check the 3×3×3 neighbourhood.
+        'outer: for dz in -1i64..=1 {
+            for dy in -1i64..=1 {
+                for dx in -1i64..=1 {
+                    if let Some(&j) = grid.get(&(cx + dx, cy + dy, cz + dz)) {
+                        let q = unique[j];
+                        let d = sub(p, q);
+                        if d[0] * d[0] + d[1] * d[1] + d[2] * d[2] <= eps2 {
+                            found = Some(j);
+                            break 'outer;
+                        }
+                    }
+                }
+            }
+        }
+
         match found {
-            Some((j, _)) => remap[i] = j,
+            Some(j) => remap[i] = j,
             None => {
-                remap[i] = unique.len();
+                let j = unique.len();
+                remap[i] = j;
                 unique.push(p);
+                grid.insert((cx, cy, cz), j);
             }
         }
     }

--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -10,7 +10,7 @@ use std::f64::consts::PI;
 use serde::Serialize;
 
 use kofem_mesh::geom::{point_in_polygon, Point2};
-use kofem_mesh::triangulate::triangulate;
+use kofem_mesh::triangulate::{bowyer_watson, filter_interior, remove_super, triangulate};
 
 use crate::geom::curve::curve_from_step;
 use crate::geom::surface::surface_from_step;
@@ -140,6 +140,9 @@ fn tessellate_face_raw(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> S
     if let Some(mesh) = try_tessellate_bspline(face, file, max_edge_len) {
         return mesh;
     }
+    if let Some(mesh) = try_tessellate_annular_disc(face, file, max_edge_len) {
+        return mesh;
+    }
     if let Some(mesh) = try_tessellate_disc(face, file, max_edge_len) {
         return mesh;
     }
@@ -190,26 +193,38 @@ fn tessellate_face_raw(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> S
         })
         .collect();
 
-    let mut mesh2d = triangulate(&pts2d);
-
-    // Reject triangles whose centroid falls inside a hole polygon.
-    if !holes2d.is_empty() {
-        let pts = mesh2d.points.clone();
-        mesh2d.triangles.retain(|t| {
-            let c = t.centroid(&pts);
+    // For faces with holes, include inner loop points in the Bowyer-Watson
+    // triangulation so that small triangles form near hole boundaries.  This
+    // makes centroid rejection accurate even for holes that are small relative
+    // to the outer polygon, avoiding stray geometry inside holes.
+    let (bw_pts2d, bw_tris) = if holes2d.is_empty() {
+        let mesh2d = triangulate(&pts2d);
+        let tris = mesh2d.triangles.iter().map(|t| t.v).collect();
+        (mesh2d.points, tris)
+    } else {
+        let mut all_pts = pts2d.clone();
+        for hole in &holes2d {
+            all_pts.extend_from_slice(hole);
+        }
+        let n_all = all_pts.len();
+        let (bw_pts, mut tris) = bowyer_watson(&all_pts);
+        remove_super(&mut tris, n_all);
+        filter_interior(&mut tris, &bw_pts, &pts2d);
+        tris.retain(|t| {
+            let c = t.centroid(&bw_pts);
             !holes2d.iter().any(|hole| point_in_polygon(c, hole))
         });
-    }
+        let pts = bw_pts[..n_all].to_vec();
+        let tris_idx = tris.iter().map(|t| t.v).collect();
+        (pts, tris_idx)
+    };
 
-    let points: Vec<[f64; 3]> = mesh2d
-        .points
+    let points: Vec<[f64; 3]> = bw_pts2d
         .iter()
         .map(|p| add(origin, add(scale(x_axis, p.x), scale(y_axis, p.y))))
         .collect();
 
-    let triangles: Vec<[usize; 3]> = mesh2d.triangles.iter().map(|t| t.v).collect();
-
-    SurfaceMesh { points, triangles }
+    SurfaceMesh { points, triangles: bw_tris }
 }
 
 // ── Curved-surface tessellation ───────────────────────────────────────────────
@@ -794,8 +809,92 @@ fn try_tessellate_bspline(
     Some(SurfaceMesh { points, triangles })
 }
 
+/// Tessellate a flat annular disc (PLANE surface, single closed-circle outer loop,
+/// single closed-circle inner loop) using a structured O-grid.
+///
+/// Generates one radial layer of quads between the outer ring (matched to the
+/// outer barrel's n_u) and the inner ring, avoiding the solid-disc generation
+/// that the general Bowyer-Watson path would produce for this case.
+fn try_tessellate_annular_disc(
+    face: &TopoFace,
+    file: &StepFile,
+    max_edge_len: f64,
+) -> Option<SurfaceMesh> {
+    // Only for PLANE surfaces with exactly one inner loop.
+    let e = file.get(&face.surface_id)?;
+    if e.type_name != "PLANE" {
+        return None;
+    }
+    if face.inner_loops.len() != 1 {
+        return None;
+    }
+
+    // Outer loop must be a single closed CIRCLE edge.
+    if face.outer_loop.len() != 1 {
+        return None;
+    }
+    let outer_edge = &face.outer_loop[0];
+    if dist3(outer_edge.start, outer_edge.end) >= 1e-10 {
+        return None;
+    }
+    let outer_circle_id = resolve_curve_id(file, outer_edge.curve_id);
+    let outer_e = file.get(&outer_circle_id)?;
+    if outer_e.type_name != "CIRCLE" {
+        return None;
+    }
+
+    // Inner loop must also be a single closed CIRCLE edge.
+    let inner_loop = &face.inner_loops[0];
+    if inner_loop.len() != 1 {
+        return None;
+    }
+    let inner_edge = &inner_loop[0];
+    if dist3(inner_edge.start, inner_edge.end) >= 1e-10 {
+        return None;
+    }
+    let inner_circle_id = resolve_curve_id(file, inner_edge.curve_id);
+    let inner_e = file.get(&inner_circle_id)?;
+    if inner_e.type_name != "CIRCLE" {
+        return None;
+    }
+
+    let outer_ax_id = get_ref(outer_e, 1).ok()?;
+    let outer_radius = get_real(outer_e, 2).ok()?;
+    let axis = axis2_placement(file, outer_ax_id).ok()?;
+    let y = axis.y();
+    let inner_radius = get_real(inner_e, 2).ok()?;
+
+    // n_u matched to the outer barrel ring count so stitch() closes the seam.
+    let n_u = ((2.0 * PI * outer_radius / max_edge_len).ceil() as usize).clamp(8, 256);
+
+    // Outer ring (0..n_u) then inner ring (n_u..2*n_u).
+    let mut points = Vec::with_capacity(n_u * 2);
+    for i in 0..n_u {
+        let u = 2.0 * PI * i as f64 / n_u as f64;
+        let radial = add(scale(axis.x, u.cos()), scale(y, u.sin()));
+        points.push(add(axis.origin, scale(radial, outer_radius)));
+    }
+    for i in 0..n_u {
+        let u = 2.0 * PI * i as f64 / n_u as f64;
+        let radial = add(scale(axis.x, u.cos()), scale(y, u.sin()));
+        points.push(add(axis.origin, scale(radial, inner_radius)));
+    }
+
+    // One radial layer of quads, CCW raw winding (outward normal = +axis.z).
+    let mut triangles = Vec::with_capacity(n_u * 2);
+    for i in 0..n_u {
+        let ni = (i + 1) % n_u;
+        let (oa, ob) = (i, ni);
+        let (ia, ib) = (n_u + i, n_u + ni);
+        triangles.push([oa, ob, ib]);
+        triangles.push([oa, ib, ia]);
+    }
+
+    Some(SurfaceMesh { points, triangles })
+}
+
 /// Tessellate a flat circular disc (PLANE surface with a single closed CIRCLE
-/// outer boundary) using a center-fan layout.
+/// outer boundary and no inner loops) using a center-fan layout.
 ///
 /// This bypasses the general Bowyer-Watson path, which is numerically unstable
 /// for cocircular inputs: all n_u boundary points lie on the same circle, so
@@ -805,9 +904,12 @@ fn try_tessellate_bspline(
 /// coincide exactly with the corresponding ring produced by
 /// `try_tessellate_cylindrical`, enabling `stitch()` to close the seam.
 fn try_tessellate_disc(face: &TopoFace, file: &StepFile, max_edge_len: f64) -> Option<SurfaceMesh> {
-    // Only for PLANE surfaces.
+    // Only for PLANE surfaces with no inner loops.
     let e = file.get(&face.surface_id)?;
     if e.type_name != "PLANE" {
+        return None;
+    }
+    if !face.inner_loops.is_empty() {
         return None;
     }
 

--- a/crates/kofem-geom/src/tess/mod.rs
+++ b/crates/kofem-geom/src/tess/mod.rs
@@ -329,32 +329,49 @@ fn try_tessellate_cylindrical(
             return None;
         }
 
+        // Build UV boundary polygon for triangle clipping.
+        let uv_bnd: Vec<Point2> = u_vals
+            .iter()
+            .zip(boundary_3d.iter())
+            .map(|(&u, &p)| {
+                let d = sub(p, axis.origin);
+                Point2::new(u, dot3(d, axis.z))
+            })
+            .collect();
+
         let arc_u = (u_max - u_min) * radius;
         let arc_v = (v_max - v_min).abs();
         let n_u = ((arc_u / max_edge_len).ceil() as usize).clamp(2, 256);
         let n_v = ((arc_v / max_edge_len).ceil() as usize).clamp(1, 256);
 
         let mut points = Vec::with_capacity((n_u + 1) * (n_v + 1));
+        let mut uv_grid = Vec::with_capacity((n_u + 1) * (n_v + 1));
         for j in 0..=n_v {
             let v = v_min + (v_max - v_min) * j as f64 / n_v as f64;
             for i in 0..=n_u {
                 let u = u_min + (u_max - u_min) * i as f64 / n_u as f64;
                 points.push(surface.point(u, v));
+                uv_grid.push(Point2::new(u, v));
             }
         }
 
         let n_cols = n_u + 1;
-        let mut triangles = Vec::with_capacity(n_u * n_v * 2);
-        for j in 0..n_v {
-            for i in 0..n_u {
-                let a = j * n_cols + i;
-                let b = j * n_cols + (i + 1);
-                let c = (j + 1) * n_cols + i;
-                let d = (j + 1) * n_cols + (i + 1);
-                triangles.push([a, b, d]);
-                triangles.push([a, d, c]);
-            }
-        }
+        let triangles: Vec<[usize; 3]> = (0..n_v)
+            .flat_map(|j| {
+                (0..n_u).flat_map(move |i| {
+                    let a = j * n_cols + i;
+                    let b = j * n_cols + (i + 1);
+                    let c = (j + 1) * n_cols + i;
+                    let d = (j + 1) * n_cols + (i + 1);
+                    [[a, b, d], [a, d, c]]
+                })
+            })
+            .filter(|&[a, b, c]| {
+                let cu = (uv_grid[a].x + uv_grid[b].x + uv_grid[c].x) / 3.0;
+                let cv = (uv_grid[a].y + uv_grid[b].y + uv_grid[c].y) / 3.0;
+                point_in_polygon(Point2::new(cu, cv), &uv_bnd)
+            })
+            .collect();
 
         Some(SurfaceMesh { points, triangles })
     }
@@ -467,32 +484,49 @@ fn try_tessellate_conical(
             return None;
         }
 
+        // Build UV boundary polygon for triangle clipping.
+        let uv_bnd: Vec<Point2> = u_vals
+            .iter()
+            .zip(boundary_3d.iter())
+            .map(|(&u, &p)| {
+                let d = sub(p, axis.origin);
+                Point2::new(u, dot3(d, axis.z) / cos_phi)
+            })
+            .collect();
+
         let arc_u = (u_max - u_min) * r_mid;
         let arc_v = (v_max - v_min).abs();
         let n_u = ((arc_u / max_edge_len).ceil() as usize).clamp(2, 256);
         let n_v = ((arc_v / max_edge_len).ceil() as usize).clamp(1, 256);
 
         let mut points = Vec::with_capacity((n_u + 1) * (n_v + 1));
+        let mut uv_grid = Vec::with_capacity((n_u + 1) * (n_v + 1));
         for j in 0..=n_v {
             let v = v_min + (v_max - v_min) * j as f64 / n_v as f64;
             for i in 0..=n_u {
                 let u = u_min + (u_max - u_min) * i as f64 / n_u as f64;
                 points.push(surface.point(u, v));
+                uv_grid.push(Point2::new(u, v));
             }
         }
 
         let n_cols = n_u + 1;
-        let mut triangles = Vec::with_capacity(n_u * n_v * 2);
-        for j in 0..n_v {
-            for i in 0..n_u {
-                let a = j * n_cols + i;
-                let b = j * n_cols + (i + 1);
-                let c = (j + 1) * n_cols + i;
-                let d = (j + 1) * n_cols + (i + 1);
-                triangles.push([a, b, d]);
-                triangles.push([a, d, c]);
-            }
-        }
+        let triangles: Vec<[usize; 3]> = (0..n_v)
+            .flat_map(|j| {
+                (0..n_u).flat_map(move |i| {
+                    let a = j * n_cols + i;
+                    let b = j * n_cols + (i + 1);
+                    let c = (j + 1) * n_cols + i;
+                    let d = (j + 1) * n_cols + (i + 1);
+                    [[a, b, d], [a, d, c]]
+                })
+            })
+            .filter(|&[a, b, c]| {
+                let cu = (uv_grid[a].x + uv_grid[b].x + uv_grid[c].x) / 3.0;
+                let cv = (uv_grid[a].y + uv_grid[b].y + uv_grid[c].y) / 3.0;
+                point_in_polygon(Point2::new(cu, cv), &uv_bnd)
+            })
+            .collect();
 
         Some(SurfaceMesh { points, triangles })
     }
@@ -794,7 +828,7 @@ fn try_tessellate_bspline(
         }
     }
 
-    let mut triangles = Vec::with_capacity((n_u - 1) * (n_v - 1) * 2);
+    let mut triangles: Vec<[usize; 3]> = Vec::with_capacity((n_u - 1) * (n_v - 1) * 2);
     for j in 0..(n_v - 1) {
         for i in 0..(n_u - 1) {
             let a = j * n_u + i;
@@ -803,6 +837,46 @@ fn try_tessellate_bspline(
             let d = (j + 1) * n_u + (i + 1);
             triangles.push([a, b, d]);
             triangles.push([a, d, c]);
+        }
+    }
+
+    // Clip generated triangles to the actual face boundary by projecting everything
+    // onto a shared tangent plane and testing centroids against the 2D boundary polygon.
+    let boundary_3d = sample_boundary_3d(&face.outer_loop, file, max_edge_len);
+    if boundary_3d.len() >= 3 {
+        if let Some(normal) = face_normal(&boundary_3d) {
+            let (bnd2d, origin, x_axis, y_axis) = project_to_2d(&boundary_3d, normal);
+            let holes2d: Vec<Vec<Point2>> = face
+                .inner_loops
+                .iter()
+                .filter_map(|inner| {
+                    let inner_3d = sample_boundary_3d(inner, file, max_edge_len);
+                    if inner_3d.len() < 3 {
+                        return None;
+                    }
+                    Some(
+                        inner_3d
+                            .iter()
+                            .map(|&p| {
+                                let d = sub(p, origin);
+                                Point2::new(dot3(d, x_axis), dot3(d, y_axis))
+                            })
+                            .collect(),
+                    )
+                })
+                .collect();
+            triangles.retain(|&[a, b, c]| {
+                let cx =
+                    (points[a][0] + points[b][0] + points[c][0]) / 3.0;
+                let cy =
+                    (points[a][1] + points[b][1] + points[c][1]) / 3.0;
+                let cz =
+                    (points[a][2] + points[b][2] + points[c][2]) / 3.0;
+                let d = sub([cx, cy, cz], origin);
+                let c2d = Point2::new(dot3(d, x_axis), dot3(d, y_axis));
+                point_in_polygon(c2d, &bnd2d)
+                    && !holes2d.iter().any(|h| point_in_polygon(c2d, h))
+            });
         }
     }
 

--- a/crates/kofem-geom/tests/tess.rs
+++ b/crates/kofem-geom/tests/tess.rs
@@ -1167,3 +1167,41 @@ fn nist_ctc_04_all_points_finite() {
         );
     }
 }
+
+// ── NIST CTC-02 (AP242 e2, contains NURBS surfaces) ──────────────────────────
+
+fn load_nist_ctc_02() -> (kofem_geom::step::StepFile, BRep) {
+    let file = parse(include_str!(
+        "../../../test_files/NIST/nist_ctc_02_asme1_ap242-e2.stp"
+    ))
+    .unwrap();
+    let brep = BRep::extract(&file).unwrap();
+    (file, brep)
+}
+
+/// NIST CTC-02 tessellates in reasonable time (regression guard for O(n²) stitch).
+#[test]
+fn nist_ctc_02_tessellates_without_panic() {
+    let (file, brep) = load_nist_ctc_02();
+    let mesh = tessellate(
+        &brep,
+        &file,
+        TessOptions {
+            max_edge_len: 5.0,
+            ..TessOptions::default()
+        },
+    )
+    .unwrap();
+    assert!(
+        mesh.triangles.len() > 10,
+        "expected triangles, got {}",
+        mesh.triangles.len()
+    );
+    for (i, p) in mesh.points.iter().enumerate() {
+        assert!(
+            p[0].is_finite() && p[1].is_finite() && p[2].is_finite(),
+            "point {i} has non-finite coords: {:?}",
+            p
+        );
+    }
+}


### PR DESCRIPTION
- Add `try_tessellate_annular_disc` to generate proper O-grid meshes for
  annular (ring-shaped) flat faces, fixing large chamfer errors on tube
  top/bottom faces and stepped shaft step face (max dropped from ~13mm to
  ~0.15mm and ~8.5mm to ~0.11mm respectively).
- Guard `try_tessellate_disc` against faces with inner loops to prevent
  solid-disc triangles overwriting the hole.
- Improve general planar hole handling: include inner loop boundary points
  in Bowyer-Watson so triangles form near hole edges and use centroid
  rejection to remove triangles inside holes.

https://claude.ai/code/session_01DBuhhmRiPHodRc6n4ou5SC