### PR TITLE
Require material assignment before solver execution

### DIFF
--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -215,7 +215,12 @@ self.onmessage = async (event: MessageEvent) => {
         hexahedra,
       };
 
-      const mat = materials[0] ?? { young: 210e9, poisson: 0.3, density: 7850 };
+      const mat = materials[0];
+      if (!mat) {
+        throw new Error(
+          "solve: no material assigned — assign a material before running the solver",
+        );
+      }
       const material = {
         young_modulus: mat.young,
         poisson_ratio: mat.poisson,


### PR DESCRIPTION
## Summary

Replace silent fallback behavior with an explicit error when no material is assigned before running the FEM solver. This improves debugging by catching configuration errors early with a clear message.

## Changes

- Changed material initialization from a defensive fallback (`materials[0] ?? { young: 210e9, poisson: 0.3, density: 7850 }`) to explicit validation
- Added error check that throws with a descriptive message if no material is assigned
- Error message guides users to assign a material before running the solver

## Implementation Details

The solver now fails fast with a clear error message rather than silently using hardcoded default material properties. This aligns with the project convention to "prefer clear and information-rich error messages over silent fall-throughs" and makes it easier to debug incomplete model configurations.

https://claude.ai/code/session_01KE181TNvq527EzqytaJhjr