### PR TITLE
Fix face-ID mapping and speed up meshing of complex CAD parts

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -32,9 +32,12 @@ target_include_directories(kofem_wasm_emcc PRIVATE
 )
 
 # Netgen internal headers (netgen_glue.cpp uses netgen::Mesh / netgen::OCCGeometry).
-# Install layouts vary: flat (include/*.hpp), nested (include/netgen/<subdir>/),
-# or umbrella (include/netgen/include/meshing.hpp).  Add every variant that exists.
+# Install layouts vary: the kofem-dependencies image has include/{occ,meshing,include,...}
+# directly, other installs nest the same tree under include/netgen/.  occ/occgeom.hpp
+# does `#include <meshing.hpp>`, which lives in the umbrella dir (libsrc/include) —
+# include/include resp. include/netgen/include.  Add every variant that exists.
 foreach(_ng_inc
+        "${NETGEN_ROOT}/include/include"
         "${NETGEN_ROOT}/include/netgen"
         "${NETGEN_ROOT}/include/netgen/include")
     if(EXISTS "${_ng_inc}")

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -23,13 +23,24 @@ foreach(V OCCT_ROOT NETGEN_ROOT MFEM_ROOT)
 endforeach()
 
 # ── Engine target ─────────────────────────────────────────────────────────────
-add_executable(kofem_wasm_emcc cpp/engine.cpp cpp/brepfill_stubs.cpp)
+add_executable(kofem_wasm_emcc cpp/engine.cpp cpp/netgen_glue.cpp cpp/brepfill_stubs.cpp)
 
 target_include_directories(kofem_wasm_emcc PRIVATE
     ${OCCT_ROOT}/include/opencascade
     ${NETGEN_ROOT}/include
     ${MFEM_ROOT}/include
 )
