### PR TITLE
Add dynamic app version display to status bar

### DIFF
--- a/web/src/components/statusbar/StatusBar.tsx
+++ b/web/src/components/statusbar/StatusBar.tsx
@@ -1,4 +1,5 @@
 import { useModelStore } from "../../store/modelStore";
+import { APP_VERSION } from "../../lib/version";
 import styles from "./StatusBar.module.css";
 
 type ViewRepr = "geometry" | "surface" | "volume" | "wireframe";
@@ -257,7 +258,7 @@ export function StatusBar() {
             Mesh OK
           </span>
         ) : null}
-        <span className={styles.muted}>m · N · Pa · v0.4.1</span>
+        <span className={styles.muted}>m · N · Pa · {APP_VERSION}</span>
       </div>
     </div>
   );

--- a/web/src/lib/version.ts
+++ b/web/src/lib/version.ts
@@ -1,0 +1,5 @@
+// App version stamp shown in the status bar. CI injects VITE_GIT_VERSION
+// (the output of `git describe --tags`, e.g. "v0.0.1-beta1") at build time via
+// web/Dockerfile, so the displayed version always matches the published commit.
+// In local dev the var is unset, so we fall back to "dev".
+export const APP_VERSION = import.meta.env.VITE_GIT_VERSION ?? "dev";

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,14 +1,14 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_GIT_VERSION?: string
+  readonly VITE_GIT_VERSION?: string;
 }
 
 interface ImportMeta {
-  readonly env: ImportMetaEnv
+  readonly env: ImportMetaEnv;
 }
 
-declare module '*.module.css' {
-  const classes: Record<string, string>
-  export default classes
+declare module "*.module.css" {
+  const classes: Record<string, string>;
+  export default classes;
 }

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_GIT_VERSION?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
 declare module '*.module.css' {
   const classes: Record<string, string>
   export default classes


### PR DESCRIPTION
## Summary
Replace the hardcoded version string in the status bar with a dynamic version that is injected at build time via the `VITE_GIT_VERSION` environment variable, with a fallback to "dev" for local development.

## Changes
- **vite-env.d.ts**: Added TypeScript interface definitions for `ImportMetaEnv` and `ImportMeta` to support accessing `import.meta.env.VITE_GIT_VERSION`
- **lib/version.ts** (new file): Created a version module that exports `APP_VERSION`, reading from the build-time injected `VITE_GIT_VERSION` variable (set by CI via the Dockerfile to `git describe --tags` output) with a "dev" fallback for local development
- **StatusBar.tsx**: Updated the status bar footer to display `APP_VERSION` instead of the hardcoded "v0.4.1" string

## Implementation Details
The version is injected at build time by the CI/Docker build process, ensuring the displayed version always matches the published commit. In local development, the variable remains unset and gracefully falls back to "dev", making the feature transparent to developers.

https://claude.ai/code/session_01A3nK5ay4X6eWHR75dpQqcP