### PR TITLE
Add moment load support with equivalent nodal force conversion

### DIFF
--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -1078,7 +1078,9 @@ function ConstraintsPanel() {
                   </select>
                 </div>
                 <div className={styles.formRow}>
-                  <span className={styles.formLabel}>Total (N)</span>
+                  <span className={styles.formLabel}>
+                    {loadDof <= 2 ? "Total (N)" : "Total (N·m)"}
+                  </span>
                   <input
                     className={styles.formInput}
                     type="number"
@@ -1090,11 +1092,9 @@ function ConstraintsPanel() {
                 <div className={styles.pickNote}>
                   {allPickedFaces.reduce((s, f) => s + f.nodeIds.length, 0)}{" "}
                   nodes →{" "}
-                  {(
-                    parseFloat(loadForce) /
-                    allPickedFaces.reduce((s, f) => s + f.nodeIds.length, 0)
-                  ).toFixed(1)}{" "}
-                  N/node
+                  {loadDof <= 2
+                    ? `${(parseFloat(loadForce) / allPickedFaces.reduce((s, f) => s + f.nodeIds.length, 0)).toFixed(1)} N/node`
+                    : "distributed as equivalent nodal forces"}
                 </div>
                 <button className={styles.loadBtn} onClick={applyLoad}>
                   Apply Load
@@ -1119,7 +1119,8 @@ function ConstraintsPanel() {
               <span className={styles.loadDot} />
               <span className={styles.bcGroupName}>{g.name}</span>
               <span className={styles.bcGroupMeta}>
-                F{DOF_LABELS[g.dof]} = {fmt(g.totalForce)} N
+                {LOAD_LABELS[g.dof]} = {fmt(g.totalForce)}{" "}
+                {g.dof <= 2 ? "N" : "N·m"}
               </span>
               <div className={styles.treeItemActions}>
                 <button

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -148,14 +148,81 @@ function rebuildConstraints(bcGroups: NamedBcGroup[]): Constraint[] {
   return result;
 }
 
-function rebuildLoads(loadGroups: NamedLoadGroup[]): Load[] {
+function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
+  const nodeById = new Map<number, Node>();
+  for (const n of nodes) nodeById.set(n.id, n);
+
   const result: Load[] = [];
-  for (const g of loadGroups)
-    for (const f of g.faces) {
-      const perNode = g.totalForce / f.nodeIds.length;
-      for (const nodeId of f.nodeIds)
-        result.push({ nodeId, dof: g.dof, value: perNode });
+  for (const g of loadGroups) {
+    if (g.dof <= 2) {
+      // Force load — distribute total evenly across face nodes
+      for (const f of g.faces) {
+        const perNode = g.totalForce / f.nodeIds.length;
+        for (const nodeId of f.nodeIds)
+          result.push({ nodeId, dof: g.dof, value: perNode });
+      }
+    } else {
+      // Moment load (dof 3=Mx, 4=My, 5=Mz) — convert to equivalent nodal forces.
+      // For each face, find the centroid, then apply tangential forces F_i = M/S·(n̂×r_i)
+      // where S = Σ|r_i⊥|² (perpendicular distance squared from moment axis).
+      // This satisfies Σ(r_i × F_i) = M exactly with zero net force.
+      const momentAxis = g.dof - 3; // 0=x, 1=y, 2=z
+      for (const f of g.faces) {
+        let cx = 0,
+          cy = 0,
+          cz = 0,
+          count = 0;
+        for (const nodeId of f.nodeIds) {
+          const n = nodeById.get(nodeId);
+          if (n) {
+            cx += n.x;
+            cy += n.y;
+            cz += n.z;
+            count++;
+          }
+        }
+        if (count === 0) continue;
+        cx /= count;
+        cy /= count;
+        cz /= count;
+
+        let S = 0;
+        for (const nodeId of f.nodeIds) {
+          const n = nodeById.get(nodeId);
+          if (!n) continue;
+          const rx = n.x - cx,
+            ry = n.y - cy,
+            rz = n.z - cz;
+          if (momentAxis === 0) S += ry * ry + rz * rz;
+          else if (momentAxis === 1) S += rx * rx + rz * rz;
+          else S += rx * rx + ry * ry;
+        }
+        if (S === 0) continue; // all nodes on the moment axis — undefined
+
+        const scale = g.totalForce / S;
+        for (const nodeId of f.nodeIds) {
+          const n = nodeById.get(nodeId);
+          if (!n) continue;
+          const rx = n.x - cx,
+            ry = n.y - cy,
+            rz = n.z - cz;
+          if (momentAxis === 0) {
+            // Mx → F = scale·(0, −rz, ry)
+            result.push({ nodeId, dof: 1, value: -scale * rz });
+            result.push({ nodeId, dof: 2, value: scale * ry });
+          } else if (momentAxis === 1) {
+            // My → F = scale·(rz, 0, −rx)
+            result.push({ nodeId, dof: 0, value: scale * rz });
+            result.push({ nodeId, dof: 2, value: -scale * rx });
+          } else {
+            // Mz → F = scale·(−ry, rx, 0)
+            result.push({ nodeId, dof: 0, value: -scale * ry });
+            result.push({ nodeId, dof: 1, value: scale * rx });
+          }
+        }
+      }
     }
+  }
   return result;
 }
 
@@ -582,7 +649,7 @@ export const useModelStore = create<ModelState>()(
         s.bcGroups = c.bcGroups;
         s.loadGroups = c.loadGroups;
         s.constraints = rebuildConstraints(c.bcGroups);
-        s.loads = rebuildLoads(c.loadGroups);
+        s.loads = rebuildLoads(c.loadGroups, c.nodes);
         s.nextBcGroupId = 2;
         s.nextLoadGroupId = 2;
         s.nextFaceEntryId = 3;
@@ -746,7 +813,7 @@ export const useModelStore = create<ModelState>()(
         s.nextLoadGroupId = loadResult.nextGroupId;
         s.nextFaceEntryId = loadResult.nextFaceId;
         s.constraints = rebuildConstraints(s.bcGroups);
-        s.loads = rebuildLoads(s.loadGroups);
+        s.loads = rebuildLoads(s.loadGroups, s.nodes);
 
         s.modelName = snap.modelName ?? "Model";
         s.result = null;
@@ -771,7 +838,7 @@ export const useModelStore = create<ModelState>()(
         s.bcGroups = a.bcGroups;
         s.loadGroups = a.loadGroups;
         s.constraints = rebuildConstraints(a.bcGroups);
-        s.loads = rebuildLoads(a.loadGroups);
+        s.loads = rebuildLoads(a.loadGroups, s.nodes);
         s.nextBcGroupId = a.nextBcGroupId;
         s.nextLoadGroupId = a.nextLoadGroupId;
         s.nextFaceEntryId = a.nextFaceEntryId;
@@ -992,7 +1059,7 @@ export const useModelStore = create<ModelState>()(
           faces: faceEntries,
         });
         s.nextLoadGroupId++;
-        s.loads = rebuildLoads(s.loadGroups);
+        s.loads = rebuildLoads(s.loadGroups, s.nodes);
         s.result = null;
       }),
 
@@ -1002,7 +1069,7 @@ export const useModelStore = create<ModelState>()(
         if (!g) return;
         const faceId = s.nextFaceEntryId++;
         g.faces.push({ id: faceId, label: face.label, nodeIds: face.nodeIds });
-        s.loads = rebuildLoads(s.loadGroups);
+        s.loads = rebuildLoads(s.loadGroups, s.nodes);
         s.result = null;
       }),
 
@@ -1013,14 +1080,14 @@ export const useModelStore = create<ModelState>()(
         g.faces = g.faces.filter((f) => f.id !== faceId);
         if (g.faces.length === 0)
           s.loadGroups = s.loadGroups.filter((g) => g.id !== groupId);
-        s.loads = rebuildLoads(s.loadGroups);
+        s.loads = rebuildLoads(s.loadGroups, s.nodes);
         s.result = null;
       }),
 
     deleteLoadGroup: (id: number) =>
       set((s) => {
         s.loadGroups = s.loadGroups.filter((g) => g.id !== id);
-        s.loads = rebuildLoads(s.loadGroups);
+        s.loads = rebuildLoads(s.loadGroups, s.nodes);
         s.result = null;
       }),
 

--- a/web/tests/moment-loads.spec.ts
+++ b/web/tests/moment-loads.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect } from "./coverage";
+
+// Helper: dismiss the welcome screen by loading the built-in example
+async function startExample(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Start with example" }).click();
+  await expect(page.getByRole("button", { name: "Import STEP" })).toBeVisible();
+}
+
+type Store = {
+  getState(): {
+    nodes: { id: number; x: number; y: number; z: number }[];
+    loads: { nodeId: number; dof: number; value: number }[];
+    clearLoads(): void;
+    createLoadGroup(
+      faces: { label: string; nodeIds: number[] }[],
+      dof: number,
+      totalForce: number,
+    ): void;
+  };
+};
+
+// ── Moment-load conversion math ───────────────────────────────────────────────
+
+test("Mz moment produces tangential forces with zero net force and correct net moment", async ({
+  page,
+}) => {
+  await startExample(page);
+
+  const result = await page.evaluate(() => {
+    const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
+
+    // End face of cantilever (x ≈ 1.0) — 9 nodes on a 3×3 grid
+    const endNodes = store.getState().nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    store.getState().clearLoads();
+    store.getState().createLoadGroup(
+      [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
+      5, // Mz
+      1000,
+    );
+
+    // Re-read loads from fresh state after mutations
+    const loads = store.getState().loads;
+
+    // Centroid of the face
+    const cx = endNodes.reduce((s, n) => s + n.x, 0) / endNodes.length;
+    const cy = endNodes.reduce((s, n) => s + n.y, 0) / endNodes.length;
+
+    const nodeById = new Map(endNodes.map((n) => [n.id, n]));
+    let netFx = 0, netFy = 0, netFz = 0, netMz = 0;
+    for (const l of loads) {
+      const n = nodeById.get(l.nodeId)!;
+      const rx = n.x - cx, ry = n.y - cy;
+      if (l.dof === 0) { netFx += l.value; netMz -= ry * l.value; }
+      if (l.dof === 1) { netFy += l.value; netMz += rx * l.value; }
+      if (l.dof === 2) netFz += l.value;
+    }
+
+    return { nodeCount: endNodes.length, netFx, netFy, netFz, netMz, loads };
+  });
+
+  expect(result.nodeCount).toBe(9); // 3×3 end face
+  // All resulting loads must be force DOFs (0–2), not moment DOFs
+  expect(result.loads.every((l) => l.dof <= 2)).toBe(true);
+  // Net force must be zero (pure couple)
+  expect(result.netFx).toBeCloseTo(0, 9);
+  expect(result.netFy).toBeCloseTo(0, 9);
+  expect(result.netFz).toBeCloseTo(0, 9);
+  // Net moment about z must equal the applied moment exactly
+  expect(result.netMz).toBeCloseTo(1000, 6);
+});
+
+test("Mx moment produces correct net moment about x and zero net force", async ({
+  page,
+}) => {
+  await startExample(page);
+
+  const result = await page.evaluate(() => {
+    const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
+
+    const endNodes = store.getState().nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    store.getState().clearLoads();
+    store.getState().createLoadGroup(
+      [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
+      3, // Mx
+      500,
+    );
+
+    const loads = store.getState().loads;
+    const cy = endNodes.reduce((s, n) => s + n.y, 0) / endNodes.length;
+    const cz = endNodes.reduce((s, n) => s + n.z, 0) / endNodes.length;
+
+    const nodeById = new Map(endNodes.map((n) => [n.id, n]));
+    let netFx = 0, netFy = 0, netFz = 0, netMx = 0;
+    for (const l of loads) {
+      const n = nodeById.get(l.nodeId)!;
+      const ry = n.y - cy, rz = n.z - cz;
+      if (l.dof === 0) netFx += l.value;
+      if (l.dof === 1) { netFy += l.value; netMx -= rz * l.value; }
+      if (l.dof === 2) { netFz += l.value; netMx += ry * l.value; }
+    }
+
+    return { netFx, netFy, netFz, netMx, loads };
+  });
+
+  expect(result.loads.every((l) => l.dof <= 2)).toBe(true);
+  expect(result.netFx).toBeCloseTo(0, 9);
+  expect(result.netFy).toBeCloseTo(0, 9);
+  expect(result.netFz).toBeCloseTo(0, 9);
+  expect(result.netMx).toBeCloseTo(500, 6);
+});
+
+test("My moment produces correct net moment about y and zero net force", async ({
+  page,
+}) => {
+  await startExample(page);
+
+  const result = await page.evaluate(() => {
+    const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
+
+    const endNodes = store.getState().nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    store.getState().clearLoads();
+    store.getState().createLoadGroup(
+      [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
+      4, // My
+      750,
+    );
+
+    const loads = store.getState().loads;
+    const cx = endNodes.reduce((s, n) => s + n.x, 0) / endNodes.length;
+    const cz = endNodes.reduce((s, n) => s + n.z, 0) / endNodes.length;
+
+    const nodeById = new Map(endNodes.map((n) => [n.id, n]));
+    let netFx = 0, netFy = 0, netFz = 0, netMy = 0;
+    for (const l of loads) {
+      const n = nodeById.get(l.nodeId)!;
+      const rx = n.x - cx, rz = n.z - cz;
+      if (l.dof === 0) { netFx += l.value; netMy += rz * l.value; }
+      if (l.dof === 1) netFy += l.value;
+      if (l.dof === 2) { netFz += l.value; netMy -= rx * l.value; }
+    }
+
+    return { netFx, netFy, netFz, netMy, loads };
+  });
+
+  expect(result.loads.every((l) => l.dof <= 2)).toBe(true);
+  expect(result.netFx).toBeCloseTo(0, 9);
+  expect(result.netFy).toBeCloseTo(0, 9);
+  expect(result.netFz).toBeCloseTo(0, 9);
+  expect(result.netMy).toBeCloseTo(750, 6);
+});
+
+// ── Solve integration ─────────────────────────────────────────────────────────
+
+test("solve completes successfully when loads include a moment (Mz)", async ({
+  page,
+}) => {
+  // Only treat errors from the app origin as fatal; ignore third-party
+  // resource failures (e.g. font CDN SSL errors in the sandboxed environment).
+  let _reject: ((e: Error) => void) | null = null;
+  const fatal = new Promise<never>((_, rej) => { _reject = rej; });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      const text = msg.text();
+      // Ignore external resource failures unrelated to the app
+      if (text.includes("net::ERR_") || text.includes("Failed to load resource"))
+        return;
+      _reject?.(new Error(`Browser error: ${text}`));
+    }
+  });
+  page.on("pageerror", (err) => _reject?.(err));
+
+  await startExample(page);
+
+  // Replace the default Fy force load with a Mz moment load via the store
+  await page.evaluate(() => {
+    const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
+    const endNodes = store.getState().nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    store.getState().clearLoads();
+    store.getState().createLoadGroup(
+      [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
+      5, // Mz — 1 kN·m torsion at the free end
+      1000,
+    );
+  });
+
+  // Navigate to Solve panel and run
+  await page
+    .locator("nav")
+    .getByRole("button")
+    .filter({ hasText: "Solve" })
+    .click();
+
+  const solveBtn = page
+    .getByRole("button")
+    .filter({ hasText: "Run static solve" });
+  await Promise.race([expect(solveBtn).toBeEnabled(), fatal]);
+  await solveBtn.click();
+
+  await Promise.race([
+    expect(page.getByText(/Max \|U\|/)).toBeVisible({ timeout: 30_000 }),
+    fatal,
+  ]);
+});

--- a/web/tests/moment-loads.spec.ts
+++ b/web/tests/moment-loads.spec.ts
@@ -31,7 +31,9 @@ test("Mz moment produces tangential forces with zero net force and correct net m
     const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
 
     // End face of cantilever (x ≈ 1.0) — 9 nodes on a 3×3 grid
-    const endNodes = store.getState().nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    const endNodes = store
+      .getState()
+      .nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
     store.getState().clearLoads();
     store.getState().createLoadGroup(
       [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
@@ -47,12 +49,22 @@ test("Mz moment produces tangential forces with zero net force and correct net m
     const cy = endNodes.reduce((s, n) => s + n.y, 0) / endNodes.length;
 
     const nodeById = new Map(endNodes.map((n) => [n.id, n]));
-    let netFx = 0, netFy = 0, netFz = 0, netMz = 0;
+    let netFx = 0,
+      netFy = 0,
+      netFz = 0,
+      netMz = 0;
     for (const l of loads) {
       const n = nodeById.get(l.nodeId)!;
-      const rx = n.x - cx, ry = n.y - cy;
-      if (l.dof === 0) { netFx += l.value; netMz -= ry * l.value; }
-      if (l.dof === 1) { netFy += l.value; netMz += rx * l.value; }
+      const rx = n.x - cx,
+        ry = n.y - cy;
+      if (l.dof === 0) {
+        netFx += l.value;
+        netMz -= ry * l.value;
+      }
+      if (l.dof === 1) {
+        netFy += l.value;
+        netMz += rx * l.value;
+      }
       if (l.dof === 2) netFz += l.value;
     }
 
@@ -78,7 +90,9 @@ test("Mx moment produces correct net moment about x and zero net force", async (
   const result = await page.evaluate(() => {
     const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
 
-    const endNodes = store.getState().nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    const endNodes = store
+      .getState()
+      .nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
     store.getState().clearLoads();
     store.getState().createLoadGroup(
       [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
@@ -91,13 +105,23 @@ test("Mx moment produces correct net moment about x and zero net force", async (
     const cz = endNodes.reduce((s, n) => s + n.z, 0) / endNodes.length;
 
     const nodeById = new Map(endNodes.map((n) => [n.id, n]));
-    let netFx = 0, netFy = 0, netFz = 0, netMx = 0;
+    let netFx = 0,
+      netFy = 0,
+      netFz = 0,
+      netMx = 0;
     for (const l of loads) {
       const n = nodeById.get(l.nodeId)!;
-      const ry = n.y - cy, rz = n.z - cz;
+      const ry = n.y - cy,
+        rz = n.z - cz;
       if (l.dof === 0) netFx += l.value;
-      if (l.dof === 1) { netFy += l.value; netMx -= rz * l.value; }
-      if (l.dof === 2) { netFz += l.value; netMx += ry * l.value; }
+      if (l.dof === 1) {
+        netFy += l.value;
+        netMx -= rz * l.value;
+      }
+      if (l.dof === 2) {
+        netFz += l.value;
+        netMx += ry * l.value;
+      }
     }
 
     return { netFx, netFy, netFz, netMx, loads };
@@ -118,7 +142,9 @@ test("My moment produces correct net moment about y and zero net force", async (
   const result = await page.evaluate(() => {
     const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
 
-    const endNodes = store.getState().nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    const endNodes = store
+      .getState()
+      .nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
     store.getState().clearLoads();
     store.getState().createLoadGroup(
       [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
@@ -131,13 +157,23 @@ test("My moment produces correct net moment about y and zero net force", async (
     const cz = endNodes.reduce((s, n) => s + n.z, 0) / endNodes.length;
 
     const nodeById = new Map(endNodes.map((n) => [n.id, n]));
-    let netFx = 0, netFy = 0, netFz = 0, netMy = 0;
+    let netFx = 0,
+      netFy = 0,
+      netFz = 0,
+      netMy = 0;
     for (const l of loads) {
       const n = nodeById.get(l.nodeId)!;
-      const rx = n.x - cx, rz = n.z - cz;
-      if (l.dof === 0) { netFx += l.value; netMy += rz * l.value; }
+      const rx = n.x - cx,
+        rz = n.z - cz;
+      if (l.dof === 0) {
+        netFx += l.value;
+        netMy += rz * l.value;
+      }
       if (l.dof === 1) netFy += l.value;
-      if (l.dof === 2) { netFz += l.value; netMy -= rx * l.value; }
+      if (l.dof === 2) {
+        netFz += l.value;
+        netMy -= rx * l.value;
+      }
     }
 
     return { netFx, netFy, netFz, netMy, loads };
@@ -158,12 +194,17 @@ test("solve completes successfully when loads include a moment (Mz)", async ({
   // Only treat errors from the app origin as fatal; ignore third-party
   // resource failures (e.g. font CDN SSL errors in the sandboxed environment).
   let _reject: ((e: Error) => void) | null = null;
-  const fatal = new Promise<never>((_, rej) => { _reject = rej; });
+  const fatal = new Promise<never>((_, rej) => {
+    _reject = rej;
+  });
   page.on("console", (msg) => {
     if (msg.type() === "error") {
       const text = msg.text();
       // Ignore external resource failures unrelated to the app
-      if (text.includes("net::ERR_") || text.includes("Failed to load resource"))
+      if (
+        text.includes("net::ERR_") ||
+        text.includes("Failed to load resource")
+      )
         return;
       _reject?.(new Error(`Browser error: ${text}`));
     }
@@ -175,7 +216,9 @@ test("solve completes successfully when loads include a moment (Mz)", async ({
   // Replace the default Fy force load with a Mz moment load via the store
   await page.evaluate(() => {
     const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
-    const endNodes = store.getState().nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    const endNodes = store
+      .getState()
+      .nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
     store.getState().clearLoads();
     store.getState().createLoadGroup(
       [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],


### PR DESCRIPTION
## Summary

Extends the load system to support moment loads (Mx, My, Mz) in addition to force loads. Moment loads are converted to equivalent nodal forces distributed across face nodes such that the net torque equals the applied moment with zero net force.

## Changes

- **`rebuildLoads()` function**: 
  - Now accepts `nodes` parameter to access node coordinates
  - Distinguishes between force loads (dof ≤ 2) and moment loads (dof 3–5)
  - For moment loads: computes face centroid, calculates perpendicular distance scaling factor `S = Σ|r_i⊥|²`, then applies tangential forces `F_i = (M/S)·(n̂×r_i)` to each node
  - This ensures `Σ(r_i × F_i) = M` exactly with zero net force

- **UI updates** (`LeftPanel.tsx`):
  - Load input label now shows "Total (N)" for forces and "Total (N·m)" for moments
  - Per-node distribution note changes from "N/node" to "distributed as equivalent nodal forces" for moments
  - Load group display uses `LOAD_LABELS` and shows correct units (N vs. N·m)

- **All call sites**: Updated `rebuildLoads()` calls throughout `modelStore.ts` to pass the `nodes` array

## Implementation Details

The moment-to-force conversion uses the standard rigid-body mechanics approach: for a moment **M** about axis **n̂** applied to a face, each node receives a force proportional to its perpendicular distance from the centroid. The scaling ensures the cross-product sum recovers the original moment exactly, avoiding net force artifacts.

https://claude.ai/code/session_017FHJCrEgq5sML4hezbrZsb