### PR TITLE
Fix interior/exterior classification in constrained Delaunay triangulation

### DIFF
--- a/crates/kofem-mesh/src/cdt.rs
+++ b/crates/kofem-mesh/src/cdt.rs
@@ -2,9 +2,9 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::geom::{in_circumcircle, orient2d, Point2};
+use crate::geom::{in_circumcircle, orient2d, point_in_polygon, Point2};
 use crate::triangulate::bowyer_watson;
-use crate::triangulate::{filter_interior, remove_super, Mesh2D, Triangle};
+use crate::triangulate::{remove_super, Mesh2D, Triangle};
 
 /// Returns `true` iff some triangle in `triangles` contains both vertex `a` and vertex `b`.
 ///
@@ -67,6 +67,22 @@ fn segments_properly_intersect(p: Point2, q: Point2, r: Point2, s: Point2) -> bo
         && ((d3 > 0.0 && d4 < 0.0) || (d3 < 0.0 && d4 > 0.0))
 }
 
+/// Retains only triangles whose centroid is strictly inside `outer` and outside
+/// every hole.  Must be called after all constraint edges are inserted — once
+/// boundaries are enforced no triangle straddles a boundary, so the centroid
+/// test is sufficient and correct.
+fn classify_interior(
+    triangles: &mut Vec<Triangle>,
+    pts: &[Point2],
+    outer: &[Point2],
+    holes: &[&[Point2]],
+) {
+    triangles.retain(|t| {
+        let c = t.centroid(pts);
+        point_in_polygon(c, outer) && !holes.iter().any(|&h| point_in_polygon(c, h))
+    });
+}
+
 /// Constrained Delaunay triangulation of a polygon with optional holes.
 ///
 /// Triangulates `boundary` (CCW, closed polygon) together with all `holes`
@@ -88,7 +104,6 @@ pub fn triangulate_constrained(boundary: &[Point2], holes: &[&[Point2]]) -> Mesh
 
     let (all_pts, mut triangles) = bowyer_watson(&all_input_pts);
     remove_super(&mut triangles, n_all);
-    filter_interior(&mut triangles, &all_pts, boundary);
 
     // Build constraint edge list from every boundary ring.
     let mut constraints: Vec<(usize, usize)> = Vec::new();
@@ -116,6 +131,8 @@ pub fn triangulate_constrained(boundary: &[Point2], holes: &[&[Point2]]) -> Mesh
     for (a, b) in constraints {
         enforce_constraint(&mut triangles, &all_pts, a, b, &constraint_set);
     }
+
+    classify_interior(&mut triangles, &all_pts, boundary, holes);
 
     Mesh2D {
         points: all_pts[..n_all].to_vec(),
@@ -461,7 +478,7 @@ pub fn legalize_edges(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::triangulate::bowyer_watson;
+    use crate::triangulate::{bowyer_watson, filter_interior};
 
     #[test]
     fn has_edge_finds_existing() {
@@ -738,5 +755,46 @@ mod tests {
         let mesh1 = triangulate_constrained(&outer, &[]);
         let mesh2 = triangulate_constrained(&outer, &[]);
         assert_eq!(mesh1.triangles.len(), mesh2.triangles.len());
+    }
+
+    // ── Issue-92 tests: interior/exterior classification ──────────────────────
+
+    #[test]
+    fn square_with_square_hole() {
+        let outer = vec![
+            Point2::new(0.0, 0.0),
+            Point2::new(4.0, 0.0),
+            Point2::new(4.0, 4.0),
+            Point2::new(0.0, 4.0),
+        ];
+        let hole = vec![
+            Point2::new(1.0, 1.0),
+            Point2::new(3.0, 1.0),
+            Point2::new(3.0, 3.0),
+            Point2::new(1.0, 3.0),
+        ];
+        let mesh = triangulate_constrained(&outer, &[hole.as_slice()]);
+        for t in &mesh.triangles {
+            let c = t.centroid(&mesh.points);
+            assert!(
+                point_in_polygon(c, &outer),
+                "centroid outside outer boundary"
+            );
+            assert!(!point_in_polygon(c, &hole), "centroid inside hole");
+        }
+        assert!(mesh.triangles.len() >= 8);
+    }
+
+    #[test]
+    fn no_triangles_outside_outer_boundary() {
+        let outer = vec![
+            Point2::new(0.0, 0.0),
+            Point2::new(1.0, 0.0),
+            Point2::new(0.5, 1.0),
+        ];
+        let mesh = triangulate_constrained(&outer, &[]);
+        assert_eq!(mesh.triangles.len(), 1);
+        let c = mesh.triangles[0].centroid(&mesh.points);
+        assert!(point_in_polygon(c, &outer));
     }
 }


### PR DESCRIPTION
## Summary

Replaces the `filter_interior` function with a new `classify_interior` function that correctly classifies triangles as interior or exterior based on centroid containment tests against the outer boundary and all holes. This fixes incorrect triangle filtering that occurred when `filter_interior` was called before constraint edges were enforced.

## Key Changes

- **Added `classify_interior` function**: New interior classification logic that retains only triangles whose centroid is strictly inside the outer boundary and outside all holes. This is called *after* all constraint edges are inserted, ensuring boundaries are properly enforced before classification.
- **Removed premature `filter_interior` call**: The old call to `filter_interior` immediately after `remove_super` is removed, as it was classifying triangles before constraint edges were enforced, leading to incorrect results.
- **Imported `point_in_polygon`**: Added import of the `point_in_polygon` utility function needed by the new classification logic.
- **Removed unused `filter_interior` import**: Removed from the main module imports (kept only in test module where it's still used for testing).
- **Added comprehensive tests**: Two new test cases verify correct behavior:
  - `square_with_square_hole`: Validates that all triangle centroids are inside the outer boundary and outside the hole
  - `no_triangles_outside_outer_boundary`: Ensures no spurious triangles exist outside a simple triangular boundary

## Implementation Details

The key insight is that once all constraint edges are inserted and boundaries are enforced, no triangle can straddle a boundary. Therefore, a simple centroid containment test is both sufficient and correct for classifying interior vs. exterior triangles. This is more robust than the previous approach of filtering before constraints were fully applied.

https://claude.ai/code/session_01Er4RRXF9obx1rT4NoNRFjV