### PR TITLE
Add native stub implementations for OCCT, Netgen, and MFEM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ name = "kofem-mesh"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/kofem-core/src/solver/mfem.rs
+++ b/crates/kofem-core/src/solver/mfem.rs
@@ -1,0 +1,36 @@
+// Native MFEM bridge — not implemented yet.
+// The production solver runs via the WASM build: see engine/cpp/engine.cpp.
+use super::{FemResult, FemSolver, SolverError};
+use crate::{BoundaryConditions, LinearElasticMaterial};
+use kofem_mesh::VolumeMesh;
+
+#[derive(Debug, Clone)]
+pub struct MfemParams {
+    /// FE polynomial order (1 = linear, 2 = quadratic).
+    pub order: i32,
+}
+
+pub struct MfemSolver {
+    params: MfemParams,
+}
+
+impl MfemSolver {
+    pub fn new(params: MfemParams) -> Self {
+        Self { params }
+    }
+}
+
+impl FemSolver for MfemSolver {
+    fn solve_linear_elastic(
+        &self,
+        _mesh: &VolumeMesh,
+        _material: &LinearElasticMaterial,
+        _bcs: &BoundaryConditions,
+    ) -> Result<FemResult, SolverError> {
+        let _ = &self.params;
+        unimplemented!(
+            "Native MFEM solver is not implemented. \
+             Use the WASM build produced by engine/cpp/engine.cpp via scripts/build-wasm.sh."
+        )
+    }
+}

--- a/crates/kofem-core/src/solver/mod.rs
+++ b/crates/kofem-core/src/solver/mod.rs
@@ -1,3 +1,5 @@
+pub mod mfem;
+
 use crate::{BoundaryConditions, LinearElasticMaterial};
 use kofem_mesh::VolumeMesh;
 use thiserror::Error;

--- a/crates/kofem-geom/src/lib.rs
+++ b/crates/kofem-geom/src/lib.rs
@@ -1,5 +1,42 @@
 use thiserror::Error;
 
+// Native OCCT bridge — not implemented yet.
+// The production pipeline runs via the WASM build: see engine/cpp/engine.cpp.
+
+/// Opaque handle to a loaded CAD model. Not usable in native builds.
+pub struct OcctModel;
+
+/// Surface tessellation produced by OCCT — vertices + triangle indices.
+pub struct Tessellation {
+    pub vertices: Vec<[f64; 3]>,
+    pub triangles: Vec<[usize; 3]>,
+}
+
+/// Load a STEP file into an [`OcctModel`].
+///
+/// # Panics
+/// Always panics on native targets. Use the WASM build via `scripts/build-wasm.sh`.
+pub fn load_step(_bytes: &[u8]) -> Result<OcctModel, GeomError> {
+    unimplemented!(
+        "Native OCCT bridge is not implemented. \
+         Use the WASM build produced by engine/cpp/engine.cpp via scripts/build-wasm.sh."
+    )
+}
+
+/// Tessellate an [`OcctModel`] into a surface triangle mesh.
+///
+/// # Panics
+/// Always panics on native targets. Use the WASM build via `scripts/build-wasm.sh`.
+pub fn tessellate_model(
+    _model: &OcctModel,
+    _opts: &TessOptions,
+) -> Result<Tessellation, GeomError> {
+    unimplemented!(
+        "Native OCCT bridge is not implemented. \
+         Use the WASM build produced by engine/cpp/engine.cpp via scripts/build-wasm.sh."
+    )
+}
+
 #[derive(Debug, Error)]
 pub enum GeomError {
     #[error("failed to load geometry: {0}")]

--- a/crates/kofem-mesh/Cargo.toml
+++ b/crates/kofem-mesh/Cargo.toml
@@ -8,3 +8,4 @@ description = "Shared mesh types for the KoFEM pipeline (SurfaceMesh, VolumeMesh
 
 [dependencies]
 serde = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/kofem-mesh/src/lib.rs
+++ b/crates/kofem-mesh/src/lib.rs
@@ -1,2 +1,24 @@
 pub mod types;
 pub use types::{MeshOptions, SurfaceMesh, VolumeMesh};
+
+use thiserror::Error;
+
+// Native Netgen bridge — not implemented yet.
+// The production pipeline runs via the WASM build: see engine/cpp/engine.cpp.
+
+#[derive(Debug, Error)]
+pub enum MeshError {
+    #[error("meshing failed: {0}")]
+    MeshingFailed(String),
+}
+
+/// Generate a tetrahedral volume mesh from a closed surface mesh using Netgen.
+///
+/// # Panics
+/// Always panics on native targets. Use the WASM build via `scripts/build-wasm.sh`.
+pub fn mesh_volume(_surface: &SurfaceMesh, _opts: &MeshOptions) -> Result<VolumeMesh, MeshError> {
+    unimplemented!(
+        "Native Netgen bridge is not implemented. \
+         Use the WASM build produced by engine/cpp/engine.cpp via scripts/build-wasm.sh."
+    )
+}


### PR DESCRIPTION
## Summary

Add placeholder native implementations for the three core C++ library bridges (OCCT geometry, Netgen meshing, MFEM solver) that panic with helpful error messages directing users to the WASM build. This establishes the module structure and trait implementations needed for the native pipeline while making it clear that the production path is via the browser-based WASM build.

## Changes

- **kofem-geom**: Add `OcctModel`, `Tessellation` types and `load_step()` / `tessellate_model()` functions that unimplemented!() with guidance to use WASM build
- **kofem-mesh**: Add `MeshError` enum and `mesh_volume()` function with same unimplemented!() pattern; add `thiserror` dependency
- **kofem-core/solver**: Create new `mfem` module with `MfemParams`, `MfemSolver` struct implementing the `FemSolver` trait; `solve_linear_elastic()` unimplemented!()
- **kofem-core/solver/mod.rs**: Export the new `mfem` module

## Implementation Details

All three modules follow the same pattern:
- Public types and functions match the expected API surface
- Functions accept the required parameters but ignore them (prefixed with `_`)
- `unimplemented!()` panics with a consistent error message pointing to `engine/cpp/engine.cpp` and `scripts/build-wasm.sh`
- Comments clarify that the native bridge is a stub and production runs via WASM

This establishes the trait and type contracts needed for downstream code (e.g., `kofem-py`) to compile and call these modules, while making the WASM-first architecture explicit.

https://claude.ai/code/session_01R95Aq3rFDji7xB7Dz2oKLi