### PR TITLE
Add Docker build configuration for web frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, production]
   pull_request:
 
 env:
@@ -88,10 +88,16 @@ jobs:
     needs: [wasm]
     runs-on: ubuntu-24.04
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Full history + tags so `git describe --tags` can stamp the image.
+          fetch-depth: 0
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
@@ -167,3 +173,48 @@ jobs:
       - name: Post mesh report to Slack
         if: always()
         run: cd web && bun scripts/generate-mesh-report.ts
+
+      # --- Docker image -----------------------------------------------------
+      # Runs in the frontend job to reuse its checkout. No `if: always()`, so a
+      # failing test above skips the build — a broken commit never ships an
+      # image. production = build + push to GHCR; every other branch/PR builds
+      # only as a smoke test. The image is built map-free in production mode by
+      # web/Dockerfile.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/production'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build web image (production = push, otherwise build only)
+        run: |
+          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_PREFIX="ghcr.io/${OWNER_LC}"
+          VERSION=$(git describe --tags --abbrev=0 || echo 'no-tags-found')
+          IMAGE_TAG="${VERSION}-$(git rev-parse --short HEAD)"
+
+          if [ "${GITHUB_REF}" = "refs/heads/production" ]; then
+            echo "Production build: pushing images"
+            PUSH_FLAG="--push"
+            TAG_ARGS="--tag ${IMAGE_PREFIX}/kofem-web:latest \
+                      --tag ${IMAGE_PREFIX}/kofem-web:${IMAGE_TAG}"
+          else
+            echo "Development build: build only, no push"
+            PUSH_FLAG=""
+            TAG_ARGS=""
+          fi
+
+          docker buildx build \
+            --platform linux/amd64 \
+            --file ./web/Dockerfile \
+            --build-arg VITE_GIT_VERSION=${VERSION} \
+            --cache-from=type=gha \
+            --cache-to=type=gha,mode=max \
+            $TAG_ARGS \
+            $PUSH_FLAG \
+            ./web

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.vite
+test-results
+playwright-results
+coverage
+.nyc_output
+screenshots/mesh-report.pdf
+screenshots/report

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,39 @@
+# Build context is ./web (see .github/workflows/docker-image.yml).
+#
+# Stage 1: Build the static frontend bundle with Bun.
+FROM oven/bun:latest AS builder
+
+WORKDIR /app
+
+# Copy only dependency manifests first — this layer is cached until
+# package.json or bun.lock changes.
+COPY package.json bun.lock ./
+
+RUN bun install --frozen-lockfile
+
+# Copy the rest of the source. This includes the pre-compiled WASM engine
+# committed under src/wasm/pkg/, so no Emscripten build is needed here.
+COPY . .
+
+# Optional version stamp injected by CI. Vite exposes VITE_* vars to the
+# bundle via import.meta.env at build time.
+ARG VITE_GIT_VERSION=local
+ENV VITE_GIT_VERSION=$VITE_GIT_VERSION
+
+RUN bun run build
+
+
+# Stage 2: Serve the static bundle with Nginx.
+FROM nginx:alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Render (and similar hosts) inject a dynamic port via $PORT; the nginx
+# template is rendered with envsubst at container start.
+ENV PORT=10000
+
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+
+EXPOSE 10000
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,7 +1,17 @@
-# Build context is ./web (see .github/workflows/docker-image.yml).
+# Build context is ./web (see .github/workflows/ci.yml, "docker" steps).
 #
-# Stage 1: Build the static frontend bundle with Bun.
-FROM oven/bun:latest AS builder
+# Stage 1: Build the static frontend bundle.
+#
+# Base image is Node with the Bun binary copied in. Bun drives the
+# frozen-lockfile install, but `vite` must run under Node: the bun-only image
+# has no Node, so vite would run on Bun's runtime, which is incompatible with
+# vite-plugin-top-level-await (TypeError: virtualModule.require is not a
+# function). With Node present, the `#!/usr/bin/env node` shebang on the vite
+# binary resolves to Node and the build succeeds. This is an isolated,
+# production-mode build (no source maps), independent of whatever the CI test
+# step left in web/dist.
+FROM node:20-bookworm-slim AS builder
+COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/bun
 
 WORKDIR /app
 
@@ -21,6 +31,9 @@ ARG VITE_GIT_VERSION=local
 ENV VITE_GIT_VERSION=$VITE_GIT_VERSION
 
 RUN bun run build
+
+# Defensive: production images must never contain source maps.
+RUN find dist -name '*.map' -type f -delete
 
 
 # Stage 2: Serve the static bundle with Nginx.

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -1,0 +1,27 @@
+# Rendered by the nginx image entrypoint (envsubst) at container start.
+# Only env vars present in the environment are substituted, so nginx
+# runtime variables like $uri are left untouched — $PORT is filled in.
+server {
+    listen       ${PORT};
+    server_name  _;
+
+    root   /usr/share/nginx/html;
+    index  index.html;
+
+    # nginx:alpine's mime.types already maps .wasm -> application/wasm.
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json application/wasm image/svg+xml;
+    gzip_min_length 1024;
+
+    # Fingerprinted Vite assets are immutable — cache them aggressively.
+    location /assets/ {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Single-page-app fallback: unknown routes serve index.html.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

Add Docker containerization for the KoFEM web frontend, enabling deployment to container platforms like Render. The setup uses a two-stage build: Bun compiles the React + Vite frontend, then Nginx serves the static bundle with appropriate caching and SPA routing.

## Key changes

- **Dockerfile**: Multi-stage build that:
  - Builds the static frontend bundle with Bun in the first stage
  - Serves the compiled assets via Nginx Alpine in the second stage
  - Supports dynamic port configuration via the `$PORT` environment variable (for Render and similar platforms)
  - Accepts optional `VITE_GIT_VERSION` build argument for version stamping

- **nginx.conf.template**: Nginx configuration template that:
  - Listens on the dynamic `$PORT` (rendered at container startup via envsubst)
  - Enables gzip compression for text, JavaScript, JSON, and WebAssembly assets
  - Implements aggressive caching (1 year, immutable) for fingerprinted Vite assets under `/assets/`
  - Provides SPA fallback routing: unknown routes serve `index.html`

- **.dockerignore**: Excludes build artifacts and development files from the Docker build context (node_modules, dist, test results, coverage, etc.)

## Implementation details

- The build context is `./web` (configured in CI workflow)
- Pre-compiled WASM engine is committed under `src/wasm/pkg/`, so no Emscripten build occurs in the container
- Bun dependency lock is frozen during install to ensure reproducible builds
- Nginx template uses `${PORT}` syntax so that nginx runtime variables like `$uri` are preserved during envsubst substitution

https://claude.ai/code/session_01CXAfn8SPtqzqHGWsX6wC9o