### PR TITLE
Re-tessellate STEP geometry for volume meshing to prevent Netgen crashes

### DIFF
--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -16,6 +16,7 @@
 // OCCT
 #include <BRep_Tool.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
+#include <BRepTools.hxx>
 #include <IFSelect_ReturnStatus.hxx>
 #include <Poly_Triangulation.hxx>
 #include <STEPControl_Reader.hxx>
@@ -118,6 +119,11 @@ static bool jbool(const val& o, const char* k, bool def) {
 
 // ── OCCT: STEP → surface mesh ─────────────────────────────────────────────────
 
+// Retained after tessellate_step so tessellate_for_meshing can re-tessellate
+// with quality parameters tuned to the requested element size.
+static TopoDS_Shape g_step_shape;
+static bool         g_has_step_shape = false;
+
 static std::string tessellate_step(val bytes_val, const std::string& opts_json) {
     val opts = parse_json(opts_json);
     double linear_defl  = jdouble(opts, "linear_deflection",  0.1);
@@ -147,6 +153,8 @@ static std::string tessellate_step(val bytes_val, const std::string& opts_json) 
         throw std::runtime_error("STEP file contains no transferable shapes");
 
     TopoDS_Shape shape = reader.OneShape();
+    g_step_shape     = shape;
+    g_has_step_shape = true;
 
     BRepMesh_IncrementalMesh mesher(shape, linear_defl, /*relative=*/false, angular_defl);
     mesher.Perform();
@@ -184,6 +192,73 @@ static std::string tessellate_step(val bytes_val, const std::string& opts_json) 
 
     if (verts.empty())
         throw std::runtime_error("shape produced no triangles — try a smaller linear_deflection");
+
+    return "{\"vertices\":" + json_vec3(verts) + ",\"triangles\":" + json_ivec3(tris) + "}";
+}
+
+// Re-tessellate the stored STEP shape with parameters tied to the target
+// element size.  The visualization tessellation (linear_deflection=0.1)
+// produces very many small triangles; passing that directly to Netgen's
+// advancing-front mesher can trigger memory-access crashes on complex geometry
+// because the size mismatch between surface triangles and volume elements
+// confuses Netgen's internal bookkeeping.
+//
+// Using linear_defl ≈ max_element_size/4 gives surface triangles roughly
+// the same scale as the volume elements, which is what Netgen expects.
+static std::string tessellate_for_meshing(const std::string& opts_json) {
+    if (!g_has_step_shape)
+        throw std::runtime_error(
+            "tessellate_for_meshing: no STEP shape loaded — call tessellate_step first");
+
+    val opts = parse_json(opts_json);
+    double max_size = jdouble(opts, "max_element_size", 10.0);
+
+    // Surface triangles at ~1/4 of the target element size; floor at 1.0 to
+    // avoid producing a surface finer than the viz tessellation.
+    double linear_defl  = std::max(1.0, max_size / 4.0);
+    double angular_defl = 0.3;
+
+    // BRepMesh_IncrementalMesh will skip faces whose stored deflection already
+    // satisfies the request.  Since we first tessellated with 0.1 (finer than
+    // max_size/4 for typical element sizes), we must clear first to force a
+    // coarser, more uniform re-tessellation.
+    BRepTools::Clean(g_step_shape);
+    BRepMesh_IncrementalMesh mesher(g_step_shape, linear_defl, /*relative=*/false, angular_defl);
+    mesher.Perform();
+    if (!mesher.IsDone())
+        throw std::runtime_error("BRepMesh_IncrementalMesh (mesh-quality) failed");
+
+    std::vector<double> verts;
+    std::vector<int>    tris;
+
+    for (TopExp_Explorer exp(g_step_shape, TopAbs_FACE); exp.More(); exp.Next()) {
+        TopoDS_Face face = TopoDS::Face(exp.Current());
+        TopLoc_Location loc;
+        Handle(Poly_Triangulation) tri = BRep_Tool::Triangulation(face, loc);
+        if (tri.IsNull()) continue;
+
+        int base = (int)(verts.size() / 3);
+
+        for (int i = 1; i <= tri->NbNodes(); ++i) {
+            gp_Pnt pt = tri->Node(i).Transformed(loc);
+            verts.push_back(pt.X());
+            verts.push_back(pt.Y());
+            verts.push_back(pt.Z());
+        }
+
+        bool rev = (face.Orientation() == TopAbs_REVERSED);
+        for (int i = 1; i <= tri->NbTriangles(); ++i) {
+            int n1, n2, n3;
+            tri->Triangle(i).Get(n1, n2, n3);
+            if (rev) std::swap(n2, n3);
+            tris.push_back(base + n1 - 1);
+            tris.push_back(base + n2 - 1);
+            tris.push_back(base + n3 - 1);
+        }
+    }
+
+    if (verts.empty())
+        throw std::runtime_error("mesh-quality tessellation produced no triangles");
 
     return "{\"vertices\":" + json_vec3(verts) + ",\"triangles\":" + json_ivec3(tris) + "}";
 }
@@ -278,15 +353,36 @@ static std::string generate_volume_mesh(
     }
 
     nglib::Ng_Meshing_Parameters mp;
-    mp.uselocalh        = uselocalh;
-    mp.maxh             = max_size;
-    mp.minh             = min_size;
-    mp.grading          = grading;
-    mp.elementsperedge  = elems_per_edge;
-    mp.elementspercurve = elems_per_curve;
-    mp.second_order     = second_ord ? 1 : 0;
-    mp.optsteps_2d      = optsteps_2d;
-    mp.optsteps_3d      = optsteps_3d;
+    // Initialise every field explicitly.  In the WASM build Netgen exports
+    // symbols in the global namespace while the re-declaration above is inside
+    // namespace nglib::, so Ng_Meshing_Parameters() may not link and leaves
+    // fields uninitialised.  Explicit assignment is correct regardless.
+    //
+    // check_overlap / check_overlapping_boundary are forced to 0: the Netgen
+    // default (1) crashes on complex STEP geometry with near-touching surfaces,
+    // and the JS deduplication step already produces a manifold mesh.
+    mp.uselocalh                  = uselocalh;
+    mp.maxh                       = max_size;
+    mp.minh                       = min_size;
+    mp.fineness                   = 0.5;
+    mp.grading                    = grading;
+    mp.elementsperedge            = elems_per_edge;
+    mp.elementspercurve           = elems_per_curve;
+    mp.closeedgeenable            = 0;
+    mp.closeedgefact              = 2.0;
+    mp.minedgelenenable           = 0;
+    mp.minedgelen                 = 1e-4;
+    mp.second_order               = second_ord ? 1 : 0;
+    mp.quad_dominated             = 0;
+    mp.meshsize_filename          = nullptr;
+    mp.optsurfmeshenable          = 1;
+    mp.optvolmeshenable           = 1;
+    mp.optsteps_3d                = optsteps_3d;
+    mp.optsteps_2d                = optsteps_2d;
+    mp.invert_tets                = 0;
+    mp.invert_trigs               = 0;
+    mp.check_overlap              = 0;
+    mp.check_overlapping_boundary = 0;
 
     nglib::Ng_Result res = nglib::Ng_GenerateVolumeMesh(mesh, &mp);
     if (res != nglib::NG_OK) {
@@ -533,8 +629,9 @@ static std::string step_to_fem_result(
 // ── Embind registrations ──────────────────────────────────────────────────────
 
 EMSCRIPTEN_BINDINGS(kofem) {
-    emscripten::function("tessellate_step",      &tessellate_step);
-    emscripten::function("generate_volume_mesh", &generate_volume_mesh);
-    emscripten::function("solve_linear_elastic", &solve_linear_elastic);
-    emscripten::function("step_to_fem_result",   &step_to_fem_result);
+    emscripten::function("tessellate_step",        &tessellate_step);
+    emscripten::function("tessellate_for_meshing", &tessellate_for_meshing);
+    emscripten::function("generate_volume_mesh",   &generate_volume_mesh);
+    emscripten::function("solve_linear_elastic",   &solve_linear_elastic);
+    emscripten::function("step_to_fem_result",     &step_to_fem_result);
 }

--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -604,7 +604,7 @@ function MeshPanel() {
 
       <div className={styles.tabContent}>
         {error && (
-          <div className={styles.errorBanner}>
+          <div className={styles.errorBanner} data-testid="meshing-error">
             <span>{error}</span>
             <button onClick={() => setError(null)}>×</button>
           </div>

--- a/web/src/components/toolbar/Toolbar.tsx
+++ b/web/src/components/toolbar/Toolbar.tsx
@@ -29,6 +29,7 @@ export function Toolbar() {
   const [isImportingStep, setIsImportingStep] = useState(false)
   const [isComputingVol, setIsComputingVol] = useState(false)
   const [isGeneratingReport, setIsGeneratingReport] = useState(false)
+  const [meshingError, setMeshingError] = useState<string | null>(null)
 
   const handleScreenshot = () => {
     const canvas = document.querySelector('canvas') as HTMLCanvasElement | null
@@ -82,6 +83,7 @@ export function Toolbar() {
   const handleComputeVolMesh = () => {
     if (!stepSurface) return
     setIsComputingVol(true)
+    setMeshingError(null)
     sendToWorker<{
       points: [number, number, number][]
       edges: [number, number][]
@@ -92,7 +94,7 @@ export function Toolbar() {
         setVolMesh({ points, edges })
         applyMeshResult(nodes, elements, modelName || 'STEP Mesh')
       })
-      .catch(err => alert(`Volume meshing failed: ${err.message}`))
+      .catch(err => setMeshingError(err instanceof Error ? err.message : String(err)))
       .finally(() => setIsComputingVol(false))
   }
 
@@ -132,6 +134,20 @@ export function Toolbar() {
         <span style={{ flex: 1 }}>STEP import failed: {stepImportError}</span>
         <button
           onClick={() => setStepImportError(null)}
+          aria-label="Dismiss error"
+          style={{ background: 'none', border: 'none', color: '#fff', cursor: 'pointer', fontSize: '16px', lineHeight: 1 }}
+        >×</button>
+      </div>
+    )}
+    {meshingError && (
+      <div
+        role="alert"
+        data-testid="toolbar-meshing-error"
+        style={{ background: '#c0392b', color: '#fff', padding: '6px 12px', fontSize: '13px', display: 'flex', gap: 8, alignItems: 'center' }}
+      >
+        <span style={{ flex: 1 }}>Volume meshing failed: {meshingError}</span>
+        <button
+          onClick={() => setMeshingError(null)}
           aria-label="Dismiss error"
           style={{ background: 'none', border: 'none', color: '#fff', cursor: 'pointer', fontSize: '16px', lineHeight: 1 }}
         >×</button>

--- a/web/src/wasm/pkg/kofem_wasm.d.ts
+++ b/web/src/wasm/pkg/kofem_wasm.d.ts
@@ -13,6 +13,13 @@ export default function init(
  */
 export function tessellate_step(step_bytes: Uint8Array, opts_json: string): string
 
+/** Re-tessellate the last loaded STEP shape with parameters scaled to the
+ *  target element size.  Must be called after tessellate_step.
+ *  @param opts_json JSON-serialised `{ max_element_size: number, … }` (same as generate_volume_mesh).
+ *  @returns JSON-serialised `{ vertices: [number,number,number][], triangles: [number,number,number][] }`.
+ */
+export function tessellate_for_meshing(opts_json: string): string
+
 /** Generate a quality tetrahedral volume mesh from a closed surface mesh.
  *  @param surface_json JSON-serialised `{ vertices: [number,number,number][], triangles: [number,number,number][] }`.
  *  @param opts_json    JSON-serialised `{ max_element_size: number, min_element_size: number, grading: number, second_order: boolean }`.

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -44,17 +44,26 @@ self.onmessage = async (event: MessageEvent) => {
       self.postMessage({ id, ok: true, points: dto.vertices, triangles: dto.triangles })
 
     } else if (type === 'volume_mesh') {
-      // payload.surface: { points: [number,number,number][], triangles: [number,number,number][] }
-      const surface = {
-        vertices: payload.surface.points as [number, number, number][],
-        triangles: payload.surface.triangles as [number, number, number][],
-      }
+      const opts = JSON.stringify({
+        max_element_size: 20.0, min_element_size: 3.0, grading: 0.5, second_order: false,
+        uselocalh: 0, elementsperedge: 1.0, elementspercurve: 1.0,
+        optsteps_2d: 0, optsteps_3d: 0,
+      })
 
-      self.postMessage({ id, log: `Surface: ${surface.vertices.length} vertices, ${surface.triangles.length} triangles` })
+      // Re-tessellate the stored STEP shape with parameters tuned to the
+      // target element size (linear_defl ≈ max_element_size/4).  The
+      // visualization tessellation (linear_deflection=0.1) produces many tiny
+      // triangles that are orders of magnitude smaller than the volume elements;
+      // this size mismatch triggers memory-access crashes in Netgen's
+      // advancing-front mesher on complex geometry.
+      self.postMessage({ id, log: 'Re-tessellating STEP shape for mesh quality…' })
+      const qualityJson = Module.tessellate_for_meshing(opts)
+      const qualityDto = JSON.parse(qualityJson) as { vertices: [number,number,number][]; triangles: [number,number,number][] }
+      const surface = { vertices: qualityDto.vertices, triangles: qualityDto.triangles }
+      self.postMessage({ id, log: `Quality surface: ${surface.vertices.length} vertices, ${surface.triangles.length} triangles` })
 
-      // OCCT tessellates each face independently, emitting duplicate vertices at shared
-      // edges. The resulting non-manifold surface causes Netgen's advancing-front to hang.
-      // Deduplicate by snapping to a 1e-4 grid and remapping triangle indices.
+      // OCCT tessellates each face independently, emitting duplicate vertices at
+      // shared edges.  Deduplicate by snapping to a 1e-4 grid.
       const PREC = 1e-4
       const keyFor = ([x, y, z]: [number, number, number]) =>
         `${Math.round(x / PREC)},${Math.round(y / PREC)},${Math.round(z / PREC)}`
@@ -71,12 +80,6 @@ self.onmessage = async (event: MessageEvent) => {
         .filter(([a, b, c]) => a !== b && b !== c && a !== c)
       self.postMessage({ id, log: `Deduped: ${surface.vertices.length}→${dedupVerts.length} vertices, ${surface.triangles.length}→${dedupTris.length} triangles` })
       const manifoldSurface = { vertices: dedupVerts, triangles: dedupTris }
-
-      const opts = JSON.stringify({
-        max_element_size: 20.0, min_element_size: 3.0, grading: 0.5, second_order: false,
-        uselocalh: 0, elementsperedge: 1.0, elementspercurve: 1.0,
-        optsteps_2d: 0, optsteps_3d: 0,
-      })
 
       self.postMessage({ id, log: 'Calling Netgen volume mesher…' })
 

--- a/web/tests/showcase.spec.ts
+++ b/web/tests/showcase.spec.ts
@@ -12,7 +12,7 @@ test.describe('Full workflow showcase', () => {
   })
 
   test('wall bracket: welcome → geometry → mesh → constraints → results', async ({ page }) => {
-    test.setTimeout(120_000)
+    test.setTimeout(360_000)
 
     if (!fs.existsSync(WALL_BRACKET)) {
       test.skip()
@@ -27,12 +27,6 @@ test.describe('Full workflow showcase', () => {
     })
     page.on('pageerror', err => console.error(`[showcase] page exception: ${err.message}`))
 
-    // ── Phase 1: Wall Bracket STEP — screenshots 1–4 ─────────────────────────
-    // Screenshots 1–4 use the real wall bracket geometry so the showcase shows
-    // an actual imported part. Volume meshing is intentionally skipped here
-    // because Netgen WASM takes several minutes on this geometry in CI; the mesh
-    // panel is captured showing the "Mesh STEP volume" control instead.
-
     await page.goto('/')
 
     // 1. Welcome screen
@@ -40,15 +34,15 @@ test.describe('Full workflow showcase', () => {
     await page.screenshot({ path: path.join(OUT_DIR, '01-select-geometry.png') })
     console.log(`[showcase] ${elapsed()} 01 screenshot done`)
 
-    // Import wall bracket — OCCT tessellation only, no volume mesh
+    // Import wall bracket
     console.log(`[showcase] ${elapsed()} importing Wall Bracket.stp`)
     await page.locator('input[type="file"][accept=".stp,.step"]').setInputFiles(WALL_BRACKET)
     await expect(page.getByText('Model geometry')).toBeVisible({ timeout: 60_000 })
     console.log(`[showcase] ${elapsed()} tessellation done`)
 
-    const errorBanner = page.getByTestId('step-error')
-    if (await errorBanner.isVisible()) {
-      throw new Error(`STEP import failed: ${await errorBanner.textContent()}`)
+    const stepErrorBanner = page.getByTestId('step-error')
+    if (await stepErrorBanner.isVisible()) {
+      throw new Error(`STEP import failed: ${await stepErrorBanner.textContent()}`)
     }
 
     await page.waitForTimeout(600)
@@ -57,57 +51,58 @@ test.describe('Full workflow showcase', () => {
     await page.screenshot({ path: path.join(OUT_DIR, '02-geometry-options.png') })
     console.log(`[showcase] ${elapsed()} 02 screenshot done`)
 
-    // 3. Mesh panel — volume mesh controls (not triggered)
+    // 3. Mesh panel — trigger volume meshing and wait for completion
     await page.locator('nav').getByRole('button').filter({ hasText: 'Mesh' }).click()
     await expect(page.getByRole('button').filter({ hasText: 'Mesh STEP volume' })).toBeVisible()
+    console.log(`[showcase] ${elapsed()} 03 clicking Mesh STEP volume…`)
+    await page.getByRole('button').filter({ hasText: 'Mesh STEP volume' }).click()
+
+    // Wait for either success ("Mesh is solver-ready") or a visible error banner.
+    // Race both so a failure fails the test immediately rather than timing out.
+    const meshingErrorBanner = page.getByTestId('meshing-error')
+    await Promise.race([
+      expect(page.getByText('Mesh is solver-ready')).toBeVisible({ timeout: 300_000 }),
+      meshingErrorBanner.waitFor({ state: 'visible', timeout: 300_000 })
+        .then(async () => {
+          throw new Error(`Volume meshing failed: ${await meshingErrorBanner.textContent()}`)
+        }),
+    ])
+    console.log(`[showcase] ${elapsed()} 03 volume mesh complete`)
     await page.screenshot({ path: path.join(OUT_DIR, '03-mesh-generation.png') })
     console.log(`[showcase] ${elapsed()} 03 screenshot done`)
 
-    // 4. Constraints panel
+    // 4. Apply BCs to the STEP volume mesh and show constraints panel.
+    // Find the mesh's long axis by bounding-box extents; fix the near face, load the far face.
+    await page.evaluate(() => {
+      type CoordNode = { id: number; x: number; y: number; z: number }
+      const store = (window as unknown as {
+        __kofemStore: {
+          getState(): {
+            nodes: CoordNode[]
+            applyBcToFace(ids: number[], dofs: number[], val: number): void
+            applyLoadToFace(ids: number[], dof: number, force: number): void
+          }
+        }
+      }).__kofemStore
+      const { nodes } = store.getState()
+
+      const axes = ['x', 'y', 'z'] as const
+      const ranges = axes.map(ax => {
+        const vals = nodes.map(n => n[ax])
+        return { ax, min: Math.min(...vals), max: Math.max(...vals) }
+      })
+      const { ax, min, max } = ranges.reduce((a, b) => (b.max - b.min > a.max - a.min ? b : a))
+      const tol = (max - min) * 0.01
+      const fixedIds = nodes.filter(n => n[ax] < min + tol).map(n => n.id)
+      const loadedIds = nodes.filter(n => n[ax] > max - tol).map(n => n.id)
+      store.getState().applyBcToFace(fixedIds, [0, 1, 2], 0)
+      store.getState().applyLoadToFace(loadedIds, 1, -2000)
+    })
+
     await page.locator('nav').getByRole('button').filter({ hasText: 'Constraints' }).click()
     await expect(page.getByText('Boundary conditions')).toBeVisible()
     await page.screenshot({ path: path.join(OUT_DIR, '04-load-application.png') })
     console.log(`[showcase] ${elapsed()} 04 screenshot done`)
-
-    // ── Phase 2: Wall Bracket simplified FEM — screenshot 5 ──────────────────
-    // Reload and inject a structured hex mesh with wall-bracket proportions
-    // (150 × 60 × 40 mm). BCs and loads are applied programmatically:
-    // min-X face fixed (wall mount), max-X face loaded in -Y (tip force).
-    // This avoids Netgen WASM while still demonstrating the full solve pipeline.
-
-    await page.goto('/')
-    await expect(page.getByRole('button', { name: 'Start with example' })).toBeVisible()
-
-    await page.evaluate(() => {
-      const store = (window as unknown as Record<string, unknown>).__kofemStore as {
-        getState(): {
-          nodes: { id: number; x: number; y: number; z: number }[]
-          startCustom(params: {
-            name: string; lx: number; ly: number; lz: number
-            nx: number; ny: number; nz: number
-          }): void
-          applyBcToFace(nodeIds: number[], dofs: number[], value: number): void
-          applyLoadToFace(nodeIds: number[], dof: number, totalForce: number): void
-        }
-      }
-      const state = store.getState()
-
-      // Build a wall-bracket proportioned hex mesh
-      state.startCustom({ name: 'Wall Bracket', lx: 0.15, ly: 0.06, lz: 0.04, nx: 6, ny: 3, nz: 2 })
-
-      const { nodes } = store.getState()
-      const xs = nodes.map(n => n.x)
-      const minX = Math.min(...xs), maxX = Math.max(...xs)
-      const tol = (maxX - minX) * 0.01
-
-      const fixedIds = nodes.filter(n => n.x < minX + tol).map(n => n.id)
-      const loadedIds = nodes.filter(n => n.x > maxX - tol).map(n => n.id)
-
-      state.applyBcToFace(fixedIds, [0, 1, 2], 0)
-      state.applyLoadToFace(loadedIds, 1, -2000)
-    })
-
-    await expect(page.getByText('Model geometry')).toBeVisible()
 
     // 5. Solve and results
     await page.locator('nav').getByRole('button').filter({ hasText: 'Solve' }).click()


### PR DESCRIPTION
## Summary

Fixes crashes in Netgen's advancing-front mesher on complex STEP geometry by re-tessellating the surface with parameters tuned to the target element size, rather than passing the fine visualization tessellation directly to the volume mesher.

## Problem

The initial STEP tessellation uses `linear_deflection=0.1` to produce a high-quality visualization mesh with many small triangles. When this mesh is passed directly to Netgen's volume mesher, the extreme size mismatch between surface triangles (orders of magnitude smaller than target volume elements) confuses Netgen's internal bookkeeping and triggers memory-access crashes on complex geometry.

## Solution

- **New `tessellate_for_meshing()` function** in `engine.cpp`: Re-tessellates the stored STEP shape with `linear_defl ≈ max_element_size/4`, producing surface triangles at roughly the same scale as the volume elements. Uses `BRepTools::Clean()` to force re-tessellation even if a finer mesh already exists.

- **Persistent STEP shape storage**: Global `g_step_shape` and `g_has_step_shape` retain the loaded geometry after initial tessellation so it can be re-tessellated with different parameters.

- **Updated solver worker**: Calls `tessellate_for_meshing()` before volume meshing instead of using the visualization surface directly.

- **Netgen parameter initialization**: Explicitly initializes all `Ng_Meshing_Parameters` fields (required for WASM build where symbols may not link correctly) and disables overlap checking (`check_overlap=0`, `check_overlapping_boundary=0`) which crashes on near-touching surfaces.

- **Test timeout increase**: Extended showcase test timeout from 120s to 360s to allow full volume meshing on the wall bracket geometry.

- **UI error handling**: Added persistent error banner for meshing failures instead of alert dialogs.

## Key Changes

- `engine/cpp/engine.cpp`: Added `#include <BRepTools.hxx>`, global shape storage, new `tessellate_for_meshing()` function, explicit Netgen parameter initialization
- `web/src/workers/solver.worker.ts`: Call `tessellate_for_meshing()` before volume meshing with mesh-quality parameters
- `web/src/components/toolbar/Toolbar.tsx`: Display meshing errors in persistent banner
- `web/src/components/panel/LeftPanel.tsx`: Add `data-testid` for error banner
- `web/src/wasm/pkg/kofem_wasm.d.ts`: Export new `tessellate_for_meshing()` function
- `web/tests/showcase.spec.ts`: Actually trigger volume meshing in the test and wait for completion; apply BCs to the resulting mesh

## Implementation Details

- Surface triangles are sized at `max(1.0, max_element_size / 4.0)` to avoid producing a surface finer than the visualization tessellation for small element sizes
- Deduplication of OCCT's per-face vertex duplication still occurs after re-tessellation
- The showcase test now exercises the full pipeline including volume meshing on real geometry

https://claude.ai/code/session_014Ar74HzX5ihsxCCzX2WnGD