### PR TITLE
Multi-face selection via shift-click for BC/load assignment

### DIFF
--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -718,6 +718,7 @@ function ConstraintsPanel() {
   const setPickMode = useModelStore((s) => s.setPickMode);
   const selectedFace = useModelStore((s) => s.selectedFace);
   const setSelectedFace = useModelStore((s) => s.setSelectedFace);
+  const pendingFaces = useModelStore((s) => s.pendingFaces);
   const createBcGroup = useModelStore((s) => s.createBcGroup);
   const addFaceToBcGroup = useModelStore((s) => s.addFaceToBcGroup);
   const removeFaceFromBcGroup = useModelStore((s) => s.removeFaceFromBcGroup);
@@ -738,33 +739,42 @@ function ConstraintsPanel() {
   const targetBcGroup = pickTargetGroupId !== null ? bcGroups.find(g => g.id === pickTargetGroupId) ?? null : null;
   const targetLoadGroup = pickTargetGroupId !== null ? loadGroups.find(g => g.id === pickTargetGroupId) ?? null : null;
 
+  // All faces picked in this session: pending (shift-clicked) + the current selection.
+  const allPickedFaces = selectedFace ? [...pendingFaces, selectedFace] : pendingFaces;
+
   function cancelPick() {
     setPickMode(null);
     setSelectedFace(null);
   }
 
   function applyBc() {
-    if (!selectedFace) return;
-    const faceLabel = `Face ${(targetBcGroup?.faces.length ?? 0) + 1}`;
-    const face = { label: faceLabel, nodeIds: selectedFace.nodeIds };
+    if (allPickedFaces.length === 0) return;
+    const existingCount = targetBcGroup?.faces.length ?? 0;
+    const faceEntries = allPickedFaces.map((f, i) => ({
+      label: `Face ${existingCount + i + 1}`,
+      nodeIds: f.nodeIds,
+    }));
     if (targetBcGroup) {
-      addFaceToBcGroup(targetBcGroup.id, face);
+      for (const fe of faceEntries) addFaceToBcGroup(targetBcGroup.id, fe);
     } else {
       const dofs = checkedDofs.map((c, i) => (c ? i : -1)).filter((i) => i >= 0);
-      createBcGroup(face, dofs, parseFloat(bcValue) || 0);
+      createBcGroup(faceEntries, dofs, parseFloat(bcValue) || 0);
     }
     setPickMode(null);
     setSelectedFace(null);
   }
 
   function applyLoad() {
-    if (!selectedFace) return;
-    const faceLabel = `Face ${(targetLoadGroup?.faces.length ?? 0) + 1}`;
-    const face = { label: faceLabel, nodeIds: selectedFace.nodeIds };
+    if (allPickedFaces.length === 0) return;
+    const existingCount = targetLoadGroup?.faces.length ?? 0;
+    const faceEntries = allPickedFaces.map((f, i) => ({
+      label: `Face ${existingCount + i + 1}`,
+      nodeIds: f.nodeIds,
+    }));
     if (targetLoadGroup) {
-      addFaceToLoadGroup(targetLoadGroup.id, face);
+      for (const fe of faceEntries) addFaceToLoadGroup(targetLoadGroup.id, fe);
     } else {
-      createLoadGroup(face, loadDof, parseFloat(loadForce) || 0);
+      createLoadGroup(faceEntries, loadDof, parseFloat(loadForce) || 0);
     }
     setPickMode(null);
     setSelectedFace(null);
@@ -799,13 +809,20 @@ function ConstraintsPanel() {
               <button className={styles.iconBtn} onClick={cancelPick} title="Cancel">✕</button>
             </div>
 
-            {!selectedFace ? (
+            {allPickedFaces.length === 0 ? (
               <div className={styles.pickHint}>Click a face in the 3D viewport</div>
             ) : (
-              <div className={styles.selectedFace}>{selectedFace.label}</div>
+              <div className={styles.selectedFace}>
+                {allPickedFaces.length === 1
+                  ? selectedFace?.label
+                  : `${allPickedFaces.length} faces selected`}
+              </div>
+            )}
+            {allPickedFaces.length > 0 && (
+              <div className={styles.pickHint}>Shift-click to add more faces</div>
             )}
 
-            {selectedFace && !targetBcGroup && (
+            {allPickedFaces.length > 0 && !targetBcGroup && (
               <>
                 <div className={styles.dofGrid}>
                   {DOF_LABELS.map((d, i) => (
@@ -833,8 +850,10 @@ function ConstraintsPanel() {
               </>
             )}
 
-            {selectedFace && targetBcGroup && (
-              <button className={styles.primaryBtn} onClick={applyBc}>Add Face</button>
+            {allPickedFaces.length > 0 && targetBcGroup && (
+              <button className={styles.primaryBtn} onClick={applyBc}>
+                {allPickedFaces.length === 1 ? "Add Face" : `Add ${allPickedFaces.length} Faces`}
+              </button>
             )}
           </div>
         )}
@@ -896,13 +915,20 @@ function ConstraintsPanel() {
               <button className={styles.iconBtn} onClick={cancelPick} title="Cancel">✕</button>
             </div>
 
-            {!selectedFace ? (
+            {allPickedFaces.length === 0 ? (
               <div className={styles.pickHint}>Click a face in the 3D viewport</div>
             ) : (
-              <div className={styles.selectedFace}>{selectedFace.label}</div>
+              <div className={styles.selectedFace}>
+                {allPickedFaces.length === 1
+                  ? selectedFace?.label
+                  : `${allPickedFaces.length} faces selected`}
+              </div>
+            )}
+            {allPickedFaces.length > 0 && (
+              <div className={styles.pickHint}>Shift-click to add more faces</div>
             )}
 
-            {selectedFace && !targetLoadGroup && (
+            {allPickedFaces.length > 0 && !targetLoadGroup && (
               <>
                 <div className={styles.formRow}>
                   <span className={styles.formLabel}>DOF</span>
@@ -927,15 +953,17 @@ function ConstraintsPanel() {
                   />
                 </div>
                 <div className={styles.pickNote}>
-                  {selectedFace.nodeIds.length} nodes →{" "}
-                  {(parseFloat(loadForce) / selectedFace.nodeIds.length).toFixed(1)} N/node
+                  {allPickedFaces.reduce((s, f) => s + f.nodeIds.length, 0)} nodes →{" "}
+                  {(parseFloat(loadForce) / allPickedFaces.reduce((s, f) => s + f.nodeIds.length, 0)).toFixed(1)} N/node
                 </div>
                 <button className={styles.loadBtn} onClick={applyLoad}>Apply Load</button>
               </>
             )}
 
-            {selectedFace && targetLoadGroup && (
-              <button className={styles.loadBtn} onClick={applyLoad}>Add Face</button>
+            {allPickedFaces.length > 0 && targetLoadGroup && (
+              <button className={styles.loadBtn} onClick={applyLoad}>
+                {allPickedFaces.length === 1 ? "Add Face" : `Add ${allPickedFaces.length} Faces`}
+              </button>
             )}
           </div>
         )}

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -3,6 +3,7 @@ import { Line } from '@react-three/drei'
 import * as THREE from 'three'
 import type { ThreeEvent } from '@react-three/fiber'
 import { useModelStore } from '../../store/modelStore'
+import type { Node } from '../../store/modelStore'
 
 const TARGET_DEFORM_FRACTION = 0.20
 // Face-picking uses two thresholds chosen by surface type (detected from the seed triangle):
@@ -11,6 +12,10 @@ const TARGET_DEFORM_FRACTION = 0.20
 // "Flat" means all immediate edge-neighbors of the seed share the same normal (< FLAT_ANGLE).
 const FLAT_ANGLE  = 15 * Math.PI / 180   // flat: normals must be within 15° of seed
 const CURVE_ANGLE = 89 * Math.PI / 180   // curved: stop only at near-perpendicular feature edges
+
+// Precomputed thresholds as cos values (absolute dot product >= threshold means "same surface").
+const COS_FLAT  = Math.cos(FLAT_ANGLE)
+const COS_CURVE = Math.cos(CURVE_ANGLE)
 
 // ── CHEXA geometry ────────────────────────────────────────────────────────────
 
@@ -64,6 +69,24 @@ function extractBoundaryTriFaceIds(tetElems: { nodeIds: number[] }[]): [number, 
   return [...faceMap.values()].filter(e => e.count === 1).map(e => e.face)
 }
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildFacePositions(
+  nodeIds: number[],
+  triangles: [number, number, number][],
+  nodeMap: Map<number, { n: Node; i: number }>,
+): Float32Array | null {
+  const nodeIdSet = new Set(nodeIds)
+  const positions: number[] = []
+  for (const [a, b, c] of triangles) {
+    if (!nodeIdSet.has(a) || !nodeIdSet.has(b) || !nodeIdSet.has(c)) continue
+    const na = nodeMap.get(a)?.n, nb = nodeMap.get(b)?.n, nc = nodeMap.get(c)?.n
+    if (!na || !nb || !nc) continue
+    positions.push(na.x, na.y, na.z, nb.x, nb.y, nb.z, nc.x, nc.y, nc.z)
+  }
+  return positions.length > 0 ? new Float32Array(positions) : null
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function MeshScene() {
@@ -76,8 +99,13 @@ export function MeshScene() {
   const volMesh = useModelStore(s => s.volMesh)
   const viewRepr = useModelStore(s => s.viewRepr)
   const pickMode = useModelStore(s => s.pickMode)
+  const pickTargetGroupId = useModelStore(s => s.pickTargetGroupId)
   const selectedFace = useModelStore(s => s.selectedFace)
+  const pendingFaces = useModelStore(s => s.pendingFaces)
   const setSelectedFace = useModelStore(s => s.setSelectedFace)
+  const setPendingFaces = useModelStore(s => s.setPendingFaces)
+  const bcGroups = useModelStore(s => s.bcGroups)
+  const loadGroups = useModelStore(s => s.loadGroups)
 
   const nodeMap = useMemo(
     () => new Map(nodes.map((n, i) => [n.id, { n, i }])),
@@ -138,7 +166,7 @@ export function MeshScene() {
       }
     }
 
-    // Per-triangle face normals
+    // Per-triangle face normals (using absolute direction — winding may be inconsistent)
     const triNormals = triangles.map(([a, b, c]) => {
       const na = nodeMap.get(a)?.n, nb = nodeMap.get(b)?.n, nc = nodeMap.get(c)?.n
       if (!na || !nb || !nc) return new THREE.Vector3(0, 1, 0)
@@ -255,26 +283,49 @@ export function MeshScene() {
     return { positions: new Float32Array(positions), normals: new Float32Array(normals) }
   }, [boundaryQuadFaceIds, boundaryTriFaceIds, nodeMap])
 
-  // Selected face highlight — build a triangle mesh from boundary triangles
-  // whose vertices are all in the selection, then render as a colour overlay.
+  // Selected face highlight — the current (latest) picked face in the active pick session.
   const selectedFacePositions = useMemo(() => {
     if (!selectedFace || !boundaryMeshTopo) return null
-    const nodeIdSet = new Set(selectedFace.nodeIds)
-    const positions: number[] = []
-    for (const [a, b, c] of boundaryMeshTopo.triangles) {
-      if (!nodeIdSet.has(a) || !nodeIdSet.has(b) || !nodeIdSet.has(c)) continue
-      const na = nodeMap.get(a)?.n, nb = nodeMap.get(b)?.n, nc = nodeMap.get(c)?.n
-      if (!na || !nb || !nc) continue
-      positions.push(na.x, na.y, na.z, nb.x, nb.y, nb.z, nc.x, nc.y, nc.z)
-    }
-    return positions.length > 0 ? new Float32Array(positions) : null
+    return buildFacePositions(selectedFace.nodeIds, boundaryMeshTopo.triangles, nodeMap)
   }, [selectedFace, boundaryMeshTopo, nodeMap])
+
+  // Pending faces — accumulated via shift-click during this pick session.
+  const pendingFacePositions = useMemo(() => {
+    if (pendingFaces.length === 0 || !boundaryMeshTopo) return null
+    const allNodeIds = pendingFaces.flatMap(f => f.nodeIds)
+    return buildFacePositions(allNodeIds, boundaryMeshTopo.triangles, nodeMap)
+  }, [pendingFaces, boundaryMeshTopo, nodeMap])
+
+  // BC face highlights — all committed faces across all BC groups.
+  // When in pick mode targeting a specific group, that group is highlighted separately (below).
+  const bcFaceHighlights = useMemo(() => {
+    if (!boundaryMeshTopo) return null
+    return bcGroups.flatMap(g =>
+      g.faces.map(f => ({
+        groupId: g.id,
+        positions: buildFacePositions(f.nodeIds, boundaryMeshTopo.triangles, nodeMap),
+      }))
+    ).filter(h => h.positions !== null) as { groupId: number; positions: Float32Array }[]
+  }, [bcGroups, boundaryMeshTopo, nodeMap])
+
+  // Load face highlights — all committed faces across all load groups.
+  const loadFaceHighlights = useMemo(() => {
+    if (!boundaryMeshTopo) return null
+    return loadGroups.flatMap(g =>
+      g.faces.map(f => ({
+        groupId: g.id,
+        positions: buildFacePositions(f.nodeIds, boundaryMeshTopo.triangles, nodeMap),
+      }))
+    ).filter(h => h.positions !== null) as { groupId: number; positions: Float32Array }[]
+  }, [loadGroups, boundaryMeshTopo, nodeMap])
 
   // Face picking handler — BFS flood-fill along boundary mesh topology.
   // Starting from the clicked triangle (e.faceIndex), expands to all adjacent
   // triangles whose normal differs by less than FEATURE_ANGLE_RAD. This selects
   // entire flat faces AND cylindrical / filleted surfaces in one click, while
   // stopping at sharp feature edges (e.g. where a cylinder meets its end cap).
+  // Uses absolute dot product for normal comparison to tolerate inconsistent
+  // winding order from the tet mesher.
   function handleFacePick(e: ThreeEvent<MouseEvent>) {
     if (!pickMode || e.faceIndex == null || !boundaryMeshTopo) return
     e.stopPropagation()
@@ -286,15 +337,15 @@ export function MeshScene() {
     const seedNormal = triNormals[startIdx]
 
     // Detect surface type: flat if the majority of edge-adjacent neighbors share the
-    // seed's normal (< FLAT_ANGLE). Using a majority vote prevents a single curved
-    // neighbor at the face boundary from misclassifying the seed as curved.
+    // seed's normal (abs dot product > cos(FLAT_ANGLE)). Using absolute dot product
+    // handles tet meshes where some boundary triangles may have reversed winding.
     const [sa, sb, sc] = triangles[startIdx]
     let flatCount = 0, curvedCount = 0
     for (const [x, y] of [[sa, sb], [sb, sc], [sc, sa]] as [number, number][]) {
       const key = x < y ? `${x},${y}` : `${y},${x}`
       for (const ni of edgeToTris.get(key) ?? []) {
         if (ni !== startIdx) {
-          if (seedNormal.angleTo(triNormals[ni]) < FLAT_ANGLE) flatCount++
+          if (Math.abs(seedNormal.dot(triNormals[ni])) > COS_FLAT) flatCount++
           else curvedCount++
         }
       }
@@ -315,12 +366,12 @@ export function MeshScene() {
         const key = x < y ? `${x},${y}` : `${y},${x}`
         for (const ni of edgeToTris.get(key) ?? []) {
           if (visited.has(ni)) continue
-          // Flat surface: keep candidates close to the seed normal (stops at any corner)
-          // Curved surface: step-to-step check only (handles cylinders and fillets)
-          const passes = isFlat
-            ? seedNormal.angleTo(triNormals[ni]) < FLAT_ANGLE
-            : n.angleTo(triNormals[ni]) < CURVE_ANGLE
-          if (passes) {
+          // Absolute dot product: handles both same and opposite winding.
+          // Flat: keep candidates close to the seed normal (stops at any corner).
+          // Curved: step-to-step check only (handles cylinders and fillets).
+          const absDot = Math.abs(isFlat ? seedNormal.dot(triNormals[ni]) : n.dot(triNormals[ni]))
+          const threshold = isFlat ? COS_FLAT : COS_CURVE
+          if (absDot > threshold) {
             visited.add(ni)
             queue.push(ni)
           }
@@ -337,12 +388,21 @@ export function MeshScene() {
     else if (ay >= ax && ay >= az) { axis = 'Y'; isMax = normal.y > 0 }
     else { axis = 'Z'; isMax = normal.z > 0 }
 
-    setSelectedFace({
+    const newFace = {
       nodeIds: faceNodeIds,
-      label: `face (${faceNodeIds.length} nodes)`,
+      label: `Face ${pendingFaces.length + 1} (${faceNodeIds.length} nodes)`,
       axis,
       isMax,
-    })
+    }
+
+    // Shift-click: move the current selectedFace into pendingFaces, then set new pick.
+    // Regular click: start fresh (clear pending).
+    if (e.nativeEvent.shiftKey && selectedFace) {
+      setPendingFaces([...pendingFaces, selectedFace])
+    } else if (!e.nativeEvent.shiftKey) {
+      setPendingFaces([])
+    }
+    setSelectedFace(newFace)
   }
 
   // BC marker: centroid + quaternion that orients triangles outward from the model
@@ -490,13 +550,55 @@ export function MeshScene() {
         </lineSegments>
       )}
 
-      {/* Selected face highlight — colour overlay on the exact picked triangles */}
+      {/* BC face highlights — persistent coloured overlay for all committed BC faces */}
+      {bcFaceHighlights?.map((h, i) => (
+        <mesh key={`bc-face-${h.groupId}-${i}`} renderOrder={1}>
+          <bufferGeometry>
+            <bufferAttribute attach="attributes-position" args={[h.positions, 3]} />
+          </bufferGeometry>
+          <meshBasicMaterial
+            color="#dc2626"
+            transparent
+            opacity={pickTargetGroupId === h.groupId ? 0.45 : 0.25}
+            depthTest={false}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      ))}
+
+      {/* Load face highlights — persistent coloured overlay for all committed load faces */}
+      {loadFaceHighlights?.map((h, i) => (
+        <mesh key={`load-face-${h.groupId}-${i}`} renderOrder={1}>
+          <bufferGeometry>
+            <bufferAttribute attach="attributes-position" args={[h.positions, 3]} />
+          </bufferGeometry>
+          <meshBasicMaterial
+            color="#d97706"
+            transparent
+            opacity={pickTargetGroupId === h.groupId ? 0.45 : 0.25}
+            depthTest={false}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      ))}
+
+      {/* Pending faces — accumulated via shift-click, same colour as selection but slightly dimmer */}
+      {pendingFacePositions && (
+        <mesh renderOrder={2}>
+          <bufferGeometry>
+            <bufferAttribute attach="attributes-position" args={[pendingFacePositions, 3]} />
+          </bufferGeometry>
+          <meshBasicMaterial color="#e05533" transparent opacity={0.45} depthTest={false} side={THREE.DoubleSide} />
+        </mesh>
+      )}
+
+      {/* Selected face highlight — the latest picked face (brightest) */}
       {selectedFacePositions && (
-        <mesh renderOrder={1}>
+        <mesh renderOrder={3}>
           <bufferGeometry>
             <bufferAttribute attach="attributes-position" args={[selectedFacePositions, 3]} />
           </bufferGeometry>
-          <meshBasicMaterial color="#e05533" transparent opacity={0.55} depthTest={false} side={THREE.DoubleSide} />
+          <meshBasicMaterial color="#e05533" transparent opacity={0.65} depthTest={false} side={THREE.DoubleSide} />
         </mesh>
       )}
 

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -309,6 +309,7 @@ interface ModelState {
   pickMode: 'bc' | 'load' | null
   pickTargetGroupId: number | null   // null = creating new group; id = adding to existing
   selectedFace: FaceSelection | null
+  pendingFaces: FaceSelection[]      // faces accumulated via shift-click within a pick session
 
   // Named BC / Load groups (primary source of truth for constraints & loads)
   bcGroups: NamedBcGroup[]
@@ -358,16 +359,17 @@ interface ModelState {
   // Pick mode / face selection
   setPickMode(mode: 'bc' | 'load' | null, targetGroupId?: number | null): void
   setSelectedFace(face: FaceSelection | null): void
+  setPendingFaces(faces: FaceSelection[]): void
 
   // BC group actions
-  createBcGroup(face: Omit<BcFaceEntry, 'id'>, dofs: number[], value: number): void
+  createBcGroup(faces: Omit<BcFaceEntry, 'id'>[], dofs: number[], value: number): void
   addFaceToBcGroup(groupId: number, face: Omit<BcFaceEntry, 'id'>): void
   removeFaceFromBcGroup(groupId: number, faceId: number): void
   deleteBcGroup(id: number): void
   clearConstraints(): void
 
   // Load group actions
-  createLoadGroup(face: Omit<BcFaceEntry, 'id'>, dof: number, totalForce: number): void
+  createLoadGroup(faces: Omit<BcFaceEntry, 'id'>[], dof: number, totalForce: number): void
   addFaceToLoadGroup(groupId: number, face: Omit<BcFaceEntry, 'id'>): void
   removeFaceFromLoadGroup(groupId: number, faceId: number): void
   deleteLoadGroup(id: number): void
@@ -413,6 +415,7 @@ export const useModelStore = create<ModelState>()(
     pickMode: null,
     pickTargetGroupId: null,
     selectedFace: null,
+    pendingFaces: [] as FaceSelection[],
     fitViewTrigger: 0,
 
     setStepImportError: (msg) => set(s => { s.stepImportError = msg }),
@@ -444,7 +447,7 @@ export const useModelStore = create<ModelState>()(
       s.modelName = 'Cantilever Beam'
       s.geometries = [DEFAULT_GEOMETRY]
       s.result = null; s.stepSurface = null; s.volMesh = null
-      s.viewRepr = 'surface'; s.selectedFace = null; s.pickMode = null; s.pickTargetGroupId = null
+      s.viewRepr = 'surface'; s.selectedFace = null; s.pendingFaces = []; s.pickMode = null; s.pickTargetGroupId = null
       s.hasStarted = true; s.mode = 'geometry'
       s.fitViewTrigger++
     }),
@@ -467,7 +470,7 @@ export const useModelStore = create<ModelState>()(
       }]
       s.nextGeomId = 2
       s.result = null; s.stepSurface = null; s.volMesh = null
-      s.viewRepr = 'surface'; s.selectedFace = null; s.pickMode = null; s.pickTargetGroupId = null
+      s.viewRepr = 'surface'; s.selectedFace = null; s.pendingFaces = []; s.pickMode = null; s.pickTargetGroupId = null
       s.hasStarted = true; s.mode = 'geometry'
       s.fitViewTrigger++
     }),
@@ -487,7 +490,7 @@ export const useModelStore = create<ModelState>()(
       s.constraints = []; s.loads = []
       s.nextBcGroupId = 1; s.nextLoadGroupId = 1; s.nextFaceEntryId = 1
       s.result = null
-      s.selectedFace = null
+      s.selectedFace = null; s.pendingFaces = []
       s.pickMode = null; s.pickTargetGroupId = null
       s.modelName = name
       s.viewRepr = 'surface'
@@ -597,20 +600,22 @@ export const useModelStore = create<ModelState>()(
     setPickMode: (mode: 'bc' | 'load' | null, targetGroupId: number | null = null) => set(s => {
       s.pickMode = mode
       s.pickTargetGroupId = mode !== null ? (targetGroupId ?? null) : null
-      if (mode === null) s.selectedFace = null
+      if (mode === null) { s.selectedFace = null; s.pendingFaces = [] }
     }),
 
     setSelectedFace: (face: FaceSelection | null) => set(s => { s.selectedFace = face }),
 
+    setPendingFaces: (faces: FaceSelection[]) => set(s => { s.pendingFaces = faces }),
+
     // BC group actions
-    createBcGroup: (face: Omit<BcFaceEntry, 'id'>, dofs: number[], value: number) => set(s => {
-      const faceId = s.nextFaceEntryId++
+    createBcGroup: (faces: Omit<BcFaceEntry, 'id'>[], dofs: number[], value: number) => set(s => {
+      const faceEntries = faces.map(f => ({ id: s.nextFaceEntryId++, label: f.label, nodeIds: f.nodeIds }))
       s.bcGroups.push({
         id: s.nextBcGroupId,
         name: `BC${s.nextBcGroupId}`,
         dofs,
         value,
-        faces: [{ id: faceId, label: face.label, nodeIds: face.nodeIds }],
+        faces: faceEntries,
       })
       s.nextBcGroupId++
       s.constraints = rebuildConstraints(s.bcGroups)
@@ -648,14 +653,14 @@ export const useModelStore = create<ModelState>()(
     }),
 
     // Load group actions
-    createLoadGroup: (face: Omit<BcFaceEntry, 'id'>, dof: number, totalForce: number) => set(s => {
-      const faceId = s.nextFaceEntryId++
+    createLoadGroup: (faces: Omit<BcFaceEntry, 'id'>[], dof: number, totalForce: number) => set(s => {
+      const faceEntries = faces.map(f => ({ id: s.nextFaceEntryId++, label: f.label, nodeIds: f.nodeIds }))
       s.loadGroups.push({
         id: s.nextLoadGroupId,
         name: `Load${s.nextLoadGroupId}`,
         dof,
         totalForce,
-        faces: [{ id: faceId, label: face.label, nodeIds: face.nodeIds }],
+        faces: faceEntries,
       })
       s.nextLoadGroupId++
       s.loads = rebuildLoads(s.loadGroups)

--- a/web/tests/showcase.spec.ts
+++ b/web/tests/showcase.spec.ts
@@ -101,8 +101,8 @@ test.describe('Full workflow showcase', () => {
         __kofemStore: {
           getState(): {
             nodes: CoordNode[]
-            createBcGroup(face: FaceEntry, dofs: number[], val: number): void
-            createLoadGroup(face: FaceEntry, dof: number, force: number): void
+            createBcGroup(faces: FaceEntry[], dofs: number[], val: number): void
+            createLoadGroup(faces: FaceEntry[], dof: number, force: number): void
           }
         }
       }).__kofemStore
@@ -117,8 +117,8 @@ test.describe('Full workflow showcase', () => {
       const tol = (max - min) * 0.01
       const fixedIds = nodes.filter(n => n[ax] < min + tol).map(n => n.id)
       const loadedIds = nodes.filter(n => n[ax] > max - tol).map(n => n.id)
-      store.getState().createBcGroup({ label: 'Face 1', nodeIds: fixedIds }, [0, 1, 2], 0)
-      store.getState().createLoadGroup({ label: 'Face 1', nodeIds: loadedIds }, 1, -2000)
+      store.getState().createBcGroup([{ label: 'Face 1', nodeIds: fixedIds }], [0, 1, 2], 0)
+      store.getState().createLoadGroup([{ label: 'Face 1', nodeIds: loadedIds }], 1, -2000)
     })
 
     await page.locator('nav').getByRole('button').filter({ hasText: 'Constraints' }).click()


### PR DESCRIPTION
## Summary

Adds support for accumulating multiple face selections via shift-click during a single pick session, allowing users to assign boundary conditions and loads to multiple faces at once. This improves the workflow for constraining or loading complex geometries with many distinct surfaces.

## Key Changes

- **Multi-face accumulation:** Shift-click now adds the current selection to a `pendingFaces` list instead of replacing it. Regular clicks clear pending and start fresh.
- **Store state:** Added `pendingFaces: FaceSelection[]` to `ModelState` and `setPendingFaces()` action to track accumulated selections.
- **Viewport rendering:** 
  - Pending faces render with a dimmer overlay (opacity 0.45) at `renderOrder={2}`
  - Selected face (latest pick) renders brightest (opacity 0.65) at `renderOrder={3}`
  - BC and load group faces render persistently at lower opacity, with higher opacity when that group is the active pick target
- **Batch application:** `createBcGroup()` and `createLoadGroup()` now accept arrays of faces instead of single faces, enabling multi-face group creation in one action.
- **UI updates:** 
  - Pick hint now shows "Shift-click to add more faces" when faces are selected
  - Face count display shows "N faces selected" when multiple faces are picked
  - Apply buttons update text to "Add N Faces" for batch operations
  - Load force distribution calculation now sums across all picked faces
- **Normal comparison fix:** Replaced angle-based normal comparison with absolute dot product to handle inconsistent winding order from the tet mesher. Precomputed `COS_FLAT` and `COS_CURVE` thresholds for efficiency.
- **Helper function:** Extracted `buildFacePositions()` to reduce duplication when building geometry for face highlights.

## Implementation Details

- Face labeling now reflects position in the session: "Face 1", "Face 2", etc., resetting on each new pick session.
- Pending faces are cleared when exiting pick mode or starting a new pick session (non-shift click).
- BC/load group highlights use red (#dc2626) and orange (#d97706) respectively, with opacity varying by pick target.
- All face selection state is properly reset in `resetModel()` and `loadModel()` to prevent stale data.

https://claude.ai/code/session_01A8iDgMCDsz7tnviu4X9ngM