### PR TITLE
Remove SI units display from top bar

### DIFF
--- a/web/src/components/topbar/TopBar.module.css
+++ b/web/src/components/topbar/TopBar.module.css
@@ -70,25 +70,6 @@
   font-size: 12.5px;
 }
 
-.units {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 9px;
-  background: #f0f2f5;
-  border: 1px solid #e2e5ea;
-  border-radius: 5px;
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 11px;
-  color: #3a4150;
-  white-space: nowrap;
-}
-
-.units b {
-  color: #0d1117;
-  font-weight: 600;
-}
-
 .iconBtn {
   display: grid;
   place-items: center;

--- a/web/src/components/topbar/TopBar.tsx
+++ b/web/src/components/topbar/TopBar.tsx
@@ -51,9 +51,6 @@ export function TopBar() {
 
       {/* Right */}
       <div className={styles.right}>
-        <span className={styles.units}>
-          <b>SI</b> · m, N, Pa
-        </span>
         <input
           ref={loadInputRef}
           type="file"


### PR DESCRIPTION
## Summary
Removes the SI units indicator badge from the top bar right section.

## Changes
- Deleted `.units` and `.units b` CSS class definitions from TopBar.module.css
- Removed the units display span (`<b>SI</b> · m, N, Pa`) from the TopBar component

## Notes
This appears to be a UI simplification, removing the static units indicator that was displayed in the top bar. The units information may be conveyed elsewhere in the interface or deemed unnecessary for the current design.

https://claude.ai/code/session_012fdcDxadPhnttgTTfa9sHd