### PR TITLE
Fix welcome screen STEP import not transitioning to main app

### DIFF
--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -289,7 +289,7 @@ export const useModelStore = create<ModelState>()(
       s.nodes = []; s.elements = []
       s.constraints = []; s.loads = []
       s.result = null
-      if (mesh) s.fitViewTrigger++
+      if (mesh) { s.fitViewTrigger++; s.hasStarted = true; s.mode = 'geometry' }
     }),
     triggerFitView: () => set(s => { s.fitViewTrigger++ }),
 


### PR DESCRIPTION
## Summary

- `setStepSurface` parsed the STEP file and updated geometry state but never set `hasStarted = true` or `mode = 'geometry'`, so the app remained stuck on the welcome screen after a successful import
- One-line fix mirrors the exact pattern already used by `startWithExample` and `startCustom`

## Root cause

`modelStore.ts` line 285 — the `setStepSurface` handler updated all geometry state correctly but omitted the navigation flags:
```ts
// before
if (mesh) s.fitViewTrigger++

// after
if (mesh) { s.fitViewTrigger++; s.hasStarted = true; s.mode = 'geometry' }
```

## Test plan
- [ ] Open the app, click "Load STEP file" on the welcome screen, select any `.stp` / `.step` file → main screen should appear with the Geometry tab active
- [ ] Verify that a bad/empty STEP file still shows the import error on the welcome screen (mesh is null, so the navigation flags are not set)
- [ ] Verify `startWithExample` and `startCustom` still work as before

closes #131

https://claude.ai/code/session_01GHitpD6B3JbcbJ8KGxN1EP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHitpD6B3JbcbJ8KGxN1EP)_