+
+# Netgen internal headers (netgen_glue.cpp uses netgen::Mesh / netgen::OCCGeometry).
+# Install layouts vary: flat (include/*.hpp), nested (include/netgen/<subdir>/),
+# or umbrella (include/netgen/include/meshing.hpp).  Add every variant that exists.
+foreach(_ng_inc
+        "${NETGEN_ROOT}/include/netgen"
+        "${NETGEN_ROOT}/include/netgen/include")
+    if(EXISTS "${_ng_inc}")
+        target_include_directories(kofem_wasm_emcc PRIVATE "${_ng_inc}")
+    endif()
+endforeach()
 
 target_link_directories(kofem_wasm_emcc PRIVATE
     ${OCCT_ROOT}/lib
@@ -177,7 +188,8 @@ target_link_libraries(kofem_wasm_emcc PRIVATE
     mfem
 )
 
-target_compile_definitions(kofem_wasm_emcc PRIVATE KOFEM_NETGEN_OCC=1)
+# OCCGEOMETRY gates the OCC parts of Netgen's internal headers (occgeom.hpp).
+target_compile_definitions(kofem_wasm_emcc PRIVATE KOFEM_NETGEN_OCC=1 OCCGEOMETRY=1)
 if(_netgen_occ_separate_lib)
     message(STATUS "Netgen OCC: linking ngocc as a separate library")
     target_link_libraries(kofem_wasm_emcc PRIVATE ngocc)

--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -30,6 +30,9 @@
 // Netgen (C API)
 #include <nglib.h>
 
+// Netgen internal-API glue (face indices, geometry from shape) — see netgen_glue.h
+#include "netgen_glue.h"
+
 // MFEM
 #include <mfem.hpp>
 
@@ -147,21 +150,18 @@ static bool jbool(const val& o, const char* k, bool def) {
 
 // ── OCCT: STEP → surface mesh ─────────────────────────────────────────────────
 
-// Stored after tessellate_step for reuse by generate_fem_mesh.
-// g_step_bytes holds the raw STEP file so Netgen can re-read it via its own
-// STEP reader (Netgen's OCC integration requires a file path, not an in-memory shape).
+// Stored after tessellate_step for reuse by generate_fem_mesh, which builds
+// the Netgen OCC geometry directly from this shape (no STEP re-read).
 static TopoDS_Shape              g_step_shape;
 static bool                      g_has_step_shape = false;
-static std::vector<uint8_t>      g_step_bytes;
 
-// Release OCCT shape + STEP byte cache.  Call this from JS after meshing is
+// Release the OCCT shape cache.  Call this from JS after meshing is
 // done so the memory is available for the MFEM solve.
 static void free_geometry_cache() {
     log_mem("free_geometry_cache: before");
     BRepTools::Clean(g_step_shape);  // detach BRepMesh triangulations from faces
     g_step_shape     = TopoDS_Shape();
     g_has_step_shape = false;
-    std::vector<uint8_t>().swap(g_step_bytes);  // swap-with-empty releases capacity
     printf("[kofem] geometry cache freed\n");
     fflush(stdout);
     log_mem("free_geometry_cache: after");
@@ -173,7 +173,6 @@ static std::string tessellate_step(val bytes_val, const std::string& opts_json) 
     double angular_defl = jdouble(opts, "angular_deflection", 0.5);
 
     std::vector<uint8_t> bytes = emscripten::vecFromJSArray<uint8_t>(bytes_val);
-    g_step_bytes = bytes;   // keep for Netgen OCC re-read in generate_fem_mesh
 
     // OCCT ReadFile requires a filesystem path; write to Emscripten's in-memory /tmp.
     char tmppath[] = "/tmp/kofem_XXXXXX.stp";
@@ -360,8 +359,6 @@ namespace nglib {
 namespace nglib {
 #ifdef KOFEM_NETGEN_OCC
     typedef void* Ng_OCC_Geometry;
-    extern Ng_OCC_Geometry* Ng_OCC_Load_STEP(const char* filename);
-    extern Ng_Result         Ng_OCC_DeleteGeometry(Ng_OCC_Geometry*);
     extern Ng_Result         Ng_OCC_SetLocalMeshSize(Ng_OCC_Geometry*, Ng_Mesh*, Ng_Meshing_Parameters*);
     extern Ng_Result         Ng_OCC_GenerateEdgeMesh(Ng_OCC_Geometry*, Ng_Mesh*, Ng_Meshing_Parameters*);
     extern Ng_Result         Ng_OCC_GenerateSurfaceMesh(Ng_OCC_Geometry*, Ng_Mesh*, Ng_Meshing_Parameters*);
@@ -375,7 +372,7 @@ namespace nglib {
 // feature lines, then fills the volume — one call, proper FEM surface mesh.
 static std::string generate_fem_mesh(const std::string& opts_json)
 {
-    if (!g_has_step_shape || g_step_bytes.empty())
+    if (!g_has_step_shape)
         throw std::runtime_error(
             "generate_fem_mesh: no STEP shape loaded — call tessellate_step first");
 
@@ -393,27 +390,24 @@ static std::string generate_fem_mesh(const std::string& opts_json)
     int    optsteps_3d     = jint   (opts, "optsteps_3d",           3);
 
 #ifdef KOFEM_NETGEN_OCC
-    // ── OCC path: Netgen reads the CAD geometry directly ─────────────────────
+    // ── OCC path: Netgen meshes the CAD geometry directly ────────────────────
     // Netgen v6.2.2401 four-step pipeline (nglib_occ.cpp, namespace nglib):
     //   1. Ng_OCC_SetLocalMeshSize  — size field from CAD curvature
     //   2. Ng_OCC_GenerateEdgeMesh  — mesh feature edges
     //   3. Ng_OCC_GenerateSurfaceMesh — mesh boundary faces
     //   4. Ng_GenerateVolumeMesh    — fill volume with tetrahedra
+    //
+    // The Netgen geometry is built straight from the OCCT shape that
+    // tessellate_step already transferred — re-reading the STEP file through
+    // Netgen's own reader (Ng_OCC_Load_STEP) parsed the whole file a second
+    // time and doubled peak geometry memory.
 
-    const char* steppath = "/tmp/kofem_fem.stp";
-    {
-        FILE* f = fopen(steppath, "wb");
-        if (!f) throw std::runtime_error("generate_fem_mesh: cannot open /tmp/kofem_fem.stp");
-        fwrite(g_step_bytes.data(), 1, g_step_bytes.size(), f);
-        fclose(f);
-    }
-
-    log_mem("generate_fem_mesh: before Ng_OCC_Load_STEP");
-    nglib::Ng_OCC_Geometry* geom = nglib::Ng_OCC_Load_STEP(steppath);
-    unlink(steppath);
+    log_mem("generate_fem_mesh: before OCC geometry build");
+    nglib::Ng_OCC_Geometry* geom =
+        (nglib::Ng_OCC_Geometry*)kofem_occ_geometry_from_shape(g_step_shape);
     if (!geom)
-        throw std::runtime_error("Ng_OCC_Load_STEP failed — check STEP geometry validity");
-    log_mem("generate_fem_mesh: after Ng_OCC_Load_STEP");
+        throw std::runtime_error("OCCGeometry construction failed — check STEP geometry validity");
+    log_mem("generate_fem_mesh: after OCC geometry build");
 
     nglib::Ng_Meshing_Parameters mp;
     mp.uselocalh                  = 1;
@@ -444,7 +438,7 @@ static std::string generate_fem_mesh(const std::string& opts_json)
 
     nglib::Ng_Mesh* mesh = nglib::Ng_NewMesh();
     if (!mesh) {
-        nglib::Ng_OCC_DeleteGeometry(geom);
+        kofem_occ_geometry_delete(geom);
         throw std::runtime_error("Ng_NewMesh returned null");
     }
 
@@ -459,7 +453,7 @@ static std::string generate_fem_mesh(const std::string& opts_json)
     nglib::Ng_Result res = nglib::Ng_OCC_GenerateEdgeMesh(geom, mesh, &mp);
     if (res != nglib::NG_OK) {
         nglib::Ng_DeleteMesh(mesh);
-        nglib::Ng_OCC_DeleteGeometry(geom);
+        kofem_occ_geometry_delete(geom);
         throw std::runtime_error(
             "Ng_OCC_GenerateEdgeMesh failed (code " + std::to_string((int)res) + ")");
     }
@@ -473,7 +467,7 @@ static std::string generate_fem_mesh(const std::string& opts_json)
     res = nglib::Ng_OCC_GenerateSurfaceMesh(geom, mesh, &mp);
     if (res != nglib::NG_OK) {
         nglib::Ng_DeleteMesh(mesh);
-        nglib::Ng_OCC_DeleteGeometry(geom);
+        kofem_occ_geometry_delete(geom);
         throw std::runtime_error(
             "Ng_OCC_GenerateSurfaceMesh failed (code " + std::to_string((int)res) + ")");
     }
@@ -491,7 +485,7 @@ static std::string generate_fem_mesh(const std::string& opts_json)
     fflush(stdout);
     log_mem("generate_fem_mesh: step 4 GenerateVolumeMesh");
     res = nglib::Ng_GenerateVolumeMesh(mesh, &mp);
-    nglib::Ng_OCC_DeleteGeometry(geom);  // safe: volume fill complete
+    kofem_occ_geometry_delete(geom);     // safe: volume fill complete
     if (res != nglib::NG_OK) {
         nglib::Ng_DeleteMesh(mesh);
         throw std::runtime_error(
@@ -526,56 +520,12 @@ static std::string generate_fem_mesh(const std::string& opts_json)
     }
 
     // Surface elements — boundary triangles from the Netgen surface mesh.
-    // We need the OCC face index (1-based) per surface element for fast face selection.
-    // Ng_GetSurfaceElementIndex is absent from many Netgen builds, so we derive face
-    // IDs from the OCCT tessellation: build a centroid→face_id lookup from
-    // BRep_Tool::Triangulation (the same API used by tessellate_step, proven WASM-safe),
-    // then for each Netgen surface element find the nearest tessellation centroid.
-    // Netgen nodes lie on the OCCT surfaces with sub-micron precision, so the nearest
-    // tessellation centroid is always on the correct face.  No high-level OCCT projection
-    // APIs (GeomAPI_*, BRepExtrema_*) are used — only plain gp_Pnt arithmetic.
-    struct TessCentroid { double x, y, z; int face_id; };
-    std::vector<TessCentroid> tess_centroids;
-    {
-        // Tessellation is normally already attached (tessellate_step runs first).
-        // Guard against direct calls: create a coarse tessellation if needed.
-        bool has_tess = false;
-        for (TopExp_Explorer exp(g_step_shape, TopAbs_FACE); exp.More(); exp.Next()) {
-            TopLoc_Location loc;
-            if (!BRep_Tool::Triangulation(TopoDS::Face(exp.Current()), loc).IsNull()) {
-                has_tess = true; break;
-            }
-        }
-        if (!has_tess) {
-            BRepMesh_IncrementalMesh mesher(g_step_shape, 1.0, /*relative=*/false, 0.5);
-            mesher.Perform();
-        }
-
-        int fid = 1;
-        for (TopExp_Explorer exp(g_step_shape, TopAbs_FACE); exp.More(); exp.Next(), ++fid) {
-            TopLoc_Location loc;
-            Handle(Poly_Triangulation) tri =
-                BRep_Tool::Triangulation(TopoDS::Face(exp.Current()), loc);
-            if (tri.IsNull()) continue;
-            for (int t = 1; t <= tri->NbTriangles(); ++t) {
-                int n1, n2, n3;
-                tri->Triangle(t).Get(n1, n2, n3);
-                gp_Pnt p1 = tri->Node(n1).Transformed(loc);
-                gp_Pnt p2 = tri->Node(n2).Transformed(loc);
-                gp_Pnt p3 = tri->Node(n3).Transformed(loc);
-                tess_centroids.push_back({
-                    (p1.X() + p2.X() + p3.X()) / 3.0,
-                    (p1.Y() + p2.Y() + p3.Y()) / 3.0,
-                    (p1.Z() + p2.Z() + p3.Z()) / 3.0,
-                    fid
-                });
-            }
-        }
-    }
-    printf("[netgen] %zu OCCT tessellation centroids for face-ID lookup\n",
-           tess_centroids.size());
-    fflush(stdout);
-
+    // Netgen records the owning CAD face of every surface element it generates
+    // during Ng_OCC_GenerateSurfaceMesh; kofem_surface_element_face_index reads
+    // that index (1-based) straight from the mesh.  The previous implementation
+    // matched each element against the nearest OCCT tessellation centroid, which
+    // was O(elements × tessellation triangles) — minutes on complex parts — and
+    // mis-assigned elements near face boundaries.
     int nse = nglib::Ng_GetNSE(mesh);
     std::vector<int> out_surf_tris;
     std::vector<int> out_surf_face_ids;
@@ -587,28 +537,7 @@ static std::string generate_fem_mesh(const std::string& opts_json)
         out_surf_tris.push_back(tri[0] - 1);
         out_surf_tris.push_back(tri[1] - 1);
         out_surf_tris.push_back(tri[2] - 1);
-
-        double cx = 0, cy = 0, cz = 0;
-        for (int j = 0; j < 3; ++j) {
-            double pt[3];
-            nglib::Ng_GetPoint(mesh, tri[j], pt);
-            cx += pt[0]; cy += pt[1]; cz += pt[2];
-        }
-        cx /= 3.0; cy /= 3.0; cz /= 3.0;
-
-        // Nearest OCCT tessellation centroid → face ID.
-        int best_fid = 1;
-        double best_d2 = 1e30;
-        for (const auto& tc : tess_centroids) {
-            double dx = tc.x - cx, dy = tc.y - cy, dz = tc.z - cz;
-            double d2 = dx*dx + dy*dy + dz*dz;
-            if (d2 < best_d2) {
-                best_d2 = d2;
-                best_fid = tc.face_id;
-                if (d2 < 1e-8) break;
-            }
-        }
-        out_surf_face_ids.push_back(best_fid);
+        out_surf_face_ids.push_back(kofem_surface_element_face_index(mesh, i));
     }
     printf("[netgen] %d surface elements, %d unique OCC face IDs\n",
            nse, (int)std::set<int>(out_surf_face_ids.begin(), out_surf_face_ids.end()).size());

--- a/engine/cpp/netgen_glue.cpp
+++ b/engine/cpp/netgen_glue.cpp
@@ -1,0 +1,35 @@
+// Netgen internal-API glue — see netgen_glue.h.
+//
+// Netgen install layouts differ between builds:
+//   flat:    <prefix>/include/occgeom.hpp
+//   nested:  <prefix>/include/netgen/include/occgeom.hpp (umbrella header)
+//   subdirs: <prefix>/include/occ/occgeom.hpp
+// CMakeLists.txt adds every existing variant to the include path; the probe
+// below picks whichever resolves. occgeom.hpp pulls in meshing.hpp
+// (netgen::Mesh, netgen::Element2d) transitively.
+#if __has_include(<occgeom.hpp>)
+#include <occgeom.hpp>
+#elif __has_include(<occ/occgeom.hpp>)
+#include <occ/occgeom.hpp>
+#else
+#error "Netgen occgeom.hpp not found — Netgen must be built with -DUSE_OCC=ON and its headers installed"
+#endif
+
+#include "netgen_glue.h"
+
+void* kofem_occ_geometry_from_shape(const TopoDS_Shape& shape) {
+    // Same constructor Ng_OCC_Load_STEP ends up in (BuildFMap + bounding box),
+    // minus the second STEP read/translate.
+    return new netgen::OCCGeometry(shape);
+}
+
+void kofem_occ_geometry_delete(void* geom) {
+    delete static_cast<netgen::OCCGeometry*>(geom);
+}
+
+int kofem_surface_element_face_index(void* mesh, int i) {
+    // Element2d::GetIndex() is the 1-based FaceDescriptor number, which for
+    // OCC-meshed geometry equals the position of the owning face in Netgen's
+    // face map (TopExp order over the shape).
+    return static_cast<netgen::Mesh*>(mesh)->SurfaceElement(i).GetIndex();
+}

--- a/engine/cpp/netgen_glue.h
+++ b/engine/cpp/netgen_glue.h
@@ -1,0 +1,20 @@
+// Thin wrappers around Netgen internal APIs that nglib does not expose.
+// Implemented in netgen_glue.cpp, which is the only translation unit that
+// includes Netgen's internal headers (keeping them out of engine.cpp, which
+// already includes MFEM and Embind).
+#pragma once
+
+class TopoDS_Shape;
+
+// Build a netgen::OCCGeometry directly from an already-transferred OCCT shape.
+// Equivalent to Ng_OCC_Load_STEP but without re-reading and re-translating the
+// STEP file. The returned pointer is an OCCGeometry* usable wherever nglib
+// expects an Ng_OCC_Geometry*. Free with kofem_occ_geometry_delete.
+void* kofem_occ_geometry_from_shape(const TopoDS_Shape& shape);
+
+void kofem_occ_geometry_delete(void* geom);
+
+// OCC face index (1-based) of surface element i (1-based) of an Ng_Mesh.
+// Netgen records the owning CAD face of every surface element it generates;
+// nglib has no accessor for it, but Ng_Mesh* is a netgen::Mesh* internally.
+int kofem_surface_element_face_index(void* mesh, int i);

--- a/test_wall_bracket.mjs
+++ b/test_wall_bracket.mjs
@@ -33,7 +33,8 @@ console.log(`tessellate_step:  ${tess.vertices.length} vertices, ${tess.triangle
 
 // 2. FEM mesh via Netgen OCC
 const mesh = JSON.parse(Module.generate_fem_mesh(JSON.stringify({
-  max_element_size: maxElementSize, min_element_size: 0.0, grading: 0.3,
+  // min_element_size floors curvature refinement — same default as solver.worker.ts
+  max_element_size: maxElementSize, min_element_size: maxElementSize / 10, grading: 0.3,
   second_order: false, elementsperedge: 2.0, elementspercurve: 2.0,
   optsteps_2d: 3, optsteps_3d: 3,
 })))

--- a/test_wall_bracket.mjs
+++ b/test_wall_bracket.mjs
@@ -4,54 +4,90 @@
 // No error handling: any failure surfaces immediately as a raw Node.js error.
 // Usage:  node test_wall_bracket.mjs [max_element_size]
 
-import { readFileSync } from 'fs'
-import { fileURLToPath } from 'url'
-import { dirname, join } from 'path'
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const maxElementSize = parseFloat(process.argv[2] ?? '20.0')
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const maxElementSize = parseFloat(process.argv[2] ?? "20.0");
 
-const wasmPkg    = join(__dirname, 'web/src/wasm/pkg')
-const wasmBinary = readFileSync(join(wasmPkg, 'kofem_wasm.wasm')).buffer
+const wasmPkg = join(__dirname, "web/src/wasm/pkg");
+const wasmBinary = readFileSync(join(wasmPkg, "kofem_wasm.wasm")).buffer;
 
-const { default: createModule } = await import(join(wasmPkg, 'kofem_wasm_emcc.js'))
+const { default: createModule } = await import(
+  join(wasmPkg, "kofem_wasm_emcc.js")
+);
 const Module = await createModule({
   wasmBinary,
-  print:    (t) => console.log('[wasm]', t),
-  printErr: (t) => console.error('[wasm:err]', t),
-})
+  print: (t) => console.log("[wasm]", t),
+  printErr: (t) => console.error("[wasm:err]", t),
+});
 
-const stepBytes = new Uint8Array(readFileSync(join(__dirname, 'test_files/Wall Bracket.stp')))
-console.log(`\nWall bracket: ${stepBytes.length} bytes, max_element_size=${maxElementSize}\n`)
+const stepBytes = new Uint8Array(
+  readFileSync(join(__dirname, "test_files/Wall Bracket.stp")),
+);
+console.log(
+  `\nWall bracket: ${stepBytes.length} bytes, max_element_size=${maxElementSize}\n`,
+);
 
 // 1. Tessellate (stores OCC shape in WASM for the mesher)
-const tess = JSON.parse(Module.tessellate_step(
-  stepBytes,
-  JSON.stringify({ linear_deflection: 0.1, angular_deflection: 0.5 }),
-))
-console.log(`tessellate_step:  ${tess.vertices.length} vertices, ${tess.triangles.length} triangles`)
+const tess = JSON.parse(
+  Module.tessellate_step(
+    stepBytes,
+    JSON.stringify({ linear_deflection: 0.1, angular_deflection: 0.5 }),
+  ),
+);
+console.log(
+  `tessellate_step:  ${tess.vertices.length} vertices, ${tess.triangles.length} triangles`,
+);
 
 // 2. FEM mesh via Netgen OCC
-const mesh = JSON.parse(Module.generate_fem_mesh(JSON.stringify({
-  // min_element_size floors curvature refinement — same default as solver.worker.ts
-  max_element_size: maxElementSize, min_element_size: maxElementSize / 10, grading: 0.3,
-  second_order: false, elementsperedge: 2.0, elementspercurve: 2.0,
-  optsteps_2d: 3, optsteps_3d: 3,
-})))
-console.log(`generate_fem_mesh: ${mesh.vertices.length} nodes, ${mesh.tetrahedra.length} tetrahedra`)
-Module.free_geometry_cache()
+const mesh = JSON.parse(
+  Module.generate_fem_mesh(
+    JSON.stringify({
+      // min_element_size floors curvature refinement — same default as solver.worker.ts
+      max_element_size: maxElementSize,
+      min_element_size: maxElementSize / 10,
+      grading: 0.3,
+      second_order: false,
+      elementsperedge: 2.0,
+      elementspercurve: 2.0,
+      optsteps_2d: 3,
+      optsteps_3d: 3,
+    }),
+  ),
+);
+console.log(
+  `generate_fem_mesh: ${mesh.vertices.length} nodes, ${mesh.tetrahedra.length} tetrahedra`,
+);
+Module.free_geometry_cache();
 
 // 3. Solve — no try/catch; WASM traps and solver errors propagate as-is
-const result = JSON.parse(Module.solve_linear_elastic(
-  JSON.stringify({ vertices: mesh.vertices, tetrahedra: mesh.tetrahedra, hexahedra: [] }),
-  JSON.stringify({ young_modulus: 210e9, poisson_ratio: 0.3 }),
-  JSON.stringify({
-    fixed_vertices: Array.from({ length: Math.min(10, mesh.vertices.length) }, (_, i) => i),
-    point_loads: [{ vertex: mesh.vertices.length - 1, force: [0, -10000, 0] }],
-  }),
-  1,
-))
+const result = JSON.parse(
+  Module.solve_linear_elastic(
+    JSON.stringify({
+      vertices: mesh.vertices,
+      tetrahedra: mesh.tetrahedra,
+      hexahedra: [],
+    }),
+    JSON.stringify({ young_modulus: 210e9, poisson_ratio: 0.3 }),
+    JSON.stringify({
+      fixed_vertices: Array.from(
+        { length: Math.min(10, mesh.vertices.length) },
+        (_, i) => i,
+      ),
+      point_loads: [
+        { vertex: mesh.vertices.length - 1, force: [0, -10000, 0] },
+      ],
+    }),
+    1,
+  ),
+);
 
-console.log(`solve_linear_elastic: ${result.displacements.length / 3} nodes solved`)
-console.log(`max von Mises: ${Math.max(...result.von_mises).toExponential(3)} Pa`)
-console.log('\nPASS')
+console.log(
+  `solve_linear_elastic: ${result.displacements.length / 3} nodes solved`,
+);
+console.log(
+  `max von Mises: ${Math.max(...result.von_mises).toExponential(3)} Pa`,
+);
+console.log("\nPASS");

--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -505,7 +505,11 @@ function MeshPanel() {
         elements: Element[];
         surfaceTriangles: [number, number, number][] | null;
         surfaceFaceIds: number[] | null;
-      }>("volume_mesh", { surface: stepSurface, maxElementSize, minElementSize });
+      }>("volume_mesh", {
+        surface: stepSurface,
+        maxElementSize,
+        minElementSize,
+      });
       applyMeshResult(
         n,
         e,

--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -470,6 +470,9 @@ function MeshPanel() {
   const stepSurface = useModelStore((s) => s.stepSurface);
 
   const [maxElementSize, setMaxElementSize] = useState(20);
+  // Floor for curvature-driven refinement; 0 lets Netgen refine fillets without
+  // limit, which can produce >10x more elements than the max size suggests.
+  const [minElementSize, setMinElementSize] = useState(2);
   const [error, setError] = useState<string | null>(null);
   const [logs, setLogs] = useState<string[]>([]);
   const [logsOpen, setLogsOpen] = useState(true);
@@ -502,7 +505,7 @@ function MeshPanel() {
         elements: Element[];
         surfaceTriangles: [number, number, number][] | null;
         surfaceFaceIds: number[] | null;
-      }>("volume_mesh", { surface: stepSurface, maxElementSize });
+      }>("volume_mesh", { surface: stepSurface, maxElementSize, minElementSize });
       applyMeshResult(
         n,
         e,
@@ -592,6 +595,22 @@ function MeshPanel() {
                   />
                   <span className={styles.toleranceUnit}>mm</span>
                 </div>
+                <div className={styles.formRow}>
+                  <span className={styles.formLabel}>Min element size</span>
+                  <input
+                    className={styles.formInput}
+                    type="number"
+                    min={0}
+                    max={500}
+                    step={0.5}
+                    value={minElementSize}
+                    disabled={isMeshing}
+                    onChange={(e) =>
+                      setMinElementSize(Math.max(0, Number(e.target.value)))
+                    }
+                  />
+                  <span className={styles.toleranceUnit}>mm</span>
+                </div>
                 <button
                   className={styles.meshVolBtn}
                   disabled={isMeshing}
@@ -654,6 +673,22 @@ function MeshPanel() {
                     disabled={isMeshing}
                     onChange={(e) =>
                       setMaxElementSize(Math.max(0.5, Number(e.target.value)))
+                    }
+                  />
+                  <span className={styles.toleranceUnit}>mm</span>
+                </div>
+                <div className={styles.formRow}>
+                  <span className={styles.formLabel}>Min element size</span>
+                  <input
+                    className={styles.formInput}
+                    type="number"
+                    min={0}
+                    max={500}
+                    step={0.5}
+                    value={minElementSize}
+                    disabled={isMeshing}
+                    onChange={(e) =>
+                      setMinElementSize(Math.max(0, Number(e.target.value)))
                     }
                   />
                   <span className={styles.toleranceUnit}>mm</span>

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -85,14 +85,21 @@ self.onmessage = async (event: MessageEvent) => {
         triangles: dto.triangles,
       });
     } else if (type === "volume_mesh") {
-      const { maxElementSize = 20.0 } = payload as {
+      const { maxElementSize = 20.0, minElementSize } = payload as {
         surface?: unknown;
         maxElementSize?: number;
+        minElementSize?: number;
       };
+
+      // Floor the curvature-driven local element size at maxElementSize/10 by
+      // default.  Without a floor, Netgen refines every fillet to ~radius/2
+      // (elementspercurve) — on fillet-heavy CAD this produces >10x more
+      // elements than the max size suggests and meshing takes minutes.
+      const minSize = minElementSize ?? maxElementSize / 10;
 
       const opts = JSON.stringify({
         max_element_size: maxElementSize,
-        min_element_size: 0.0,
+        min_element_size: minSize,
         grading: 0.3,
         second_order: false,
         elementsperedge: 2.0,
@@ -106,7 +113,7 @@ self.onmessage = async (event: MessageEvent) => {
       // feature lines), then fills the volume — all in one pass.
       self.postMessage({
         id,
-        log: `Generating FEM mesh via Netgen OCC (max element size: ${maxElementSize} mm)…`,
+        log: `Generating FEM mesh via Netgen OCC (element size: ${minSize}–${maxElementSize} mm)…`,
       });
       const json = m().generate_fem_mesh(opts);
       const dto = JSON.parse(json) as {
@@ -144,8 +151,12 @@ self.onmessage = async (event: MessageEvent) => {
         propertyId: 1,
       }));
 
-      // Derive unique edges from tetrahedra for wireframe display
-      const edgeSet = new Set<string>();
+      // Derive unique edges from tetrahedra for wireframe display.
+      // Numeric keys (lo * nVerts + hi): string keys cost seconds of hashing
+      // and GC at >100k-node mesh sizes.  Max key is nVerts² < 2^53 for any
+      // mesh that fits in WASM memory.
+      const nVerts = dto.vertices.length;
+      const edgeSet = new Set<number>();
       const edges: [number, number][] = [];
       for (const [a, b, c, d] of dto.tetrahedra) {
         for (const [u, v] of [
@@ -156,7 +167,7 @@ self.onmessage = async (event: MessageEvent) => {
           [b, d],
           [c, d],
         ] as [number, number][]) {
-          const key = u < v ? `${u}-${v}` : `${v}-${u}`;
+          const key = u < v ? u * nVerts + v : v * nVerts + u;
           if (!edgeSet.has(key)) {
             edgeSet.add(key);
             edges.push([u, v]);


### PR DESCRIPTION
## Summary

Meshing complex CAD parts (e.g. `test_files/new_bracket_2.stp`, 486 faces / 2,266 edges) took minutes in the browser, and face selection on the meshed surface picked wrong faces. Profiling (native Netgen 6.2.2604 with the exact engine parameters) found three independent causes, all fixed here:

### 1. Face IDs now come straight from Netgen (fixes wrong face selection)

Netgen records the owning CAD face index of every surface element it generates (`Element2d::GetIndex()`). The new `engine/cpp/netgen_glue.{h,cpp}` reads it through Netgen's internal API — `Ng_Mesh*` is a `netgen::Mesh*` internally, the same cast nglib uses. The previous nearest-tessellation-centroid match is deleted: it was O(elements × tessellation triangles) (~4.4 billion distance checks on this part, ~20–40 s in WASM) and mis-assigned elements near face boundaries, because dense fillet-face centroids "steal" matches from large planar faces whose tessellation has only a handful of triangles.

The glue is a separate translation unit so Netgen's internal headers stay out of the MFEM/Embind TU. Requires `-DOCCGEOMETRY` (added to CMakeLists) and handles flat/nested Netgen header install layouts.

### 2. `min_element_size` floors curvature refinement (12x meshing speedup)

The worker sent `min_element_size: 0.0`, letting curvature-based refinement shrink elements to ~radius/2 on every fillet. On fillet-heavy CAD this produced 486k tets / 67 s native for a part whose max element size was 20 mm. The default is now `maxElementSize / 10`, exposed as a "Min element size" input in the mesh panel (set 0 to restore unbounded refinement). Measured: **67 s / 486k tets → 5.4 s / 38.7k tets**.

### 3. No second STEP parse

`generate_fem_mesh` builds `netgen::OCCGeometry` directly from the OCCT shape `tessellate_step` already transferred, instead of writing the STEP bytes to `/tmp` and re-parsing through `Ng_OCC_Load_STEP` (~3 s native / ~10 s WASM on this part, plus doubled peak geometry memory). The `g_step_bytes` cache is removed.

Also: the tet-wireframe edge dedup in `solver.worker.ts` uses numeric keys instead of string keys (5.4 s → sub-second at 486k tets).

## Validation

- `netgen_glue.cpp` compiles clean against Netgen 6.2.2604 + OCCT 7.8.1 headers.
- Verified via Python Netgen on `new_bracket_2.stp`: the shape-constructed geometry produces an identical mesh (11,232 pts / 38,665 tets) to the file-loaded path; all 486 face indices appear; 500/500 sampled surface elements lie on the correct face's bounding box.
- `bun run typecheck` passes.
- WASM build not run locally (requires the dependencies image) — relying on CI for the Emscripten build.

https://claude.ai/code/session_01QH9hwU1X2fzcZofntyJDA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH9hwU1X2fzcZofntyJDA5)_