### PR TITLE
Replace unimplemented!() panics with proper error returns

### DIFF
--- a/crates/kofem-core/src/solver/mfem.rs
+++ b/crates/kofem-core/src/solver/mfem.rs
@@ -28,9 +28,10 @@ impl FemSolver for MfemSolver {
         _bcs: &BoundaryConditions,
     ) -> Result<FemResult, SolverError> {
         let _ = &self.params;
-        unimplemented!(
-            "Native MFEM solver is not implemented. \
+        Err(SolverError::Internal(
+            "Native MFEM solver is not yet implemented. \
              Use the WASM build produced by engine/cpp/engine.cpp via scripts/build-wasm.sh."
-        )
+                .to_string(),
+        ))
     }
 }

--- a/crates/kofem-geom/src/lib.rs
+++ b/crates/kofem-geom/src/lib.rs
@@ -14,27 +14,31 @@ pub struct Tessellation {
 
 /// Load a STEP file into an [`OcctModel`].
 ///
-/// # Panics
-/// Always panics on native targets. Use the WASM build via `scripts/build-wasm.sh`.
+/// # Errors
+/// Always returns [`GeomError::LoadFailed`] on native targets — the OCCT bridge is not yet
+/// implemented. Use the WASM build via `scripts/build-wasm.sh`.
 pub fn load_step(_bytes: &[u8]) -> Result<OcctModel, GeomError> {
-    unimplemented!(
-        "Native OCCT bridge is not implemented. \
+    Err(GeomError::LoadFailed(
+        "Native OCCT bridge is not yet implemented. \
          Use the WASM build produced by engine/cpp/engine.cpp via scripts/build-wasm.sh."
-    )
+            .to_string(),
+    ))
 }
 
 /// Tessellate an [`OcctModel`] into a surface triangle mesh.
 ///
-/// # Panics
-/// Always panics on native targets. Use the WASM build via `scripts/build-wasm.sh`.
+/// # Errors
+/// Always returns [`GeomError::TessFailed`] on native targets — the OCCT bridge is not yet
+/// implemented. Use the WASM build via `scripts/build-wasm.sh`.
 pub fn tessellate_model(
     _model: &OcctModel,
     _opts: &TessOptions,
 ) -> Result<Tessellation, GeomError> {
-    unimplemented!(
-        "Native OCCT bridge is not implemented. \
+    Err(GeomError::TessFailed(
+        "Native OCCT bridge is not yet implemented. \
          Use the WASM build produced by engine/cpp/engine.cpp via scripts/build-wasm.sh."
-    )
+            .to_string(),
+    ))
 }
 
 #[derive(Debug, Error)]

--- a/crates/kofem-mesh/src/lib.rs
+++ b/crates/kofem-mesh/src/lib.rs
@@ -14,11 +14,13 @@ pub enum MeshError {
 
 /// Generate a tetrahedral volume mesh from a closed surface mesh using Netgen.
 ///
-/// # Panics
-/// Always panics on native targets. Use the WASM build via `scripts/build-wasm.sh`.
+/// # Errors
+/// Always returns [`MeshError::MeshingFailed`] on native targets — the Netgen bridge is not yet
+/// implemented. Use the WASM build via `scripts/build-wasm.sh`.
 pub fn mesh_volume(_surface: &SurfaceMesh, _opts: &MeshOptions) -> Result<VolumeMesh, MeshError> {
-    unimplemented!(
-        "Native Netgen bridge is not implemented. \
+    Err(MeshError::MeshingFailed(
+        "Native Netgen bridge is not yet implemented. \
          Use the WASM build produced by engine/cpp/engine.cpp via scripts/build-wasm.sh."
-    )
+            .to_string(),
+    ))
 }


### PR DESCRIPTION
## Summary

Replace three `unimplemented!()` macro calls with proper `Result` error returns in the native (non-WASM) code paths. This allows graceful error handling instead of panics when users attempt to use native builds without the required C++ bridges.

## Changes

- **kofem-geom**: `load_step()` now returns `GeomError::LoadFailed` instead of panicking
- **kofem-geom**: `tessellate_model()` now returns `GeomError::TessFailed` instead of panicking  
- **kofem-mesh**: `mesh_volume()` now returns `MeshError::MeshingFailed` instead of panicking
- **kofem-core**: `MfemSolver::solve()` now returns `SolverError::Internal` instead of panicking

Updated all corresponding doc comments from `# Panics` to `# Errors` to reflect the new behavior.

## Implementation Details

Each function now constructs an appropriate error variant with a descriptive message directing users to the WASM build via `scripts/build-wasm.sh`. Error messages use "not yet implemented" to clarify that these are planned features rather than unsupported operations.

This change improves the user experience by providing clear, actionable error messages instead of runtime panics when the native C++ bridges are unavailable.

https://claude.ai/code/session_01Uh1s4TRQtYT1nBko6uFtv8