### PR TITLE
Standardize unit system to N·mm·MPa for FEM consistency

### DIFF
--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -32,9 +32,9 @@ function MaterialForm({
   onCancel(): void;
 }) {
   const [name, setName] = useState(mat?.name ?? "Material");
-  const [young, setYoung] = useState(String(mat?.young ?? 210e9));
+  const [young, setYoung] = useState(String(mat?.young ?? 210000));
   const [poisson, setPoisson] = useState(String(mat?.poisson ?? 0.3));
-  const [density, setDensity] = useState(String(mat?.density ?? 7850));
+  const [density, setDensity] = useState(String(mat?.density ?? 7.85e-9));
   return (
     <div className={styles.inlineForm}>
       <div className={styles.formRow}>
@@ -46,12 +46,12 @@ function MaterialForm({
         />
       </div>
       <div className={styles.formRow}>
-        <span className={styles.formLabel}>E (Pa)</span>
+        <span className={styles.formLabel}>E (MPa)</span>
         <input
           className={styles.formInput}
           type="number"
           value={young}
-          step="1e9"
+          step="1000"
           onChange={(e) => setYoung(e.target.value)}
         />
       </div>
@@ -66,12 +66,12 @@ function MaterialForm({
         />
       </div>
       <div className={styles.formRow}>
-        <span className={styles.formLabel}>ρ (kg/m³)</span>
+        <span className={styles.formLabel}>ρ (t/mm³)</span>
         <input
           className={styles.formInput}
           type="number"
           value={density}
-          step="100"
+          step="1e-9"
           onChange={(e) => setDensity(e.target.value)}
         />
       </div>
@@ -84,9 +84,9 @@ function MaterialForm({
           onClick={() =>
             onSave({
               name: name || "Material",
-              young: parseFloat(young) || 210e9,
+              young: parseFloat(young) || 210000,
               poisson: parseFloat(poisson) || 0.3,
-              density: parseFloat(density) || 7850,
+              density: parseFloat(density) || 7.85e-9,
             })
           }
         >
@@ -464,7 +464,7 @@ function GeometryPanel() {
                 <div className={styles.treeItemBody}>
                   <div className={styles.treeItemName}>{m.name}</div>
                   <div className={styles.treeItemDetail}>
-                    E = {fmt(m.young, 3)} Pa · ν = {m.poisson}
+                    E = {fmt(m.young, 3)} MPa · ν = {m.poisson}
                   </div>
                 </div>
                 <div className={styles.treeItemActions}>
@@ -976,7 +976,7 @@ function SolvePanel() {
     [
       matOk,
       materials.length > 0
-        ? `Material assigned · ${materials[0].name} · E=${fmt(materials[0].young, 3)} Pa`
+        ? `Material assigned · ${materials[0].name} · E=${fmt(materials[0].young, 3)} MPa`
         : "No material assigned",
     ],
     [

--- a/web/src/lib/resultField.ts
+++ b/web/src/lib/resultField.ts
@@ -102,6 +102,8 @@ export function resultFieldSymbol(resultType: ResultType): string {
       : resultType;
 }
 
+// Canonical unit system is N · mm · MPa: displacements come out in mm and
+// stresses in MPa (force/area = N/mm²).
 export function resultUnit(resultType: ResultType): string {
-  return resultType === "Von Mises stress" ? "Pa" : "m";
+  return resultType === "Von Mises stress" ? "MPa" : "mm";
 }

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -525,7 +525,13 @@ export const useModelStore = create<ModelState>()(
         s.nodes = [];
         s.elements = [];
         s.materials = [
-          { id: 1, name: "Steel", young: 210000, poisson: 0.3, density: 7.85e-9 },
+          {
+            id: 1,
+            name: "Steel",
+            young: 210000,
+            poisson: 0.3,
+            density: 7.85e-9,
+          },
         ];
         s.properties = [{ id: 1, type: "PSOLID", materialId: 1 }];
         s.bcGroups = [];

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -324,7 +324,10 @@ const EMPTY_MODEL = {
   nodes: [] as Node[],
   elements: [] as Element[],
   materials: [
-    { id: 1, name: "Steel", young: 210e9, poisson: 0.3, density: 7850 },
+    // Canonical unit system: N · mm · MPa · tonne. Steel: E = 210 GPa = 210000 MPa,
+    // ρ = 7850 kg/m³ = 7.85e-9 t/mm³. STEP geometry imports in mm, so materials,
+    // loads (N), and results (mm, MPa) must share this system to stay consistent.
+    { id: 1, name: "Steel", young: 210000, poisson: 0.3, density: 7.85e-9 },
   ] as Material[],
   properties: [{ id: 1, type: "PSOLID" as const, materialId: 1 }] as Property[],
   constraints: [] as Constraint[],
@@ -522,7 +525,7 @@ export const useModelStore = create<ModelState>()(
         s.nodes = [];
         s.elements = [];
         s.materials = [
-          { id: 1, name: "Steel", young: 210e9, poisson: 0.3, density: 7850 },
+          { id: 1, name: "Steel", young: 210000, poisson: 0.3, density: 7.85e-9 },
         ];
         s.properties = [{ id: 1, type: "PSOLID", materialId: 1 }];
         s.bcGroups = [];


### PR DESCRIPTION
## Summary

Converts the material property units and result display units to a canonical unit system of **N · mm · MPa · tonne** to ensure consistency between STEP geometry imports (in mm), material properties, loads, and FEM results.

## Changes

- **Material properties**: Updated Young's modulus from Pa (210e9) to MPa (210000) and density from kg/m³ (7850) to t/mm³ (7.85e-9) in default Steel material and form inputs
- **UI labels**: Changed Young's modulus label from "E (Pa)" to "E (MPa)" and density from "ρ (kg/m³)" to "ρ (t/mm³)"
- **Input step values**: Adjusted form input step increments to match new units (1000 for MPa, 1e-9 for t/mm³)
- **Result units**: Updated result display from "Pa" to "MPa" for Von Mises stress and "m" to "mm" for displacements
- **Documentation**: Added inline comment in `modelStore.ts` explaining the canonical unit system and conversion rationale

## Implementation Details

The unit conversions maintain physical equivalence:
- E: 210 GPa = 210,000 MPa (force/area in N/mm²)
- ρ: 7850 kg/m³ = 7.85×10⁻⁹ t/mm³ (mass/volume in tonnes/mm³)

This ensures that when STEP geometry is imported in millimeters, all downstream calculations (stiffness matrix assembly, stress computation) remain dimensionally consistent without requiring conversion factors at the solver boundary.

https://claude.ai/code/session_01GLv2MQyoExkFwgJVgFvEat