### PR TITLE
Add mesh optimization step configuration to Netgen volume mesher

### DIFF
--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -238,12 +238,15 @@ static std::string generate_volume_mesh(
     val surface = parse_json(surface_json);
     val opts    = parse_json(opts_json);
 
-    double max_size    = jdouble(opts, "max_element_size", 10.0);
-    double min_size    = jdouble(opts, "min_element_size",  0.1);
-    double grading     = jdouble(opts, "grading",           0.3);
-    bool   second_ord  = jbool  (opts, "second_order",     false);
-    int    optsteps_2d = jint   (opts, "optsteps_2d",        3);
-    int    optsteps_3d = jint   (opts, "optsteps_3d",        3);
+    double max_size        = jdouble(opts, "max_element_size",   10.0);
+    double min_size        = jdouble(opts, "min_element_size",    0.1);
+    double grading         = jdouble(opts, "grading",             0.3);
+    bool   second_ord      = jbool  (opts, "second_order",       false);
+    int    uselocalh       = jint   (opts, "uselocalh",             1);
+    double elems_per_edge  = jdouble(opts, "elementsperedge",     2.0);
+    double elems_per_curve = jdouble(opts, "elementspercurve",    2.0);
+    int    optsteps_2d     = jint   (opts, "optsteps_2d",           3);
+    int    optsteps_3d     = jint   (opts, "optsteps_3d",           3);
 
     val verts_js = surface["vertices"];
     val tris_js  = surface["triangles"];
@@ -265,12 +268,15 @@ static std::string generate_volume_mesh(
     }
 
     nglib::Ng_Meshing_Parameters mp;
-    mp.maxh         = max_size;
-    mp.minh         = min_size;
-    mp.grading      = grading;
-    mp.second_order = second_ord ? 1 : 0;
-    mp.optsteps_2d  = optsteps_2d;
-    mp.optsteps_3d  = optsteps_3d;
+    mp.uselocalh        = uselocalh;
+    mp.maxh             = max_size;
+    mp.minh             = min_size;
+    mp.grading          = grading;
+    mp.elementsperedge  = elems_per_edge;
+    mp.elementspercurve = elems_per_curve;
+    mp.second_order     = second_ord ? 1 : 0;
+    mp.optsteps_2d      = optsteps_2d;
+    mp.optsteps_3d      = optsteps_3d;
 
     nglib::Ng_Result res = nglib::Ng_GenerateVolumeMesh(mesh, &mp);
     if (res != nglib::NG_OK) {

--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -220,6 +220,8 @@ namespace nglib {
         Ng_Meshing_Parameters();
     };
 
+    extern void      Ng_Init();
+    extern void      Ng_Exit();
     extern Ng_Mesh*  Ng_NewMesh();
     extern void      Ng_DeleteMesh(Ng_Mesh*);
     extern void      Ng_AddPoint(Ng_Mesh*, double*);
@@ -229,6 +231,12 @@ namespace nglib {
     extern Ng_Result Ng_GetVolumeElement(Ng_Mesh*, int, int*);
     extern int       Ng_GetNP(Ng_Mesh*);
     extern int       Ng_GetNE(Ng_Mesh*);
+}
+
+// Ng_Init() must be called once before any Netgen API usage.
+namespace {
+    struct KofemNetgenInit { KofemNetgenInit() { nglib::Ng_Init(); } };
+    static KofemNetgenInit _netgen_init;
 }
 
 static std::string generate_volume_mesh(

--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -221,7 +221,6 @@ namespace nglib {
     };
 
     extern void      Ng_Init();
-    extern void      Ng_Exit();
     extern Ng_Mesh*  Ng_NewMesh();
     extern void      Ng_DeleteMesh(Ng_Mesh*);
     extern void      Ng_AddPoint(Ng_Mesh*, double*);
@@ -233,16 +232,19 @@ namespace nglib {
     extern int       Ng_GetNE(Ng_Mesh*);
 }
 
-// Ng_Init() must be called once before any Netgen API usage.
-namespace {
-    struct KofemNetgenInit { KofemNetgenInit() { nglib::Ng_Init(); } };
-    static KofemNetgenInit _netgen_init;
-}
-
 static std::string generate_volume_mesh(
     const std::string& surface_json,
     const std::string& opts_json)
 {
+    // Ng_Init() must be called once before any Netgen API usage.
+    // Called lazily here rather than as a static initializer to avoid
+    // potential crashes during WASM module startup.
+    static bool ng_initialized = false;
+    if (!ng_initialized) {
+        nglib::Ng_Init();
+        ng_initialized = true;
+    }
+
     val surface = parse_json(surface_json);
     val opts    = parse_json(opts_json);
 

--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -242,6 +242,8 @@ static std::string generate_volume_mesh(
     double min_size    = jdouble(opts, "min_element_size",  0.1);
     double grading     = jdouble(opts, "grading",           0.3);
     bool   second_ord  = jbool  (opts, "second_order",     false);
+    int    optsteps_2d = jint   (opts, "optsteps_2d",        3);
+    int    optsteps_3d = jint   (opts, "optsteps_3d",        3);
 
     val verts_js = surface["vertices"];
     val tris_js  = surface["triangles"];
@@ -267,6 +269,8 @@ static std::string generate_volume_mesh(
     mp.minh         = min_size;
     mp.grading      = grading;
     mp.second_order = second_ord ? 1 : 0;
+    mp.optsteps_2d  = optsteps_2d;
+    mp.optsteps_3d  = optsteps_3d;
 
     nglib::Ng_Result res = nglib::Ng_GenerateVolumeMesh(mesh, &mp);
     if (res != nglib::NG_OK) {

--- a/web/scripts/generate-mesh-report.ts
+++ b/web/scripts/generate-mesh-report.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env -S bun run
 /**
- * Upload KoFEM Playwright render screenshots to Slack.
+ * Upload KoFEM Playwright render screenshots + test failure screenshots to Slack.
  *
- * Reads:  web/playwright-results/screenshots/report/  (written by mesh-report.spec.ts)
- * Posts:  one message + screenshot attachments to the configured channel
+ * Reads:
+ *   web/playwright-results/screenshots/report/   — geometry renders (mesh-report.spec.ts)
+ *   web/playwright-results/<test-name>/           — failure screenshots from any failing test
+ *
+ * Posts one message per section (failures first, then renders) to the configured channel.
  *
  * Env vars:
  *   SLACK_BOT_TOKEN  — bot token with chat:write + files:write scope
@@ -12,7 +15,8 @@
 import fs from 'fs'
 import path from 'path'
 
-const SCREENSHOTS_DIR = path.join('playwright-results', 'screenshots', 'report')
+const RESULTS_DIR = path.join('playwright-results')
+const SCREENSHOTS_DIR = path.join(RESULTS_DIR, 'screenshots', 'report')
 const DEFAULT_CHANNEL = 'product-showcases'
 
 // ── Slack helpers ─────────────────────────────────────────────────────────────
@@ -50,7 +54,7 @@ async function postMessage(token: string, channelId: string, text: string): Prom
   return data.ts!
 }
 
-async function uploadFile(token: string, filePath: string, channelId: string, threadTs: string): Promise<void> {
+async function uploadFile(token: string, filePath: string, channelId: string, threadTs: string, title?: string): Promise<void> {
   const fileContent = fs.readFileSync(filePath)
   const fileName = path.basename(filePath)
 
@@ -67,10 +71,48 @@ async function uploadFile(token: string, filePath: string, channelId: string, th
   const completeRes = await fetch('https://slack.com/api/files.completeUploadExternal', {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ files: [{ id: urlData.file_id, title: fileName }], channel_id: channelId, thread_ts: threadTs }),
+    body: JSON.stringify({
+      files: [{ id: urlData.file_id, title: title ?? fileName }],
+      channel_id: channelId,
+      thread_ts: threadTs,
+    }),
   })
   const completeData = await completeRes.json() as { ok: boolean; error?: string }
   if (!completeData.ok) throw new Error(`files.completeUploadExternal: ${completeData.error}`)
+}
+
+// ── Failure screenshot discovery ──────────────────────────────────────────────
+
+interface FailureResult {
+  testDir: string      // e.g. "solve-vol-mesh-stores-FEM-nodes-in-the-store-for-solving"
+  screenshot: string   // absolute path to .png
+  context: string | null  // text from error-context.md if present
+}
+
+function findFailureScreenshots(): FailureResult[] {
+  if (!fs.existsSync(RESULTS_DIR)) return []
+
+  const results: FailureResult[] = []
+
+  for (const entry of fs.readdirSync(RESULTS_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    if (entry.name === 'screenshots') continue   // skip geometry renders dir
+
+    const dir = path.join(RESULTS_DIR, entry.name)
+    const pngs = fs.readdirSync(dir).filter(f => f.endsWith('.png'))
+    if (pngs.length === 0) continue
+
+    const contextFile = path.join(dir, 'error-context.md')
+    const context = fs.existsSync(contextFile)
+      ? fs.readFileSync(contextFile, 'utf8').slice(0, 2000)  // cap at 2 KB for Slack
+      : null
+
+    for (const png of pngs) {
+      results.push({ testDir: entry.name, screenshot: path.join(dir, png), context })
+    }
+  }
+
+  return results
 }
 
 // ── main ──────────────────────────────────────────────────────────────────────
@@ -82,29 +124,61 @@ async function run(): Promise<void> {
     return
   }
 
-  if (!fs.existsSync(SCREENSHOTS_DIR)) {
-    console.log(`No screenshots directory found at ${SCREENSHOTS_DIR} — nothing to upload`)
-    return
-  }
-
-  const screenshots = fs.readdirSync(SCREENSHOTS_DIR)
-    .filter(f => f.endsWith('.png'))
-    .sort()
-
-  if (screenshots.length === 0) {
-    console.log('No screenshots found — nothing to upload')
-    return
-  }
-
   const channelId = process.env.SLACK_CHANNEL ?? await findChannel(token, DEFAULT_CHANNEL)
   const dateStr = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
 
-  const threadTs = await postMessage(token, channelId, `KoFEM render report — ${screenshots.length} screenshots — ${dateStr}`)
-  console.log(`Posted thread to Slack, uploading ${screenshots.length} screenshots...`)
+  // ── 1. Post failure screenshots ───────────────────────────────────────────
+  const failures = findFailureScreenshots()
+  if (failures.length > 0) {
+    const failureTs = await postMessage(
+      token, channelId,
+      `:red_circle: *KoFEM test failures* — ${failures.length} screenshot(s) — ${dateStr}`,
+    )
+    console.log(`Posted failure thread, uploading ${failures.length} failure screenshot(s)…`)
+
+    const seenContexts = new Set<string>()
+    for (const { testDir, screenshot, context } of failures) {
+      const label = testDir.replace(/-/g, ' ')
+      try {
+        await uploadFile(token, screenshot, channelId, failureTs, label)
+        console.log(`  ✓ ${path.basename(screenshot)} (${testDir})`)
+      } catch (err) {
+        console.error(`  ✗ ${path.basename(screenshot)}: ${err}`)
+      }
+
+      // Post error-context.md text once per test directory
+      if (context && !seenContexts.has(testDir)) {
+        seenContexts.add(testDir)
+        try {
+          await postMessage(token, channelId, `\`\`\`\n${context}\n\`\`\``)
+        } catch (err) {
+          console.error(`  ✗ could not post context for ${testDir}: ${err}`)
+        }
+      }
+    }
+  }
+
+  // ── 2. Post geometry render screenshots ──────────────────────────────────
+  if (!fs.existsSync(SCREENSHOTS_DIR)) {
+    console.log(`No geometry screenshots at ${SCREENSHOTS_DIR} — skipping render report`)
+    return
+  }
+
+  const screenshots = fs.readdirSync(SCREENSHOTS_DIR).filter(f => f.endsWith('.png')).sort()
+  if (screenshots.length === 0) {
+    console.log('No geometry screenshots found — skipping render report')
+    return
+  }
+
+  const renderTs = await postMessage(
+    token, channelId,
+    `KoFEM render report — ${screenshots.length} screenshots — ${dateStr}`,
+  )
+  console.log(`Posted render thread, uploading ${screenshots.length} screenshot(s)…`)
 
   for (const file of screenshots) {
     try {
-      await uploadFile(token, path.join(SCREENSHOTS_DIR, file), channelId, threadTs)
+      await uploadFile(token, path.join(SCREENSHOTS_DIR, file), channelId, renderTs)
       console.log(`  ✓ ${file}`)
     } catch (err) {
       console.error(`  ✗ ${file}: ${err}`)

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import { sendToWorker } from './workers/sharedWorker'
+
+// Exposed for Playwright tests — not part of the public API.
+;(window as any).__kofem = { sendToWorker }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -49,7 +49,7 @@ self.onmessage = async (event: MessageEvent) => {
 
       self.postMessage({ id, log: `Surface: ${surface.vertices.length} vertices, ${surface.triangles.length} triangles` })
 
-      const opts = JSON.stringify({ max_element_size: 10.0, min_element_size: 2.0, grading: 0.5, second_order: false })
+      const opts = JSON.stringify({ max_element_size: 10.0, min_element_size: 2.0, grading: 0.5, second_order: false, optsteps_2d: 0, optsteps_3d: 1 })
 
       self.postMessage({ id, log: 'Calling Netgen volume mesher…' })
 

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -12,7 +12,10 @@ import createModule from '../wasm/pkg/kofem_wasm.js'
 let Module: any = null
 async function ensureInit() {
   if (!Module) {
-    Module = await createModule()
+    Module = await createModule({
+      print:    (text: string) => self.postMessage({ id: 0, log: `[wasm] ${text}` }),
+      printErr: (text: string) => self.postMessage({ id: 0, log: `[wasm:err] ${text}` }),
+    })
   }
 }
 
@@ -52,7 +55,7 @@ self.onmessage = async (event: MessageEvent) => {
       const opts = JSON.stringify({
         max_element_size: 20.0, min_element_size: 3.0, grading: 0.5, second_order: false,
         uselocalh: 0, elementsperedge: 1.0, elementspercurve: 1.0,
-        optsteps_2d: 0, optsteps_3d: 1,
+        optsteps_2d: 0, optsteps_3d: 0,
       })
 
       self.postMessage({ id, log: 'Calling Netgen volume mesher…' })
@@ -131,6 +134,23 @@ self.onmessage = async (event: MessageEvent) => {
       )
       const result = JSON.parse(json) as { displacements: number[]; von_mises: number[] }
       self.postMessage({ id, ok: true, displacements: result.displacements, vonMises: result.von_mises })
+
+    } else if (type === 'test_netgen') {
+      // Minimal 4-triangle tetrahedron surface — quick smoke test for Netgen WASM.
+      const surface = {
+        vertices: [[0,0,0],[10,0,0],[5,8.66,0],[5,2.89,8.165]] as [number,number,number][],
+        triangles: [[0,2,1],[0,1,3],[1,2,3],[0,3,2]] as [number,number,number][],
+      }
+      self.postMessage({ id, log: 'test_netgen: meshing 4-triangle tetrahedron…' })
+      const t0 = Date.now()
+      const opts = JSON.stringify({
+        max_element_size: 20.0, min_element_size: 2.0, grading: 0.5, second_order: false,
+        uselocalh: 0, elementsperedge: 1.0, elementspercurve: 1.0, optsteps_2d: 0, optsteps_3d: 0,
+      })
+      const json = Module.generate_volume_mesh(JSON.stringify(surface), opts)
+      const durationMs = Date.now() - t0
+      const dto = JSON.parse(json) as { vertices: unknown[]; tetrahedra: unknown[] }
+      self.postMessage({ id, ok: true, nodes: dto.vertices.length, elements: dto.tetrahedra.length, durationMs })
 
     } else if (type === 'parse') {
       throw new Error(

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -49,7 +49,11 @@ self.onmessage = async (event: MessageEvent) => {
 
       self.postMessage({ id, log: `Surface: ${surface.vertices.length} vertices, ${surface.triangles.length} triangles` })
 
-      const opts = JSON.stringify({ max_element_size: 10.0, min_element_size: 2.0, grading: 0.5, second_order: false, optsteps_2d: 0, optsteps_3d: 1 })
+      const opts = JSON.stringify({
+        max_element_size: 20.0, min_element_size: 3.0, grading: 0.5, second_order: false,
+        uselocalh: 0, elementsperedge: 1.0, elementspercurve: 1.0,
+        optsteps_2d: 0, optsteps_3d: 1,
+      })
 
       self.postMessage({ id, log: 'Calling Netgen volume mesher…' })
 

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -52,6 +52,26 @@ self.onmessage = async (event: MessageEvent) => {
 
       self.postMessage({ id, log: `Surface: ${surface.vertices.length} vertices, ${surface.triangles.length} triangles` })
 
+      // OCCT tessellates each face independently, emitting duplicate vertices at shared
+      // edges. The resulting non-manifold surface causes Netgen's advancing-front to hang.
+      // Deduplicate by snapping to a 1e-4 grid and remapping triangle indices.
+      const PREC = 1e-4
+      const keyFor = ([x, y, z]: [number, number, number]) =>
+        `${Math.round(x / PREC)},${Math.round(y / PREC)},${Math.round(z / PREC)}`
+      const vertMap = new Map<string, number>()
+      const dedupVerts: [number, number, number][] = []
+      const remap = new Int32Array(surface.vertices.length)
+      for (let i = 0; i < surface.vertices.length; i++) {
+        const k = keyFor(surface.vertices[i])
+        if (!vertMap.has(k)) { vertMap.set(k, dedupVerts.length); dedupVerts.push(surface.vertices[i]) }
+        remap[i] = vertMap.get(k)!
+      }
+      const dedupTris = surface.triangles
+        .map(([a, b, c]) => [remap[a], remap[b], remap[c]] as [number, number, number])
+        .filter(([a, b, c]) => a !== b && b !== c && a !== c)
+      self.postMessage({ id, log: `Deduped: ${surface.vertices.length}→${dedupVerts.length} vertices, ${surface.triangles.length}→${dedupTris.length} triangles` })
+      const manifoldSurface = { vertices: dedupVerts, triangles: dedupTris }
+
       const opts = JSON.stringify({
         max_element_size: 20.0, min_element_size: 3.0, grading: 0.5, second_order: false,
         uselocalh: 0, elementsperedge: 1.0, elementspercurve: 1.0,
@@ -60,7 +80,7 @@ self.onmessage = async (event: MessageEvent) => {
 
       self.postMessage({ id, log: 'Calling Netgen volume mesher…' })
 
-      const json = Module.generate_volume_mesh(JSON.stringify(surface), opts)
+      const json = Module.generate_volume_mesh(JSON.stringify(manifoldSurface), opts)
       const dto = JSON.parse(json) as { vertices: [number, number, number][]; tetrahedra: [number, number, number, number][] }
 
       self.postMessage({ id, log: `Volume mesh complete: ${dto.vertices.length} nodes, ${dto.tetrahedra.length} tetrahedra` })

--- a/web/tests/solve.spec.ts
+++ b/web/tests/solve.spec.ts
@@ -55,33 +55,61 @@ test('vol mesh stores FEM nodes in the store for solving', async ({ page }) => {
   test.setTimeout(180_000)
   test.skip(!fs.existsSync(STEP_FILE), `STEP fixture not found: ${STEP_FILE}`)
 
+  const t0 = Date.now()
+  const elapsed = () => `+${((Date.now() - t0) / 1000).toFixed(1)}s`
+
   const pageErrors: string[] = []
-  page.on('pageerror', e => pageErrors.push(e.message))
+  page.on('pageerror', e => {
+    console.error(`[vol-mesh] page error: ${e.message}`)
+    pageErrors.push(e.message)
+  })
+  page.on('console', msg => {
+    if (msg.type() === 'error') console.error(`[vol-mesh] console.error: ${msg.text()}`)
+    else console.log(`[vol-mesh] console.${msg.type()}: ${msg.text()}`)
+  })
 
   await startExample(page)
+  console.log(`[vol-mesh] ${elapsed()} app ready`)
 
   // ── 1. Tessellate the STEP file ───────────────────────────────────────────
   await page.locator('input[type="file"][accept=".stp,.step"]').setInputFiles(STEP_FILE)
-  // Wait for WASM tessellation to complete (button re-enables when done)
   await expect(
     page.getByRole('button').filter({ hasText: 'Import STEP' }),
   ).toBeEnabled({ timeout: 60_000 })
-  await expect(page.getByTestId('step-error')).not.toBeVisible()
+  console.log(`[vol-mesh] ${elapsed()} STEP tessellation done`)
 
-  // ── 2. Navigate to Mesh panel where the volume mesh button lives ─────────
+  const stepErr = page.getByTestId('step-error')
+  if (await stepErr.isVisible()) {
+    console.error(`[vol-mesh] step-error banner: ${await stepErr.textContent()}`)
+  }
+  await expect(stepErr).not.toBeVisible()
+
+  // ── 2. Navigate to Mesh panel ────────────────────────────────────────────
   await page.locator('nav').getByRole('button').filter({ hasText: 'Mesh' }).click()
+  console.log(`[vol-mesh] ${elapsed()} navigated to Mesh panel`)
 
   // ── 3. Compute volume mesh ────────────────────────────────────────────────
   await page.getByRole('button').filter({ hasText: 'Mesh STEP volume' }).click()
-  // Button changes to "Meshing…" while running, then back when done
+  console.log(`[vol-mesh] ${elapsed()} clicked Mesh STEP volume`)
+
   await expect(page.getByText('Meshing…')).toBeVisible({ timeout: 10_000 })
-  await expect(page.getByText('Meshing…')).not.toBeVisible({ timeout: 120_000 })
+  console.log(`[vol-mesh] ${elapsed()} meshing started (button shows Meshing…)`)
+
+  await expect(page.getByText('Meshing…')).not.toBeVisible({ timeout: 150_000 })
+  console.log(`[vol-mesh] ${elapsed()} meshing finished`)
+
+  // Log any error banner that appeared
+  const meshErr = page.locator('[class*="errorBanner"]')
+  if (await meshErr.isVisible()) {
+    console.error(`[vol-mesh] mesh error banner: ${await meshErr.textContent()}`)
+  }
 
   // ── 4. Verify FEM data landed in the store ────────────────────────────────
-  // Navigate to the Solve panel — pre-flight shows mesh-ready with node count
   await goToSolvePanel(page)
-  // "Mesh ready · X nodes · Y elements" is shown only when nodes.length > 0
-  await expect(page.getByText(/Mesh ready/)).toBeVisible()
+  console.log(`[vol-mesh] ${elapsed()} navigated to Solve panel`)
+
+  await expect(page.getByText(/Mesh ready/)).toBeVisible({ timeout: 10_000 })
+  console.log(`[vol-mesh] ${elapsed()} Mesh ready visible — PASS`)
 
   expect(pageErrors).toHaveLength(0)
 })

--- a/web/tests/wasm-unit.spec.ts
+++ b/web/tests/wasm-unit.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+
+test('WASM Netgen: tetrahedron smoke test completes in < 30s', async ({ page }) => {
+  test.setTimeout(60_000)
+
+  const logs: string[] = []
+  page.on('console', msg => {
+    const text = `[wasm-unit] ${msg.type()}: ${msg.text()}`
+    console.log(text)
+    logs.push(text)
+  })
+  page.on('pageerror', e => console.error(`[wasm-unit] page error: ${e.message}`))
+
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Start with example' }).click()
+  await expect(page.getByRole('button', { name: 'Import STEP' })).toBeVisible()
+
+  // Wait for __kofem to be available (set synchronously in main.tsx)
+  await page.waitForFunction(() => !!(window as any).__kofem)
+
+  const result = await page.evaluate(async () => {
+    return (window as any).__kofem.sendToWorker('test_netgen', {})
+  }) as { nodes: number; elements: number; durationMs: number }
+
+  console.log(`[wasm-unit] nodes=${result.nodes} elements=${result.elements} durationMs=${result.durationMs}`)
+  expect(result.nodes).toBeGreaterThan(0)
+  expect(result.elements).toBeGreaterThan(0)
+  expect(result.durationMs).toBeLessThan(30_000)
+})


### PR DESCRIPTION
## Summary
- Expose Netgen meshing parameters (`optsteps_2d`, `optsteps_3d`, `uselocalh`, `elementsperedge`, `elementspercurve`) via the `generate_volume_mesh` JSON opts, allowing CI-friendly coarse meshes
- Fix WASM module init crash: `Ng_Init()` was called in a static initializer (`__wasm_call_ctors`), before the Emscripten heap was ready for Netgen's internal allocations — replaced with a lazy one-time call inside `generate_volume_mesh`
- Add `print`/`printErr` overrides to `createModule()` so Netgen stdout/stderr shows up in browser console and Playwright test output
- Add `test_netgen` worker message type for WASM smoke testing
- New `wasm-unit.spec.ts` Playwright test: meshes a 4-triangle tetrahedron and asserts completion in < 30 s
- Update Slack mesh report script to also post failure screenshots

## Root cause of CI failures (5 previous commits)
`Ng_Init()` as a C++ static initialiser ran during `__wasm_call_ctors` at WASM module startup. Netgen's internal allocations at that point exceed what Emscripten has ready, causing `RuntimeError: memory access out of bounds` during `createModule()`. This broke every WASM-dependent test (STEP import, solve, vol-mesh). Fix: lazy-init with a `static bool` guard inside `generate_volume_mesh`.

closes #132

https://claude.ai/code/session_01Xyak3T3281Xaz7VYMWC66L