### PR TITLE
Fix build config to fail closed on source maps and minification

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ detached with `-d`).
 
 The container's internal port is configurable via the `PORT` environment
 variable (default `10000`). Only change this if something else is already using
-10000 *inside* the container — for normal use, just change the host side of the
+10000 _inside_ the container — for normal use, just change the host side of the
 `-p` mapping:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# KoFEM
+
+KoFEM is a browser-first finite element analysis application. It runs the full
+pipeline — **STEP geometry → OCCT tessellation → Netgen volume mesh → MFEM FEM
+solve** — directly in the browser via a C++ engine compiled to WebAssembly,
+with a React + Three.js frontend.
+
+For architecture and development details, see [`CLAUDE.md`](./CLAUDE.md).
+
+## Running the production app with Docker
+
+The production app is a static frontend (pre-built WASM engine + React UI)
+served by Nginx. The image is self-contained: the compiled WASM engine is
+committed under `web/src/wasm/pkg/`, so **you do not need Emscripten, Rust, or
+the C++ libraries to build or run it** — just Docker.
+
+The container listens on port **10000** inside the image.
+
+### Option A — Build and run the image yourself
+
+```bash
+# From the repository root.
+# The build context is the web/ directory (the Dockerfile lives at web/Dockerfile).
+docker build -t kofem-web ./web
+
+# Run it, mapping host port 8080 → container port 10000.
+docker run --rm -p 8080:10000 kofem-web
+```
+
+Then open <http://localhost:8080> in your browser. The marketing landing page
+is served at `/`, and the solver app at `/app/`.
+
+To stop it, press `Ctrl+C` (or `docker stop <container>` if you ran it
+detached with `-d`).
+
+#### Choosing a different port
+
+The container's internal port is configurable via the `PORT` environment
+variable (default `10000`). Only change this if something else is already using
+10000 *inside* the container — for normal use, just change the host side of the
+`-p` mapping:
+
+```bash
+# Serve on http://localhost:3000 instead.
+docker run --rm -p 3000:10000 kofem-web
+```
+
+#### Optional: stamp a version
+
+CI passes a version string into the bundle via a build arg. You can do the same:
+
+```bash
+docker build -t kofem-web --build-arg VITE_GIT_VERSION="$(git describe --tags --always)" ./web
+```
+
+### Option B — Use the pre-built image from the registry
+
+Published images are available at `ghcr.io/mkofler96/kofem-web:latest`. The
+repository ships a `docker-compose.yaml` and a helper script that pulls and
+(re)starts the container:
+
+```bash
+# Pulls the latest image and starts it in the background.
+./update-prod.sh
+```
+
+> **Note:** `docker-compose.yaml` is wired to an external Docker network
+> (`dashboard_mybasil-network`) used by the production deployment behind a
+> reverse proxy, and `expose`s the port to that network rather than publishing
+> it to the host. For a quick local run, prefer **Option A** above, which
+> publishes the port directly with `-p`.
+
+## Development
+
+See [`CLAUDE.md`](./CLAUDE.md) for native build prerequisites (OCCT, Netgen,
+MFEM), the WASM build flow, and frontend dev commands. The short version for
+the web frontend:
+
+```bash
+cd web && bun install && bun run dev
+```

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -55,8 +55,14 @@ export default defineConfig(({ mode }) => ({
   },
   build: {
     target: "esnext",
-    sourcemap: mode !== "production",
-    minify: mode === "production" ? "esbuild" : false,
+    // Fail closed: source maps and unminified output are an explicit
+    // `--mode development` opt-in (see the build:dev script). Every other
+    // invocation — the default production build, CI, or any custom/empty mode
+    // a deploy host might pass — ships minified and map-free. Keying these off
+    // `mode === "production"` instead leaks readable, mapped source whenever
+    // the mode is anything but that exact string.
+    sourcemap: mode === "development",
+    minify: mode === "development" ? false : "esbuild",
     rollupOptions: {
       input: {
         app: htmlEntry("./app/index.html"),


### PR DESCRIPTION
## Summary

Inverts the logic for `sourcemap` and `minify` build configuration to adopt a "fail closed" security posture. Source maps and unminified output now require an explicit `--mode development` opt-in, while all other build invocations (production, CI, custom/empty modes) ship minified and map-free by default.

## Changes

- **Sourcemap generation**: Changed from `mode !== "production"` to `mode === "development"`
  - Previously: any mode except "production" would leak readable, mapped source
  - Now: only the explicit development mode includes source maps
  
- **Minification**: Inverted from `mode === "production" ? "esbuild" : false` to `mode === "development" ? false : "esbuild"`
  - Previously: only production mode was minified
  - Now: all modes except development are minified

- **Documentation**: Added detailed comment explaining the rationale and risk of the previous approach

## Rationale

The original configuration keyed off `mode === "production"`, which meant any non-standard mode string (whether from CI, deploy hosts, or accidental empty modes) would produce unminified, source-mapped builds. This inadvertently leaked sensitive source code in production deployments. The new approach explicitly opts into development behavior, ensuring secure defaults across all deployment scenarios.

https://claude.ai/code/session_01F6iz1FhJbvYzfzicJBLSHk