### PR TITLE
Fix flaky vol mesh test by waiting for stable post-mesh state

### DIFF
--- a/web/tests/solve.spec.ts
+++ b/web/tests/solve.spec.ts
@@ -157,16 +157,14 @@ test("vol mesh stores FEM nodes in the store for solving", async ({ page }) => {
     .click();
   console.log(`[vol-mesh] ${elapsed()} clicked Mesh STEP volume`);
 
+  // "Meshing…" is a transient label that can vanish before Playwright polls for
+  // it when the WASM worker completes very quickly.  Wait for the stable
+  // post-mesh state instead: "Mesh is solver-ready" only appears once the store
+  // has nodes (nodes.length > 0), regardless of how fast meshing ran.
   await Promise.race([
-    expect(page.getByText("Meshing…")).toBeVisible({ timeout: 10_000 }),
-    fatal,
-  ]);
-  console.log(
-    `[vol-mesh] ${elapsed()} meshing started (button shows Meshing…)`,
-  );
-
-  await Promise.race([
-    expect(page.getByText("Meshing…")).not.toBeVisible({ timeout: 150_000 }),
+    expect(page.getByText("Mesh is solver-ready")).toBeVisible({
+      timeout: 150_000,
+    }),
     fatal,
   ]);
   console.log(`[vol-mesh] ${elapsed()} meshing finished`);


### PR DESCRIPTION
## Summary

Replace transient "Meshing…" label polling with a stable "Mesh is solver-ready" state check in the volume mesh test. This eliminates a race condition where the WASM worker completes meshing so quickly that Playwright misses the intermediate "Meshing…" label entirely.

## Changes

- **Removed** two-stage polling: waiting for "Meshing…" to appear, then waiting for it to disappear
- **Added** single stable state check: wait for "Mesh is solver-ready" text to appear
  - This label only appears once the store has populated nodes (`nodes.length > 0`), making it a reliable indicator of completed meshing regardless of speed
  - Increased timeout to 150s to account for actual meshing work
- **Added** explanatory comment documenting why the transient label approach was unreliable

## Implementation Details

The "Mesh is solver-ready" state is guaranteed to be stable because it depends on the store's node population, which persists after the WASM worker completes. This eliminates the timing sensitivity that caused the test to flake when meshing completed very quickly.

https://claude.ai/code/session_01USnZgZqBdgnLBZSywRDRg5