### PR TITLE
Add validation and error handling to material form

### DIFF
--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -35,8 +35,38 @@ function MaterialForm({
   const [young, setYoung] = useState(String(mat?.young ?? 210e9));
   const [poisson, setPoisson] = useState(String(mat?.poisson ?? 0.3));
   const [density, setDensity] = useState(String(mat?.density ?? 7850));
+  const [error, setError] = useState<string | null>(null);
+
+  function handleSave() {
+    const e = parseFloat(young);
+    const nu = parseFloat(poisson);
+    const rho = parseFloat(density);
+
+    if (!isFinite(e) || e <= 0) {
+      setError("Young's modulus must be a positive number");
+      return;
+    }
+    // ν must lie in (-1, 0.5); ν = 0 is physically valid (e.g. auxetic foams,
+    // cork) and must not be silently replaced by the steel default.
+    if (!isFinite(nu) || nu <= -1 || nu >= 0.5) {
+      setError("Poisson's ratio must be in the range (-1, 0.5)");
+      return;
+    }
+    if (!isFinite(rho) || rho < 0) {
+      setError("Density must be a non-negative number");
+      return;
+    }
+    onSave({ name: name || "Material", young: e, poisson: nu, density: rho });
+  }
+
   return (
     <div className={styles.inlineForm}>
+      {error && (
+        <div className={styles.errorBanner} data-testid="material-error">
+          <span>{error}</span>
+          <button onClick={() => setError(null)}>×</button>
+        </div>
+      )}
       <div className={styles.formRow}>
         <span className={styles.formLabel}>Name</span>
         <input
@@ -79,17 +109,7 @@ function MaterialForm({
         <button className={styles.cancelBtn} onClick={onCancel}>
           Cancel
         </button>
-        <button
-          className={styles.primaryBtn}
-          onClick={() =>
-            onSave({
-              name: name || "Material",
-              young: parseFloat(young) || 210e9,
-              poisson: parseFloat(poisson) || 0.3,
-              density: parseFloat(density) || 7850,
-            })
-          }
-        >
+        <button className={styles.primaryBtn} onClick={handleSave}>
           Save
         </button>
       </div>


### PR DESCRIPTION
## Summary
Add input validation and user-facing error messages to the MaterialForm component. Previously, invalid inputs (negative Young's modulus, out-of-range Poisson's ratio, etc.) would silently fall back to defaults. Now the form validates all inputs before saving and displays clear error messages to the user.

## Key Changes
- Extract save logic into a `handleSave()` function with comprehensive validation:
  - Young's modulus must be positive and finite
  - Poisson's ratio must be in the range (-1, 0.5) — note that ν = 0 is physically valid (e.g. auxetic foams, cork) and must not be silently replaced by defaults
  - Density must be non-negative and finite
- Add error state management with `useState<string | null>`
- Display error banner with dismissible close button when validation fails
- Replace inline save handler with call to `handleSave()`

## Implementation Details
The validation logic respects the physical constraints of linear elasticity. The Poisson's ratio bounds are particularly important: the range (-1, 0.5) is required for material stability, and the code explicitly avoids silently replacing ν = 0 with the steel default (0.3), since zero is a valid value for certain material types.

https://claude.ai/code/session_0119GSUs9NeRYbbjXC3ajPDG