### PR TITLE
Add undeformed geometry overlay toggle for deformed results

### DIFF
--- a/web/src/components/statusbar/StatusBar.tsx
+++ b/web/src/components/statusbar/StatusBar.tsx
@@ -3,15 +3,32 @@ import styles from "./StatusBar.module.css";
 
 type ViewRepr = "geometry" | "surface" | "volume" | "wireframe";
 
-const REPR_BUTTONS: { id: ViewRepr; label: string; tooltip: string; icon: React.ReactNode }[] = [
+const REPR_BUTTONS: {
+  id: ViewRepr;
+  label: string;
+  tooltip: string;
+  icon: React.ReactNode;
+}[] = [
   {
     id: "geometry",
     label: "Geometry",
     tooltip: "Shaded — smooth surface, no mesh edges",
     icon: (
       <svg viewBox="0 0 16 16" fill="none" width="13" height="13">
-        <path d="M8 2L13 5v6L8 14L3 11V5z" fill="currentColor" fillOpacity="0.25" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/>
-        <path d="M8 2L8 14M3 5l5 3.5M13 5l-5 3.5" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round"/>
+        <path
+          d="M8 2L13 5v6L8 14L3 11V5z"
+          fill="currentColor"
+          fillOpacity="0.25"
+          stroke="currentColor"
+          strokeWidth="1.3"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M8 2L8 14M3 5l5 3.5M13 5l-5 3.5"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          strokeLinecap="round"
+        />
       </svg>
     ),
   },
@@ -21,8 +38,20 @@ const REPR_BUTTONS: { id: ViewRepr; label: string; tooltip: string; icon: React.
     tooltip: "Surface mesh — shaded with element edges",
     icon: (
       <svg viewBox="0 0 16 16" fill="none" width="13" height="13">
-        <path d="M8 2L13 5v6L8 14L3 11V5z" fill="currentColor" fillOpacity="0.18" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/>
-        <path d="M3 5l5 3.5M13 5l-5 3.5M8 2l-3 5.5M8 2l3 5.5M3 11l5-2M13 11l-5-2" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round"/>
+        <path
+          d="M8 2L13 5v6L8 14L3 11V5z"
+          fill="currentColor"
+          fillOpacity="0.18"
+          stroke="currentColor"
+          strokeWidth="1.3"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M3 5l5 3.5M13 5l-5 3.5M8 2l-3 5.5M8 2l3 5.5M3 11l5-2M13 11l-5-2"
+          stroke="currentColor"
+          strokeWidth="0.9"
+          strokeLinecap="round"
+        />
       </svg>
     ),
   },
@@ -32,8 +61,19 @@ const REPR_BUTTONS: { id: ViewRepr; label: string; tooltip: string; icon: React.
     tooltip: "Volume mesh — all tetrahedral edges",
     icon: (
       <svg viewBox="0 0 16 16" fill="none" width="13" height="13">
-        <path d="M8 2L13 5v6L8 14L3 11V5z" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/>
-        <path d="M3 5l5 3.5M13 5l-5 3.5M8 8.5L8 14M3 5l5 9M13 5l-5 9M3 11l5-2.5M13 11l-5-2.5" stroke="currentColor" strokeWidth="0.8" strokeLinecap="round"/>
+        <path
+          d="M8 2L13 5v6L8 14L3 11V5z"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.3"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M3 5l5 3.5M13 5l-5 3.5M8 8.5L8 14M3 5l5 9M13 5l-5 9M3 11l5-2.5M13 11l-5-2.5"
+          stroke="currentColor"
+          strokeWidth="0.8"
+          strokeLinecap="round"
+        />
       </svg>
     ),
   },
@@ -43,8 +83,20 @@ const REPR_BUTTONS: { id: ViewRepr; label: string; tooltip: string; icon: React.
     tooltip: "Wireframe — edges only, no fill",
     icon: (
       <svg viewBox="0 0 16 16" fill="none" width="13" height="13">
-        <path d="M8 2L13 5v6L8 14L3 11V5z" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/>
-        <path d="M8 2L8 14M3 5l5 3.5M13 5l-5 3.5" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeDasharray="2 1.5"/>
+        <path
+          d="M8 2L13 5v6L8 14L3 11V5z"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.3"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M8 2L8 14M3 5l5 3.5M13 5l-5 3.5"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          strokeLinecap="round"
+          strokeDasharray="2 1.5"
+        />
       </svg>
     ),
   },
@@ -61,7 +113,9 @@ export function StatusBar() {
   const viewRepr = useModelStore((s) => s.viewRepr);
   const setViewRepr = useModelStore((s) => s.setViewRepr);
   const showUndeformedOverlay = useModelStore((s) => s.showUndeformedOverlay);
-  const setShowUndeformedOverlay = useModelStore((s) => s.setShowUndeformedOverlay);
+  const setShowUndeformedOverlay = useModelStore(
+    (s) => s.setShowUndeformedOverlay,
+  );
   const volMesh = useModelStore((s) => s.volMesh);
   const stepSurface = useModelStore((s) => s.stepSurface);
 
@@ -162,10 +216,28 @@ export function StatusBar() {
             className={`${styles.reprBtn} ${showUndeformedOverlay ? styles.reprBtnActive : ""}`}
             aria-label="Toggle undeformed overlay"
             data-tooltip="Show undeformed geometry as overlay"
-            style={{ width: "auto", padding: "0 7px", borderRadius: 5, border: "1px solid #e2e5ea" }}
+            style={{
+              width: "auto",
+              padding: "0 7px",
+              borderRadius: 5,
+              border: "1px solid #e2e5ea",
+            }}
           >
-            <svg viewBox="0 0 16 16" fill="none" width="13" height="13" style={{ marginRight: 4 }}>
-              <path d="M8 2L13 5v6L8 14L3 11V5z" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" strokeDasharray="2.5 1.5"/>
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              width="13"
+              height="13"
+              style={{ marginRight: 4 }}
+            >
+              <path
+                d="M8 2L13 5v6L8 14L3 11V5z"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.3"
+                strokeLinejoin="round"
+                strokeDasharray="2.5 1.5"
+              />
             </svg>
             Undeformed
           </button>

--- a/web/src/components/statusbar/StatusBar.tsx
+++ b/web/src/components/statusbar/StatusBar.tsx
@@ -60,6 +60,8 @@ export function StatusBar() {
   const pickMode = useModelStore((s) => s.pickMode);
   const viewRepr = useModelStore((s) => s.viewRepr);
   const setViewRepr = useModelStore((s) => s.setViewRepr);
+  const showUndeformedOverlay = useModelStore((s) => s.showUndeformedOverlay);
+  const setShowUndeformedOverlay = useModelStore((s) => s.setShowUndeformedOverlay);
   const volMesh = useModelStore((s) => s.volMesh);
   const stepSurface = useModelStore((s) => s.stepSurface);
 
@@ -137,21 +139,37 @@ export function StatusBar() {
         )}
       </div>
 
-      {/* Center — repr toolbar */}
-      <div className={styles.reprGroup}>
-        {REPR_BUTTONS.map(({ id, label, tooltip, icon }, i) => (
+      {/* Center — repr toolbar + undeformed overlay toggle */}
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <div className={styles.reprGroup}>
+          {REPR_BUTTONS.map(({ id, label, tooltip, icon }, i) => (
+            <button
+              key={id}
+              disabled={isDisabled(id)}
+              onClick={() => setViewRepr(id)}
+              className={`${styles.reprBtn} ${viewRepr === id ? styles.reprBtnActive : ""}`}
+              aria-label={label}
+              data-tooltip={tooltip}
+              style={{ borderLeft: i > 0 ? "1px solid #e2e5ea" : "none" }}
+            >
+              {icon}
+            </button>
+          ))}
+        </div>
+        {result && (
           <button
-            key={id}
-            disabled={isDisabled(id)}
-            onClick={() => setViewRepr(id)}
-            className={`${styles.reprBtn} ${viewRepr === id ? styles.reprBtnActive : ""}`}
-            aria-label={label}
-            data-tooltip={tooltip}
-            style={{ borderLeft: i > 0 ? "1px solid #e2e5ea" : "none" }}
+            onClick={() => setShowUndeformedOverlay(!showUndeformedOverlay)}
+            className={`${styles.reprBtn} ${showUndeformedOverlay ? styles.reprBtnActive : ""}`}
+            aria-label="Toggle undeformed overlay"
+            data-tooltip="Show undeformed geometry as overlay"
+            style={{ width: "auto", padding: "0 7px", borderRadius: 5, border: "1px solid #e2e5ea" }}
           >
-            {icon}
+            <svg viewBox="0 0 16 16" fill="none" width="13" height="13" style={{ marginRight: 4 }}>
+              <path d="M8 2L13 5v6L8 14L3 11V5z" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" strokeDasharray="2.5 1.5"/>
+            </svg>
+            Undeformed
           </button>
-        ))}
+        )}
       </div>
 
       {/* Right */}

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -148,6 +148,7 @@ export function MeshScene() {
   const setPendingFaces = useModelStore((s) => s.setPendingFaces);
   const bcGroups = useModelStore((s) => s.bcGroups);
   const loadGroups = useModelStore((s) => s.loadGroups);
+  const showUndeformedOverlay = useModelStore((s) => s.showUndeformedOverlay);
 
   const nodeMap = useMemo(
     () => new Map(nodes.map((n, i) => [n.id, { n, i }])),
@@ -279,31 +280,6 @@ export function MeshScene() {
     }
     return segs.length > 0 ? new Float32Array(segs) : null;
   }, [hexElements, tetElements, nodeMap]);
-
-  const deformedEdgePositions = useMemo(() => {
-    if (!result) return null;
-    const d = result.displacements;
-    const coord = (id: number) => {
-      const { n, i } = nodeMap.get(id)!;
-      return [
-        n.x + (d[i * 3] ?? 0) * deformScale,
-        n.y + (d[i * 3 + 1] ?? 0) * deformScale,
-        n.z + (d[i * 3 + 2] ?? 0) * deformScale,
-      ];
-    };
-    const segs: number[] = [];
-    for (const el of hexElements) {
-      for (const [a, b] of HEX_EDGES) {
-        segs.push(...coord(el.nodeIds[a]), ...coord(el.nodeIds[b]));
-      }
-    }
-    for (const el of tetElements) {
-      for (const [a, b] of TET_EDGES) {
-        segs.push(...coord(el.nodeIds[a]), ...coord(el.nodeIds[b]));
-      }
-    }
-    return segs.length > 0 ? new Float32Array(segs) : null;
-  }, [result, hexElements, tetElements, nodeMap, deformScale]);
 
   const barLines = useMemo(
     () =>
@@ -802,16 +778,16 @@ export function MeshScene() {
         </mesh>
       )}
 
-      {/* Deformed wireframe overlay */}
-      {deformedEdgePositions && (
+      {/* Undeformed geometry overlay — shows original shape as reference over deformed result */}
+      {result && showUndeformedOverlay && undeformedEdgePositions && (
         <lineSegments>
           <bufferGeometry>
             <bufferAttribute
               attach="attributes-position"
-              args={[deformedEdgePositions, 3]}
+              args={[undeformedEdgePositions, 3]}
             />
           </bufferGeometry>
-          <lineBasicMaterial color="#1e3a5f" transparent opacity={0.4} />
+          <lineBasicMaterial color="#1e3a5f" transparent opacity={0.25} />
         </lineSegments>
       )}
 

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -281,6 +281,31 @@ export function MeshScene() {
     return segs.length > 0 ? new Float32Array(segs) : null;
   }, [hexElements, tetElements, nodeMap]);
 
+  const deformedEdgePositions = useMemo(() => {
+    if (!result) return null;
+    const d = result.displacements;
+    const coord = (id: number) => {
+      const { n, i } = nodeMap.get(id)!;
+      return [
+        n.x + (d[i * 3] ?? 0) * deformScale,
+        n.y + (d[i * 3 + 1] ?? 0) * deformScale,
+        n.z + (d[i * 3 + 2] ?? 0) * deformScale,
+      ];
+    };
+    const segs: number[] = [];
+    for (const el of hexElements) {
+      for (const [a, b] of HEX_EDGES) {
+        segs.push(...coord(el.nodeIds[a]), ...coord(el.nodeIds[b]));
+      }
+    }
+    for (const el of tetElements) {
+      for (const [a, b] of TET_EDGES) {
+        segs.push(...coord(el.nodeIds[a]), ...coord(el.nodeIds[b]));
+      }
+    }
+    return segs.length > 0 ? new Float32Array(segs) : null;
+  }, [result, hexElements, tetElements, nodeMap, deformScale]);
+
   const barLines = useMemo(
     () =>
       barElements.map((el) =>
@@ -778,6 +803,19 @@ export function MeshScene() {
         </mesh>
       )}
 
+      {/* Deformed wireframe overlay */}
+      {deformedEdgePositions && (
+        <lineSegments>
+          <bufferGeometry>
+            <bufferAttribute
+              attach="attributes-position"
+              args={[deformedEdgePositions, 3]}
+            />
+          </bufferGeometry>
+          <lineBasicMaterial color="#1e3a5f" transparent opacity={0.4} />
+        </lineSegments>
+      )}
+
       {/* Undeformed geometry overlay — shows original shape as reference over deformed result */}
       {result && showUndeformedOverlay && undeformedEdgePositions && (
         <lineSegments>
@@ -787,12 +825,12 @@ export function MeshScene() {
               args={[undeformedEdgePositions, 3]}
             />
           </bufferGeometry>
-          <lineBasicMaterial color="#1e3a5f" transparent opacity={0.25} />
+          <lineBasicMaterial color="#6b8cad" transparent opacity={0.35} />
         </lineSegments>
       )}
 
       {/* BC face highlights — persistent coloured overlay for all committed BC faces */}
-      {bcFaceHighlights?.map((h, i) => (
+      {!result && bcFaceHighlights?.map((h, i) => (
         <mesh key={`bc-face-${h.groupId}-${i}`} renderOrder={1}>
           <bufferGeometry>
             <bufferAttribute
@@ -811,7 +849,7 @@ export function MeshScene() {
       ))}
 
       {/* Load face highlights — persistent coloured overlay for all committed load faces */}
-      {loadFaceHighlights?.map((h, i) => (
+      {!result && loadFaceHighlights?.map((h, i) => (
         <mesh key={`load-face-${h.groupId}-${i}`} renderOrder={1}>
           <bufferGeometry>
             <bufferAttribute
@@ -868,7 +906,7 @@ export function MeshScene() {
       )}
 
       {/* BC markers — triangular fixed-support symbols (3-sided cone, apex at face, base outward) */}
-      {bcMarkerData && (
+      {!result && bcMarkerData && (
         <group position={bcMarkerData.pos} quaternion={bcMarkerData.quaternion}>
           <mesh position={[0, -modelSize * 0.075, 0]}>
             <coneGeometry args={[modelSize * 0.09, modelSize * 0.15, 3]} />
@@ -886,7 +924,7 @@ export function MeshScene() {
       )}
 
       {/* Load arrow — resultant of all force DOFs, cylinder shaft + cone head */}
-      {loadArrowData &&
+      {!result && loadArrowData &&
         (() => {
           const shaftLen = modelSize * 0.22;
           const headLen = modelSize * 0.09;

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -281,6 +281,26 @@ export function MeshScene() {
     return segs.length > 0 ? new Float32Array(segs) : null;
   }, [hexElements, tetElements, nodeMap]);
 
+  const undeformedSurfaceEdgePositions = useMemo(() => {
+    const seen = new Set<string>();
+    const segs: number[] = [];
+    const addEdge = (a: number, b: number) => {
+      const key = a < b ? `${a},${b}` : `${b},${a}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      const na = nodeMap.get(a)?.n, nb = nodeMap.get(b)?.n;
+      if (!na || !nb) return;
+      segs.push(na.x, na.y, na.z, nb.x, nb.y, nb.z);
+    };
+    for (const [a, b, c, d] of boundaryQuadFaceIds) {
+      addEdge(a, b); addEdge(b, c); addEdge(c, d); addEdge(d, a);
+    }
+    for (const [a, b, c] of boundaryTriFaceIds) {
+      addEdge(a, b); addEdge(b, c); addEdge(c, a);
+    }
+    return segs.length > 0 ? new Float32Array(segs) : null;
+  }, [boundaryQuadFaceIds, boundaryTriFaceIds, nodeMap]);
+
   const deformedEdgePositions = useMemo(() => {
     if (!result) return null;
     const d = result.displacements;
@@ -816,16 +836,16 @@ export function MeshScene() {
         </lineSegments>
       )}
 
-      {/* Undeformed geometry overlay — shows original shape as reference over deformed result */}
-      {result && showUndeformedOverlay && undeformedEdgePositions && (
+      {/* Undeformed geometry overlay — shows original surface edges as reference over deformed result */}
+      {result && showUndeformedOverlay && undeformedSurfaceEdgePositions && (
         <lineSegments>
           <bufferGeometry>
             <bufferAttribute
               attach="attributes-position"
-              args={[undeformedEdgePositions, 3]}
+              args={[undeformedSurfaceEdgePositions, 3]}
             />
           </bufferGeometry>
-          <lineBasicMaterial color="#6b8cad" transparent opacity={0.35} />
+          <lineBasicMaterial color="#6b8cad" transparent opacity={0.5} />
         </lineSegments>
       )}
 

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -288,15 +288,21 @@ export function MeshScene() {
       const key = a < b ? `${a},${b}` : `${b},${a}`;
       if (seen.has(key)) return;
       seen.add(key);
-      const na = nodeMap.get(a)?.n, nb = nodeMap.get(b)?.n;
+      const na = nodeMap.get(a)?.n,
+        nb = nodeMap.get(b)?.n;
       if (!na || !nb) return;
       segs.push(na.x, na.y, na.z, nb.x, nb.y, nb.z);
     };
     for (const [a, b, c, d] of boundaryQuadFaceIds) {
-      addEdge(a, b); addEdge(b, c); addEdge(c, d); addEdge(d, a);
+      addEdge(a, b);
+      addEdge(b, c);
+      addEdge(c, d);
+      addEdge(d, a);
     }
     for (const [a, b, c] of boundaryTriFaceIds) {
-      addEdge(a, b); addEdge(b, c); addEdge(c, a);
+      addEdge(a, b);
+      addEdge(b, c);
+      addEdge(c, a);
     }
     return segs.length > 0 ? new Float32Array(segs) : null;
   }, [boundaryQuadFaceIds, boundaryTriFaceIds, nodeMap]);
@@ -850,42 +856,44 @@ export function MeshScene() {
       )}
 
       {/* BC face highlights — persistent coloured overlay for all committed BC faces */}
-      {!result && bcFaceHighlights?.map((h, i) => (
-        <mesh key={`bc-face-${h.groupId}-${i}`} renderOrder={1}>
-          <bufferGeometry>
-            <bufferAttribute
-              attach="attributes-position"
-              args={[h.positions, 3]}
+      {!result &&
+        bcFaceHighlights?.map((h, i) => (
+          <mesh key={`bc-face-${h.groupId}-${i}`} renderOrder={1}>
+            <bufferGeometry>
+              <bufferAttribute
+                attach="attributes-position"
+                args={[h.positions, 3]}
+              />
+            </bufferGeometry>
+            <meshBasicMaterial
+              color="#dc2626"
+              transparent
+              opacity={pickTargetGroupId === h.groupId ? 0.45 : 0.25}
+              depthTest={false}
+              side={THREE.DoubleSide}
             />
-          </bufferGeometry>
-          <meshBasicMaterial
-            color="#dc2626"
-            transparent
-            opacity={pickTargetGroupId === h.groupId ? 0.45 : 0.25}
-            depthTest={false}
-            side={THREE.DoubleSide}
-          />
-        </mesh>
-      ))}
+          </mesh>
+        ))}
 
       {/* Load face highlights — persistent coloured overlay for all committed load faces */}
-      {!result && loadFaceHighlights?.map((h, i) => (
-        <mesh key={`load-face-${h.groupId}-${i}`} renderOrder={1}>
-          <bufferGeometry>
-            <bufferAttribute
-              attach="attributes-position"
-              args={[h.positions, 3]}
+      {!result &&
+        loadFaceHighlights?.map((h, i) => (
+          <mesh key={`load-face-${h.groupId}-${i}`} renderOrder={1}>
+            <bufferGeometry>
+              <bufferAttribute
+                attach="attributes-position"
+                args={[h.positions, 3]}
+              />
+            </bufferGeometry>
+            <meshBasicMaterial
+              color="#d97706"
+              transparent
+              opacity={pickTargetGroupId === h.groupId ? 0.45 : 0.25}
+              depthTest={false}
+              side={THREE.DoubleSide}
             />
-          </bufferGeometry>
-          <meshBasicMaterial
-            color="#d97706"
-            transparent
-            opacity={pickTargetGroupId === h.groupId ? 0.45 : 0.25}
-            depthTest={false}
-            side={THREE.DoubleSide}
-          />
-        </mesh>
-      ))}
+          </mesh>
+        ))}
 
       {/* Pending faces — accumulated via shift-click, same colour as selection but slightly dimmer */}
       {pendingFacePositions && (
@@ -944,7 +952,8 @@ export function MeshScene() {
       )}
 
       {/* Load arrow — resultant of all force DOFs, cylinder shaft + cone head */}
-      {!result && loadArrowData &&
+      {!result &&
+        loadArrowData &&
         (() => {
           const shaftLen = modelSize * 0.22;
           const headLen = modelSize * 0.09;

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -396,11 +396,13 @@ interface ModelState {
   surfaceTriangles: [number, number, number][] | null;
   surfaceFaceIds: number[] | null;
   viewRepr: "geometry" | "surface" | "volume" | "wireframe";
+  showUndeformedOverlay: boolean;
   stepImportError: string | null;
   setStepSurface(mesh: StepSurfaceMesh | null): void;
   setVolMesh(mesh: VolMesh | null): void;
   setSurfaceFaceIds(ids: number[] | null): void;
   setViewRepr(v: "geometry" | "surface" | "volume" | "wireframe"): void;
+  setShowUndeformedOverlay(v: boolean): void;
   setStepImportError(msg: string | null): void;
 
   // Welcome screen entry points
@@ -506,6 +508,7 @@ export const useModelStore = create<ModelState>()(
     surfaceTriangles: null,
     surfaceFaceIds: null,
     viewRepr: "surface" as const,
+    showUndeformedOverlay: true,
     stepImportError: null,
     geometries: [],
     nextGeomId: 2,
@@ -523,6 +526,10 @@ export const useModelStore = create<ModelState>()(
     setViewRepr: (v) =>
       set((s) => {
         s.viewRepr = v;
+      }),
+    setShowUndeformedOverlay: (v) =>
+      set((s) => {
+        s.showUndeformedOverlay = v;
       }),
     setVolMesh: (mesh) =>
       set((s) => {


### PR DESCRIPTION
## Summary
Adds a UI control to toggle an overlay of the original (undeformed) surface geometry when viewing deformed FEM results. This allows users to visually compare the deformed shape against the original CAD boundary.

## Changes
- **StatusBar.tsx**: Added "Undeformed" button to the center toolbar that toggles the overlay when a result is loaded. The button displays a dashed wireframe icon and is styled to match the existing repr buttons.
- **MeshScene.tsx**: 
  - Computes `undeformedSurfaceEdgePositions` from the original node coordinates and boundary face topology
  - Renders the undeformed surface edges as a semi-transparent blue line overlay when `showUndeformedOverlay` is true and a result exists
  - Hides BC/load face highlights and markers when a result is displayed (they are only relevant during pre-analysis setup)
- **modelStore.ts**: Added `showUndeformedOverlay` state (default `true`) and `setShowUndeformedOverlay` setter to the model store

## Implementation Details
- The undeformed overlay uses the original node coordinates from `nodeMap` (which are never modified by deformation) paired with the boundary face topology (`boundaryQuadFaceIds`, `boundaryTriFaceIds`)
- Rendered with `lineBasicMaterial` at 50% opacity in a muted blue (`#6b8cad`) to distinguish it from the deformed geometry
- The overlay is only shown when both a result exists and the toggle is enabled, preventing visual clutter during mesh setup
- BC and load visualization elements are now hidden during result viewing to avoid overlapping UI elements

https://claude.ai/code/session_011oT2xq7K9mK527PdQXKH8P