### PR TITLE
Add result type selector and von Mises stress visualization

### DIFF
--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -1124,7 +1124,7 @@ function SolvePanel() {
 
   function handleSolve() {
     setRunning(true);
-    sendToWorker<{ displacements: number[] }>("solve", {
+    sendToWorker<{ displacements: number[]; vonMises: number[] }>("solve", {
       nodes,
       elements,
       materials,
@@ -1132,8 +1132,11 @@ function SolvePanel() {
       constraints,
       loads,
     })
-      .then(({ displacements }) => {
-        setResult({ displacements: new Float64Array(displacements) });
+      .then(({ displacements, vonMises }) => {
+        setResult({
+          displacements: new Float64Array(displacements),
+          vonMises: vonMises ? new Float64Array(vonMises) : undefined,
+        });
         setMode("results");
       })
       .catch((err) => {

--- a/web/src/components/results/ResultsPanel.tsx
+++ b/web/src/components/results/ResultsPanel.tsx
@@ -1,13 +1,12 @@
-import { useModelStore } from '../../store/modelStore'
+import { useModelStore, RESULT_TYPES } from '../../store/modelStore'
 import styles from './ResultsPanel.module.css'
-
-const MAX_X_TOL = 1e-6  // tolerance for finding nodes at the max-X face
-
-const RESULT_TYPES = ['Displacement (magnitude)', 'Ux', 'Uy', 'Uz', 'Von Mises stress'] as const
 
 export function ResultsPanel() {
   const result = useModelStore(s => s.result)
+  const resultType = useModelStore(s => s.resultType)
+  const setResultType = useModelStore(s => s.setResultType)
   const nodes = useModelStore(s => s.nodes)
+  const elements = useModelStore(s => s.elements)
 
   if (!result) {
     return (
@@ -18,39 +17,107 @@ export function ResultsPanel() {
     )
   }
 
-
   const d = result.displacements
-  const maxAbsDisp = Math.max(...Array.from(d).map(Math.abs))
 
-  // Average Uy over nodes at the max-X face (within tolerance)
-  const maxX = nodes.reduce((m, n) => Math.max(m, n.x), -Infinity)
-  const tipNodes = nodes
-    .map((n, i) => ({ i, n }))
-    .filter(({ n }) => n.x >= maxX - MAX_X_TOL)
-  const tipUy = tipNodes.length > 0
-    ? tipNodes.reduce((sum, { i }) => sum + (d[i * 3 + 1] ?? 0), 0) / tipNodes.length
-    : 0
+  // Per-component min/max stats
+  const stats = (() => {
+    const n = nodes.length
+    if (n === 0) return null
 
-  // CHEXA cantilever: P=10 kN, L=1 m, h=0.1 m square section → I = h⁴/12
-  const P = 10_000, E = 210e9, h = 0.1
-  const I = h ** 4 / 12
-  const theory = -P / (3 * E * I)
+    let minMag = Infinity, maxMag = -Infinity
+    let minUx = Infinity, maxUx = -Infinity
+    let minUy = Infinity, maxUy = -Infinity
+    let minUz = Infinity, maxUz = -Infinity
+
+    for (let i = 0; i < n; i++) {
+      const ux = d[i * 3] ?? 0
+      const uy = d[i * 3 + 1] ?? 0
+      const uz = d[i * 3 + 2] ?? 0
+      const mag = Math.sqrt(ux * ux + uy * uy + uz * uz)
+      if (mag < minMag) minMag = mag
+      if (mag > maxMag) maxMag = mag
+      if (ux < minUx) minUx = ux
+      if (ux > maxUx) maxUx = ux
+      if (uy < minUy) minUy = uy
+      if (uy > maxUy) maxUy = uy
+      if (uz < minUz) minUz = uz
+      if (uz > maxUz) maxUz = uz
+    }
+    return { minMag, maxMag, minUx, maxUx, minUy, maxUy, minUz, maxUz }
+  })()
+
+  // Per-node von Mises (averaged from element values)
+  const vmStats = (() => {
+    if (!result.vonMises || elements.length === 0 || nodes.length === 0) return null
+    const vm = result.vonMises
+    let minVm = Infinity, maxVm = -Infinity
+
+    // Build nodeIndex map: nodeId → flat index in nodes array
+    const nodeIndex = new Map<number, number>()
+    for (let i = 0; i < nodes.length; i++) nodeIndex.set(nodes[i].id, i)
+    const sums = new Float64Array(nodes.length)
+    const counts = new Int32Array(nodes.length)
+    for (let ei = 0; ei < elements.length; ei++) {
+      const vmVal = vm[ei] ?? 0
+      for (const nodeId of elements[ei].nodeIds) {
+        const ni = nodeIndex.get(nodeId)
+        if (ni !== undefined) {
+          sums[ni as number] += vmVal
+          counts[ni as number]++
+        }
+      }
+    }
+    for (let i = 0; i < nodes.length; i++) {
+      const v = counts[i] > 0 ? sums[i] / counts[i] : 0
+      if (v < minVm) minVm = v
+      if (v > maxVm) maxVm = v
+    }
+    return { minVm, maxVm }
+  })()
 
   return (
     <div className={styles.panel}>
       <div className={styles.title}>Results</div>
-      <select className={styles.select}>
-        {RESULT_TYPES.map(t => <option key={t}>{t}</option>)}
+      <select
+        className={styles.select}
+        value={resultType}
+        onChange={e => setResultType(e.target.value as typeof RESULT_TYPES[number])}
+      >
+        {RESULT_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
       </select>
-      <div className={styles.stat}>
-        Max |displacement|: {maxAbsDisp.toExponential(3)} m
-      </div>
-      <div className={styles.stat}>
-        Avg tip Uy: {tipUy.toExponential(4)} m
-      </div>
-      <div className={styles.stat}>
-        Theory δ = PL³/3EI: {theory.toExponential(4)} m
-      </div>
+
+      {stats && (resultType === 'Displacement (magnitude)') && (
+        <>
+          <div className={styles.stat}>Min |U|: {stats.minMag.toExponential(3)} m</div>
+          <div className={styles.stat}>Max |U|: {stats.maxMag.toExponential(3)} m</div>
+        </>
+      )}
+      {stats && resultType === 'Ux' && (
+        <>
+          <div className={styles.stat}>Min Ux: {stats.minUx.toExponential(3)} m</div>
+          <div className={styles.stat}>Max Ux: {stats.maxUx.toExponential(3)} m</div>
+        </>
+      )}
+      {stats && resultType === 'Uy' && (
+        <>
+          <div className={styles.stat}>Min Uy: {stats.minUy.toExponential(3)} m</div>
+          <div className={styles.stat}>Max Uy: {stats.maxUy.toExponential(3)} m</div>
+        </>
+      )}
+      {stats && resultType === 'Uz' && (
+        <>
+          <div className={styles.stat}>Min Uz: {stats.minUz.toExponential(3)} m</div>
+          <div className={styles.stat}>Max Uz: {stats.maxUz.toExponential(3)} m</div>
+        </>
+      )}
+      {resultType === 'Von Mises stress' && (
+        vmStats
+          ? <>
+              <div className={styles.stat}>Min σ_vm: {vmStats.minVm.toExponential(3)} Pa</div>
+              <div className={styles.stat}>Max σ_vm: {vmStats.maxVm.toExponential(3)} Pa</div>
+            </>
+          : <div className={styles.stat}>Von Mises data not available</div>
+      )}
     </div>
   )
 }

--- a/web/src/components/results/ResultsPanel.tsx
+++ b/web/src/components/results/ResultsPanel.tsx
@@ -1,12 +1,12 @@
-import { useModelStore, RESULT_TYPES } from '../../store/modelStore'
-import styles from './ResultsPanel.module.css'
+import { useModelStore, RESULT_TYPES } from "../../store/modelStore";
+import styles from "./ResultsPanel.module.css";
 
 export function ResultsPanel() {
-  const result = useModelStore(s => s.result)
-  const resultType = useModelStore(s => s.resultType)
-  const setResultType = useModelStore(s => s.setResultType)
-  const nodes = useModelStore(s => s.nodes)
-  const elements = useModelStore(s => s.elements)
+  const result = useModelStore((s) => s.result);
+  const resultType = useModelStore((s) => s.resultType);
+  const setResultType = useModelStore((s) => s.setResultType);
+  const nodes = useModelStore((s) => s.nodes);
+  const elements = useModelStore((s) => s.elements);
 
   if (!result) {
     return (
@@ -14,66 +14,72 @@ export function ResultsPanel() {
         <div className={styles.title}>Results</div>
         <div className={styles.empty}>No results — run the solver first</div>
       </div>
-    )
+    );
   }
 
-  const d = result.displacements
+  const d = result.displacements;
 
   // Per-component min/max stats
   const stats = (() => {
-    const n = nodes.length
-    if (n === 0) return null
+    const n = nodes.length;
+    if (n === 0) return null;
 
-    let minMag = Infinity, maxMag = -Infinity
-    let minUx = Infinity, maxUx = -Infinity
-    let minUy = Infinity, maxUy = -Infinity
-    let minUz = Infinity, maxUz = -Infinity
+    let minMag = Infinity,
+      maxMag = -Infinity;
+    let minUx = Infinity,
+      maxUx = -Infinity;
+    let minUy = Infinity,
+      maxUy = -Infinity;
+    let minUz = Infinity,
+      maxUz = -Infinity;
 
     for (let i = 0; i < n; i++) {
-      const ux = d[i * 3] ?? 0
-      const uy = d[i * 3 + 1] ?? 0
-      const uz = d[i * 3 + 2] ?? 0
-      const mag = Math.sqrt(ux * ux + uy * uy + uz * uz)
-      if (mag < minMag) minMag = mag
-      if (mag > maxMag) maxMag = mag
-      if (ux < minUx) minUx = ux
-      if (ux > maxUx) maxUx = ux
-      if (uy < minUy) minUy = uy
-      if (uy > maxUy) maxUy = uy
-      if (uz < minUz) minUz = uz
-      if (uz > maxUz) maxUz = uz
+      const ux = d[i * 3] ?? 0;
+      const uy = d[i * 3 + 1] ?? 0;
+      const uz = d[i * 3 + 2] ?? 0;
+      const mag = Math.sqrt(ux * ux + uy * uy + uz * uz);
+      if (mag < minMag) minMag = mag;
+      if (mag > maxMag) maxMag = mag;
+      if (ux < minUx) minUx = ux;
+      if (ux > maxUx) maxUx = ux;
+      if (uy < minUy) minUy = uy;
+      if (uy > maxUy) maxUy = uy;
+      if (uz < minUz) minUz = uz;
+      if (uz > maxUz) maxUz = uz;
     }
-    return { minMag, maxMag, minUx, maxUx, minUy, maxUy, minUz, maxUz }
-  })()
+    return { minMag, maxMag, minUx, maxUx, minUy, maxUy, minUz, maxUz };
+  })();
 
   // Per-node von Mises (averaged from element values)
   const vmStats = (() => {
-    if (!result.vonMises || elements.length === 0 || nodes.length === 0) return null
-    const vm = result.vonMises
-    let minVm = Infinity, maxVm = -Infinity
+    if (!result.vonMises || elements.length === 0 || nodes.length === 0)
+      return null;
+    const vm = result.vonMises;
+    let minVm = Infinity,
+      maxVm = -Infinity;
 
     // Build nodeIndex map: nodeId → flat index in nodes array
-    const nodeIndex = new Map<number, number>()
-    for (let i = 0; i < nodes.length; i++) nodeIndex.set(nodes[i].id, i)
-    const sums = new Float64Array(nodes.length)
-    const counts = new Int32Array(nodes.length)
+    const nodeIndex = new Map<number, number>();
+    for (let i = 0; i < nodes.length; i++) nodeIndex.set(nodes[i].id, i);
+    const sums = new Float64Array(nodes.length);
+    const counts = new Int32Array(nodes.length);
     for (let ei = 0; ei < elements.length; ei++) {
-      const vmVal = vm[ei] ?? 0
+      const vmVal = vm[ei] ?? 0;
       for (const nodeId of elements[ei].nodeIds) {
-        const ni = nodeIndex.get(nodeId)
+        const ni = nodeIndex.get(nodeId);
         if (ni !== undefined) {
-          sums[ni as number] += vmVal
-          counts[ni as number]++
+          sums[ni as number] += vmVal;
+          counts[ni as number]++;
         }
       }
     }
     for (let i = 0; i < nodes.length; i++) {
-      const v = counts[i] > 0 ? sums[i] / counts[i] : 0
-      if (v < minVm) minVm = v
-      if (v > maxVm) maxVm = v
+      const v = counts[i] > 0 ? sums[i] / counts[i] : 0;
+      if (v < minVm) minVm = v;
+      if (v > maxVm) maxVm = v;
     }
-    return { minVm, maxVm }
-  })()
+    return { minVm, maxVm };
+  })();
 
   return (
     <div className={styles.panel}>
@@ -81,43 +87,70 @@ export function ResultsPanel() {
       <select
         className={styles.select}
         value={resultType}
-        onChange={e => setResultType(e.target.value as typeof RESULT_TYPES[number])}
+        onChange={(e) =>
+          setResultType(e.target.value as (typeof RESULT_TYPES)[number])
+        }
       >
-        {RESULT_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+        {RESULT_TYPES.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
       </select>
 
-      {stats && (resultType === 'Displacement (magnitude)') && (
+      {stats && resultType === "Displacement (magnitude)" && (
         <>
-          <div className={styles.stat}>Min |U|: {stats.minMag.toExponential(3)} m</div>
-          <div className={styles.stat}>Max |U|: {stats.maxMag.toExponential(3)} m</div>
+          <div className={styles.stat}>
+            Min |U|: {stats.minMag.toExponential(3)} m
+          </div>
+          <div className={styles.stat}>
+            Max |U|: {stats.maxMag.toExponential(3)} m
+          </div>
         </>
       )}
-      {stats && resultType === 'Ux' && (
+      {stats && resultType === "Ux" && (
         <>
-          <div className={styles.stat}>Min Ux: {stats.minUx.toExponential(3)} m</div>
-          <div className={styles.stat}>Max Ux: {stats.maxUx.toExponential(3)} m</div>
+          <div className={styles.stat}>
+            Min Ux: {stats.minUx.toExponential(3)} m
+          </div>
+          <div className={styles.stat}>
+            Max Ux: {stats.maxUx.toExponential(3)} m
+          </div>
         </>
       )}
-      {stats && resultType === 'Uy' && (
+      {stats && resultType === "Uy" && (
         <>
-          <div className={styles.stat}>Min Uy: {stats.minUy.toExponential(3)} m</div>
-          <div className={styles.stat}>Max Uy: {stats.maxUy.toExponential(3)} m</div>
+          <div className={styles.stat}>
+            Min Uy: {stats.minUy.toExponential(3)} m
+          </div>
+          <div className={styles.stat}>
+            Max Uy: {stats.maxUy.toExponential(3)} m
+          </div>
         </>
       )}
-      {stats && resultType === 'Uz' && (
+      {stats && resultType === "Uz" && (
         <>
-          <div className={styles.stat}>Min Uz: {stats.minUz.toExponential(3)} m</div>
-          <div className={styles.stat}>Max Uz: {stats.maxUz.toExponential(3)} m</div>
+          <div className={styles.stat}>
+            Min Uz: {stats.minUz.toExponential(3)} m
+          </div>
+          <div className={styles.stat}>
+            Max Uz: {stats.maxUz.toExponential(3)} m
+          </div>
         </>
       )}
-      {resultType === 'Von Mises stress' && (
-        vmStats
-          ? <>
-              <div className={styles.stat}>Min σ_vm: {vmStats.minVm.toExponential(3)} Pa</div>
-              <div className={styles.stat}>Max σ_vm: {vmStats.maxVm.toExponential(3)} Pa</div>
-            </>
-          : <div className={styles.stat}>Von Mises data not available</div>
-      )}
+      {resultType === "Von Mises stress" &&
+        (vmStats ? (
+          <>
+            <div className={styles.stat}>
+              Min σ_vm: {vmStats.minVm.toExponential(3)} Pa
+            </div>
+            <div className={styles.stat}>
+              Max σ_vm: {vmStats.maxVm.toExponential(3)} Pa
+            </div>
+          </>
+        ) : (
+          <div className={styles.stat}>Von Mises data not available</div>
+        ))}
     </div>
-  )
+  );
 }

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -3,7 +3,7 @@ import { Line } from "@react-three/drei";
 import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useModelStore } from "../../store/modelStore";
-import type { Node } from "../../store/modelStore";
+import type { Node, ResultType } from "../../store/modelStore";
 import { buildBoundaryMeshTopo, pickFaceNodeIds } from "../../lib/facePick";
 import type { Vec3, Tri } from "../../lib/facePick";
 
@@ -134,6 +134,7 @@ export function MeshScene() {
   const constraints = useModelStore((s) => s.constraints);
   const loads = useModelStore((s) => s.loads);
   const result = useModelStore((s) => s.result);
+  const resultType = useModelStore((s) => s.resultType);
   const stepSurface = useModelStore((s) => s.stepSurface);
   const volMesh = useModelStore((s) => s.volMesh);
   const surfaceTriangles = useModelStore((s) => s.surfaceTriangles);
@@ -315,6 +316,29 @@ export function MeshScene() {
     [barElements, nodeMap],
   );
 
+  // Per-node von Mises: average element-level stresses to nodes.
+  const nodeVonMises = useMemo(() => {
+    if (!result?.vonMises || elements.length === 0 || nodes.length === 0) return null;
+    const vm = result.vonMises;
+    const sums = new Float64Array(nodes.length);
+    const counts = new Int32Array(nodes.length);
+    for (let ei = 0; ei < elements.length; ei++) {
+      const vmVal = vm[ei] ?? 0;
+      for (const nodeId of elements[ei].nodeIds) {
+        const entry = nodeMap.get(nodeId);
+        if (entry) {
+          sums[entry.i] += vmVal;
+          counts[entry.i]++;
+        }
+      }
+    }
+    const avg = new Float64Array(nodes.length);
+    for (let i = 0; i < nodes.length; i++) {
+      avg[i] = counts[i] > 0 ? sums[i] / counts[i] : 0;
+    }
+    return avg;
+  }, [result, elements, nodes, nodeMap]);
+
   const deformedSurface = useMemo(() => {
     if (!result) return null;
     const hasQuads = boundaryQuadFaceIds.length > 0;
@@ -322,16 +346,31 @@ export function MeshScene() {
     if (!hasQuads && !hasTris) return null;
 
     const d = result.displacements;
+
+    // Compute per-node scalar value for the selected result type
+    const nodeValue = (i: number, rt: ResultType): number => {
+      switch (rt) {
+        case 'Ux': return d[i * 3] ?? 0;
+        case 'Uy': return d[i * 3 + 1] ?? 0;
+        case 'Uz': return d[i * 3 + 2] ?? 0;
+        case 'Von Mises stress': return nodeVonMises?.[i] ?? 0;
+        default: {
+          const ux = d[i * 3] ?? 0, uy = d[i * 3 + 1] ?? 0, uz = d[i * 3 + 2] ?? 0;
+          return Math.sqrt(ux * ux + uy * uy + uz * uz);
+        }
+      }
+    };
+
+    let minVal = Infinity, maxVal = -Infinity;
+    for (let i = 0; i < nodes.length; i++) {
+      const v = nodeValue(i, resultType);
+      if (v < minVal) minVal = v;
+      if (v > maxVal) maxVal = v;
+    }
+    const range = maxVal - minVal || 1;
+
     const positions: number[] = [];
     const colors: number[] = [];
-    let minUy = Infinity,
-      maxUy = -Infinity;
-    nodes.forEach((_, i) => {
-      const uy = d[i * 3 + 1] ?? 0;
-      if (uy < minUy) minUy = uy;
-      if (uy > maxUy) maxUy = uy;
-    });
-    const range = maxUy - minUy || 1;
 
     const deformedPos = (id: number): [number, number, number] => {
       const { n, i } = nodeMap.get(id)!;
@@ -343,7 +382,7 @@ export function MeshScene() {
     };
     const nodeColor = (id: number): [number, number, number] => {
       const { i } = nodeMap.get(id)!;
-      const t = ((d[i * 3 + 1] ?? 0) - minUy) / range;
+      const t = (nodeValue(i, resultType) - minVal) / range;
       const c = new THREE.Color();
       c.setHSL(0.667 * (1 - t), 1, 0.5);
       return [c.r, c.g, c.b];
@@ -378,6 +417,8 @@ export function MeshScene() {
     };
   }, [
     result,
+    resultType,
+    nodeVonMises,
     boundaryQuadFaceIds,
     boundaryTriFaceIds,
     nodeMap,

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -318,7 +318,8 @@ export function MeshScene() {
 
   // Per-node von Mises: average element-level stresses to nodes.
   const nodeVonMises = useMemo(() => {
-    if (!result?.vonMises || elements.length === 0 || nodes.length === 0) return null;
+    if (!result?.vonMises || elements.length === 0 || nodes.length === 0)
+      return null;
     const vm = result.vonMises;
     const sums = new Float64Array(nodes.length);
     const counts = new Int32Array(nodes.length);
@@ -350,18 +351,25 @@ export function MeshScene() {
     // Compute per-node scalar value for the selected result type
     const nodeValue = (i: number, rt: ResultType): number => {
       switch (rt) {
-        case 'Ux': return d[i * 3] ?? 0;
-        case 'Uy': return d[i * 3 + 1] ?? 0;
-        case 'Uz': return d[i * 3 + 2] ?? 0;
-        case 'Von Mises stress': return nodeVonMises?.[i] ?? 0;
+        case "Ux":
+          return d[i * 3] ?? 0;
+        case "Uy":
+          return d[i * 3 + 1] ?? 0;
+        case "Uz":
+          return d[i * 3 + 2] ?? 0;
+        case "Von Mises stress":
+          return nodeVonMises?.[i] ?? 0;
         default: {
-          const ux = d[i * 3] ?? 0, uy = d[i * 3 + 1] ?? 0, uz = d[i * 3 + 2] ?? 0;
+          const ux = d[i * 3] ?? 0,
+            uy = d[i * 3 + 1] ?? 0,
+            uz = d[i * 3 + 2] ?? 0;
           return Math.sqrt(ux * ux + uy * uy + uz * uz);
         }
       }
     };
 
-    let minVal = Infinity, maxVal = -Infinity;
+    let minVal = Infinity,
+      maxVal = -Infinity;
     for (let i = 0; i < nodes.length; i++) {
       const v = nodeValue(i, resultType);
       if (v < minVal) minVal = v;

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -67,6 +67,15 @@ export interface SolverResult {
   vonMises?: Float64Array;
 }
 
+export const RESULT_TYPES = [
+  'Displacement (magnitude)',
+  'Ux',
+  'Uy',
+  'Uz',
+  'Von Mises stress',
+] as const;
+export type ResultType = typeof RESULT_TYPES[number];
+
 export interface StepSurfaceMesh {
   points: [number, number, number][];
   triangles: [number, number, number][];
@@ -358,6 +367,7 @@ interface ModelState {
   hasStarted: boolean;
   mode: AppMode;
   result: SolverResult | null;
+  resultType: ResultType;
   stepSurface: StepSurfaceMesh | null;
   isRunning: boolean;
   isMeshing: boolean;
@@ -405,6 +415,7 @@ interface ModelState {
   addMaterial(mat: Material): void;
   addProperty(prop: Property): void;
   setResult(result: SolverResult): void;
+  setResultType(t: ResultType): void;
   setRunning(v: boolean): void;
   setMeshing(v: boolean): void;
   applyMeshResult(
@@ -485,6 +496,7 @@ export const useModelStore = create<ModelState>()(
     hasStarted: false,
     mode: "geometry" as AppMode,
     result: null,
+    resultType: 'Displacement (magnitude)' as ResultType,
     stepSurface: null,
     isRunning: false,
     isMeshing: false,
@@ -657,6 +669,11 @@ export const useModelStore = create<ModelState>()(
     setResult: (result) =>
       set((s) => {
         s.result = result;
+        s.resultType = 'Displacement (magnitude)';
+      }),
+    setResultType: (t) =>
+      set((s) => {
+        s.resultType = t;
       }),
     setRunning: (v) =>
       set((s) => {

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -68,13 +68,13 @@ export interface SolverResult {
 }
 
 export const RESULT_TYPES = [
-  'Displacement (magnitude)',
-  'Ux',
-  'Uy',
-  'Uz',
-  'Von Mises stress',
+  "Displacement (magnitude)",
+  "Ux",
+  "Uy",
+  "Uz",
+  "Von Mises stress",
 ] as const;
-export type ResultType = typeof RESULT_TYPES[number];
+export type ResultType = (typeof RESULT_TYPES)[number];
 
 export interface StepSurfaceMesh {
   points: [number, number, number][];
@@ -496,7 +496,7 @@ export const useModelStore = create<ModelState>()(
     hasStarted: false,
     mode: "geometry" as AppMode,
     result: null,
-    resultType: 'Displacement (magnitude)' as ResultType,
+    resultType: "Displacement (magnitude)" as ResultType,
     stepSurface: null,
     isRunning: false,
     isMeshing: false,
@@ -669,7 +669,7 @@ export const useModelStore = create<ModelState>()(
     setResult: (result) =>
       set((s) => {
         s.result = result;
-        s.resultType = 'Displacement (magnitude)';
+        s.resultType = "Displacement (magnitude)";
       }),
     setResultType: (t) =>
       set((s) => {


### PR DESCRIPTION
## Summary
Extends the results panel to support interactive selection between displacement components (magnitude, Ux, Uy, Uz) and von Mises stress, with corresponding min/max statistics and viewport coloring.

## Key Changes

- **Result type state management**: Added `resultType` and `setResultType` to the model store, with `RESULT_TYPES` constant exported for use across components. Result type defaults to 'Displacement (magnitude)' and resets when a new solve completes.

- **Results panel refactor**: Replaced hardcoded cantilever-specific statistics (tip deflection, theory comparison) with generic min/max stats computed for the selected result type. The dropdown now controls which result is displayed and visualized.

- **Von Mises averaging**: Implemented per-node von Mises stress by averaging element-level values to nodes using a nodeId→index map. Applied in both the results panel (for statistics) and viewport (for coloring).

- **Viewport coloring by result type**: Modified `deformedSurface` computation to color the mesh based on the selected result type via a `nodeValue()` helper. Min/max range is recalculated for each result type to ensure proper color scaling.

- **Solver integration**: Updated the solve handler to receive and store von Mises data from the worker, passing it through to the `SolverResult` object.

## Implementation Details

- Von Mises averaging uses `Float64Array` for sums and `Int32Array` for element counts to avoid floating-point precision loss.
- The `nodeValue()` function in `MeshScene` centralizes the logic for extracting the appropriate scalar from displacements or von Mises data based on result type.
- Result type selection is reactive: changing the dropdown immediately updates both the statistics display and the viewport coloring.

https://claude.ai/code/session_019S5eEqnqfPxg5KQpJbp1f8