### PR TITLE
feat(mesh): add CDT has_edge helper

### DIFF
--- a/crates/kofem-mesh/src/cdt.rs
+++ b/crates/kofem-mesh/src/cdt.rs
@@ -1,0 +1,32 @@
+//! Constrained Delaunay Triangulation (CDT) helpers.
+
+use crate::triangulate::Triangle;
+
+/// Returns `true` iff some triangle in `triangles` contains both vertex `a` and vertex `b`.
+///
+/// Order of `a` and `b` does not matter.
+pub fn has_edge(triangles: &[Triangle], a: usize, b: usize) -> bool {
+    triangles
+        .iter()
+        .any(|t| t.v.contains(&a) && t.v.contains(&b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_edge_finds_existing() {
+        let tris = vec![Triangle { v: [0, 1, 2] }, Triangle { v: [1, 2, 3] }];
+        assert!(has_edge(&tris, 0, 1));
+        assert!(has_edge(&tris, 1, 0)); // reverse
+        assert!(has_edge(&tris, 1, 3));
+        assert!(!has_edge(&tris, 0, 3)); // not adjacent
+    }
+
+    #[test]
+    fn has_edge_empty_triangulation() {
+        let tris: Vec<Triangle> = vec![];
+        assert!(!has_edge(&tris, 0, 1));
+    }
+}

--- a/crates/kofem-mesh/src/lib.rs
+++ b/crates/kofem-mesh/src/lib.rs
@@ -8,6 +8,7 @@
 //! 4. [`extrude`] sweeps the 2-D mesh into a 3-D [`Mesh3D`] of tetrahedra.
 //! 5. [`volume::volume_mesh`] fills a closed [`volume::SurfaceMesh`] with quality tetrahedra.
 
+pub mod cdt;
 pub mod extrude;
 pub mod geom;
 pub mod quality;


### PR DESCRIPTION
Implements `has_edge(&triangles, a, b)` in a new `crates/kofem-mesh/src/cdt.rs`
module. Returns true iff any triangle contains both vertex indices, handling
both orderings. Covers the two red-green tests from issue #86.

closes #86

https://claude.ai/code/session_011rF6unfEG4gej1d6fznKTR