### PR TITLE
fix(wasm): fix wasm-opt OOM + enable Netgen OCC in docker-build-wasm.sh

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -193,6 +193,7 @@ target_compile_options(kofem_wasm_emcc PRIVATE
 
 # Embind (--bind) + modularised ES6 output + exception support
 target_link_options(kofem_wasm_emcc PRIVATE
+    -O2   # cap at O2: Release default (-O3) OOMs wasm-opt on the combined OCCT+Netgen+MFEM binary
     --bind
     -fexceptions
     -sDISABLE_EXCEPTION_CATCHING=0

--- a/scripts/docker-build-wasm.sh
+++ b/scripts/docker-build-wasm.sh
@@ -220,11 +220,12 @@ if [ ! -f "${NETGEN_ROOT}/lib/libnglib.a" ]; then
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_CXX_FLAGS="-fPIC" \
         -DCMAKE_C_FLAGS="-fPIC" \
+        -DCMAKE_PREFIX_PATH="${OCCT_ROOT}" \
         -DUSE_SUPERBUILD=OFF \
         -DUSE_GUI=OFF \
         -DUSE_PYTHON=OFF \
         -DUSE_MPI=OFF \
-        -DUSE_OCC=OFF \
+        -DUSE_OCC=ON \
         -DUSE_NUMA=OFF \
         -DUSE_NATIVE_ARCH=OFF \
         -DBUILD_SHARED_LIBS=OFF \


### PR DESCRIPTION
## Problem

Two separate build failures in the WASM pipeline:

### 1. `wasm-opt` SIGKILL — issue #150
`cmake -DCMAKE_BUILD_TYPE=Release` sets `-O3` for the final emcc link step. wasm-opt then tries to run `-O3` over the combined OCCT + Netgen + MFEM binary (~50 MB unoptimised), which requires more RAM than most dev machines have free — Linux OOM-killer sends SIGKILL. The binaryen version mismatch warning (`expected 118, got 124`) is a separate, pre-existing warning from the emsdk version pinning.

### 2. `docker-build-wasm.sh` builds Netgen with `-DUSE_OCC=OFF`
Commit d1bd4e6 shipped `engine/CMakeLists.txt` with a `FATAL_ERROR` if Netgen OCC support isn't detected, but forgot to flip `-DUSE_OCC=OFF → ON` in `docker-build-wasm.sh`. Anyone building from scratch with the Docker helper would hit the cmake configure error before even reaching the link step.

## Fix

- **`engine/CMakeLists.txt`** — add `-O2` to `target_link_options`. This overrides the Release `-O3` for the wasm-opt pass, cutting peak memory use to a level that fits on typical 8–16 GB machines. The binary remains fully optimised by all other LLVM and binaryen passes.

- **`scripts/docker-build-wasm.sh`** — enable `-DUSE_OCC=ON` for the Netgen cmake build and add `-DCMAKE_PREFIX_PATH` so CMake can locate the already-compiled OCCT install. This matches what the `kofem-dependencies` CI image already provides.

closes #150

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKBXSZnayJU4KLRELps5Ne)_