### PR TITLE
Fix re-mesh failing with opaque "Error: &lt;pointer&gt;"

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -211,6 +211,10 @@ target_link_options(kofem_wasm_emcc PRIVATE
     --bind
     -fexceptions
     -sDISABLE_EXCEPTION_CATCHING=0
+    # Export getExceptionMessage so the JS worker can decode a thrown C++
+    # exception (surfaced as a raw heap pointer under -fexceptions) into its
+    # what() text instead of showing an opaque number like "Error: 12190840".
+    -sEXPORT_EXCEPTION_HANDLING_HELPERS=1
     -sMODULARIZE=1
     -sEXPORT_ES6=1
     -sENVIRONMENT=web,worker

--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -130,6 +130,8 @@ function GeometryPanel() {
   const updateMaterial = useModelStore((s) => s.updateMaterial);
   const deleteMaterial = useModelStore((s) => s.deleteMaterial);
   const stepSurface = useModelStore((s) => s.stepSurface);
+  const stepBytes = useModelStore((s) => s.stepBytes);
+  const setStepBytes = useModelStore((s) => s.setStepBytes);
   const isMeshing = useModelStore((s) => s.isMeshing);
   const setMeshing = useModelStore((s) => s.setMeshing);
   const applyMeshResult = useModelStore((s) => s.applyMeshResult);
@@ -173,7 +175,12 @@ function GeometryPanel() {
     }>("parse_step", { bytes })
       .then(({ points, triangles }) => {
         if (points.length === 0) setStepImportError("No geometry found.");
-        else setStepSurface({ points, triangles });
+        else {
+          // Retain the raw STEP so the geometry can be reloaded for a re-mesh
+          // (the worker is reset after each mesh and loses the loaded shape).
+          setStepBytes(bytes);
+          setStepSurface({ points, triangles });
+        }
       })
       .catch((err) => setStepImportError(err.message ?? "STEP import failed"))
       .finally(() => {
@@ -184,6 +191,12 @@ function GeometryPanel() {
 
   async function handleVolMesh() {
     if (!stepSurface) return;
+    if (!stepBytes) {
+      setMeshError(
+        "Cannot mesh: the original STEP file is no longer available (e.g. after loading a saved analysis). Re-import the STEP file to mesh.",
+      );
+      return;
+    }
     setMeshing(true);
     setLogs([]);
     try {
@@ -198,7 +211,7 @@ function GeometryPanel() {
         surfaceTriangles: [number, number, number][] | null;
         surfaceFaceIds: number[] | null;
       }>("volume_mesh", {
-        surface: stepSurface,
+        bytes: stepBytes,
         maxElementSize,
         minElementSize,
       });
@@ -215,7 +228,8 @@ function GeometryPanel() {
       resetWorker();
     } catch (err) {
       console.error("[meshing] volume mesh failed:", err);
-      setMeshError(`Volume meshing failed: ${err}`);
+      const detail = err instanceof Error ? err.message : String(err);
+      setMeshError(`Volume meshing failed: ${detail}`);
     } finally {
       setMeshing(false);
     }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,20 +1,20 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import { sendToWorker, resetWorker } from './workers/sharedWorker'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import { sendToWorker, resetWorker } from "./workers/sharedWorker";
 
 // Exposed for Playwright tests — not part of the public API.
-;(
+(
   window as Window & {
     __kofem?: {
-      sendToWorker: typeof sendToWorker
-      resetWorker: typeof resetWorker
-    }
+      sendToWorker: typeof sendToWorker;
+      resetWorker: typeof resetWorker;
+    };
   }
-).__kofem = { sendToWorker, resetWorker }
+).__kofem = { sendToWorker, resetWorker };
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
-)
+  </React.StrictMode>,
+);

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,10 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
-import { sendToWorker } from './workers/sharedWorker'
+import { sendToWorker, resetWorker } from './workers/sharedWorker'
 
 // Exposed for Playwright tests — not part of the public API.
-;(window as Window & { __kofem?: { sendToWorker: typeof sendToWorker } }).__kofem = { sendToWorker }
+;(
+  window as Window & {
+    __kofem?: {
+      sendToWorker: typeof sendToWorker
+      resetWorker: typeof resetWorker
+    }
+  }
+).__kofem = { sendToWorker, resetWorker }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -226,6 +226,11 @@ interface ModelState {
   result: SolverResult | null;
   resultType: ResultType;
   stepSurface: StepSurfaceMesh | null;
+  // Raw bytes of the imported STEP file, retained so the geometry can be
+  // reloaded into the mesher for a re-mesh. The worker is torn down after every
+  // mesh (resetWorker), discarding the OCCT shape it held, so re-meshing must
+  // re-supply the original file. Not persisted in saved analyses (no STEP there).
+  stepBytes: Uint8Array | null;
   isRunning: boolean;
   isMeshing: boolean;
   nextMatId: number;
@@ -253,6 +258,7 @@ interface ModelState {
   showUndeformedOverlay: boolean;
   stepImportError: string | null;
   setStepSurface(mesh: StepSurfaceMesh | null): void;
+  setStepBytes(bytes: Uint8Array | null): void;
   setVolMesh(mesh: VolMesh | null): void;
   setSurfaceFaceIds(ids: number[] | null): void;
   setViewRepr(v: "geometry" | "surface" | "volume" | "wireframe"): void;
@@ -348,6 +354,7 @@ export const useModelStore = create<ModelState>()(
     result: null,
     resultType: "Displacement (magnitude)" as ResultType,
     stepSurface: null,
+    stepBytes: null,
     isRunning: false,
     isMeshing: false,
     volMesh: null,
@@ -384,9 +391,16 @@ export const useModelStore = create<ModelState>()(
       set((s) => {
         s.surfaceFaceIds = ids;
       }),
+    setStepBytes: (bytes) =>
+      set((s) => {
+        s.stepBytes = bytes;
+      }),
     setStepSurface: (mesh) =>
       set((s) => {
         s.stepSurface = mesh;
+        // Clearing the geometry also drops the retained STEP bytes — keeping the
+        // invariant "no surface ⇒ nothing left to re-mesh from".
+        if (!mesh) s.stepBytes = null;
         s.volMesh = null;
         s.viewRepr = "geometry";
         s.stepImportError = null;
@@ -501,6 +515,9 @@ export const useModelStore = create<ModelState>()(
         s.nextFaceEntryId = a.nextFaceEntryId;
         s.nextMatId = a.nextMatId;
         s.stepSurface = a.stepSurface;
+        // Saved analyses carry the tessellated surface but not the original STEP
+        // file, so re-meshing a loaded analysis requires re-importing the STEP.
+        s.stepBytes = null;
         s.volMesh = a.volMesh;
         s.surfaceTriangles = a.surfaceTriangles;
         s.surfaceFaceIds = a.surfaceFaceIds;
@@ -544,6 +561,7 @@ export const useModelStore = create<ModelState>()(
         s.modelName = "";
         s.result = null;
         s.stepSurface = null;
+        s.stepBytes = null;
         s.volMesh = null;
         s.surfaceTriangles = null;
         s.surfaceFaceIds = null;

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -10,6 +10,41 @@ import createModule from "../wasm/pkg/kofem_wasm.js";
 import type { KofemModule } from "../wasm/pkg/kofem_wasm.js";
 
 let Module: KofemModule | null = null;
+
+// True once tessellate_step has loaded the OCCT STEP shape into THIS worker's
+// WASM module. The worker is torn down after every mesh (resetWorker in
+// LeftPanel) to keep Netgen's global state out of the MFEM solve, so a re-mesh
+// starts in a fresh module where this is false and the geometry must be
+// reloaded from the original STEP bytes before meshing.
+let geometryLoaded = false;
+
+// Emscripten (-fexceptions) surfaces an uncaught C++ exception to JS as the raw
+// heap pointer of the exception object — a bare number such as 12190840. Decode
+// it to the real what() text via getExceptionMessage, exported by the build flag
+// EXPORT_EXCEPTION_HANDLING_HELPERS. Degrades gracefully (labelled pointer) when
+// the helper is absent, e.g. an older wasm binary built before the flag was added.
+function describeError(err: unknown): string {
+  if (err instanceof Error)
+    return `${err.name}: ${err.message}\n${err.stack ?? ""}`;
+  if (typeof err === "number") {
+    const getMsg = (
+      Module as unknown as {
+        getExceptionMessage?: (ptr: number) => [string, string];
+      } | null
+    )?.getExceptionMessage;
+    if (getMsg) {
+      try {
+        const [type, message] = getMsg(err);
+        return message ? `${type}: ${message}` : type;
+      } catch {
+        // decoding failed — fall through to the labelled raw pointer
+      }
+    }
+    return `C++ exception (undecoded, ptr ${err})`;
+  }
+  return String(err);
+}
+
 async function ensureInit() {
   if (!Module) {
     Module = await createModule({
@@ -73,6 +108,9 @@ self.onmessage = async (event: MessageEvent) => {
         angular_deflection: 0.5,
       });
       const json = m().tessellate_step(payload.bytes as Uint8Array, opts);
+      // tessellate_step stores the OCCT shape in the module — record that so a
+      // subsequent volume_mesh in this same worker can skip the reload.
+      geometryLoaded = true;
       const dto = JSON.parse(json) as {
         vertices: [number, number, number][];
         triangles: [number, number, number][];
@@ -85,11 +123,37 @@ self.onmessage = async (event: MessageEvent) => {
         triangles: dto.triangles,
       });
     } else if (type === "volume_mesh") {
-      const { maxElementSize = 20.0, minElementSize } = payload as {
-        surface?: unknown;
+      const {
+        bytes,
+        maxElementSize = 20.0,
+        minElementSize,
+      } = payload as {
+        bytes?: Uint8Array;
         maxElementSize?: number;
         minElementSize?: number;
       };
+
+      // A re-mesh runs in a fresh worker (the previous mesh tore this worker's
+      // predecessor down), so the OCCT shape generate_fem_mesh needs is gone.
+      // Reload it from the original STEP bytes first. This makes every mesh
+      // reproduce the known-good import→mesh sequence — tessellate_step (loads
+      // the shape) then generate_fem_mesh — rather than meshing twice inside one
+      // Netgen-contaminated module.
+      if (!geometryLoaded) {
+        if (!bytes)
+          throw new Error(
+            "volume_mesh: no STEP geometry is loaded and no STEP bytes were provided to reload it — re-import the STEP file before meshing",
+          );
+        self.postMessage({
+          id,
+          log: "Reloading STEP geometry into the mesher…",
+        });
+        m().tessellate_step(
+          bytes,
+          JSON.stringify({ linear_deflection: 0.1, angular_deflection: 0.5 }),
+        );
+        geometryLoaded = true;
+      }
 
       // Floor the curvature-driven local element size at maxElementSize/10 by
       // default.  Without a floor, Netgen refines every fillet to ~radius/2
@@ -137,6 +201,7 @@ self.onmessage = async (event: MessageEvent) => {
       // needed once meshing is done, and freeing them before the solve gives
       // MFEM more headroom for stiffness-matrix assembly.
       m().free_geometry_cache();
+      geometryLoaded = false;
 
       const nodes: Node[] = dto.vertices.map(([x, y, z], i) => ({
         id: i,
@@ -317,10 +382,7 @@ self.onmessage = async (event: MessageEvent) => {
         err.message.includes("unreachable") ||
         err.message.includes("null function or function signature mismatch") ||
         err.message.includes("table index is out of bounds"));
-    const detail =
-      err instanceof Error
-        ? `${err.name}: ${err.message}\n${err.stack ?? ""}`
-        : String(err);
+    const detail = describeError(err);
     const errorMessage = isWasmTrap
       ? `WASM trap (code bug, not OOM): ${detail}`
       : detail;

--- a/web/tests/remesh.spec.ts
+++ b/web/tests/remesh.spec.ts
@@ -60,3 +60,77 @@ test("re-mesh succeeds after the worker is reset (issue #250)", async ({
   expect(result.first).toBeGreaterThan(0);
   expect(result.second).toBeGreaterThan(0);
 });
+
+// Guard path: meshing with no geometry loaded and no STEP bytes to reload from
+// (e.g. re-meshing a loaded analysis) must fail with an actionable message, not
+// an opaque pointer. A fresh worker has no geometry, so volume_mesh without
+// bytes hits the reload guard directly.
+test("volume_mesh without STEP bytes fails with an actionable message", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+
+  await page.goto("/app/", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () => !!(window as Window & { __kofem?: unknown }).__kofem,
+    { timeout: 30_000 },
+  );
+
+  const message = await page.evaluate(async () => {
+    const k = (
+      window as Window & {
+        __kofem: { sendToWorker: (t: string, p: unknown) => Promise<unknown> };
+      }
+    ).__kofem;
+    try {
+      await k.sendToWorker("volume_mesh", {
+        maxElementSize: 20,
+        minElementSize: 2,
+      });
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  });
+
+  expect(message).not.toBeNull();
+  expect(message).toContain("no STEP geometry");
+  expect(message).toContain("re-import");
+});
+
+// A C++ engine error (here: feeding the OCCT reader invalid STEP bytes) used to
+// reach JS as a bare heap pointer, rendering as the meaningless "Error: 12190840"
+// from issue #250. describeError must now produce human-readable text. The
+// assertion holds whether or not the wasm exports getExceptionMessage: decoded
+// what() text and the "C++ exception (undecoded, ptr N)" fallback both contain
+// letters — a bare pointer number does not.
+test("a C++ engine error surfaces as readable text, not a bare pointer (issue #250)", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+
+  await page.goto("/app/", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () => !!(window as Window & { __kofem?: unknown }).__kofem,
+    { timeout: 30_000 },
+  );
+
+  const message = await page.evaluate(async () => {
+    const k = (
+      window as Window & {
+        __kofem: { sendToWorker: (t: string, p: unknown) => Promise<unknown> };
+      }
+    ).__kofem;
+    const garbage = new TextEncoder().encode("this is not a STEP file");
+    try {
+      await k.sendToWorker("parse_step", { bytes: garbage });
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  });
+
+  expect(message).not.toBeNull();
+  expect(message).toMatch(/[a-zA-Z]/);
+  expect(message?.trim()).not.toMatch(/^\d+$/);
+});

--- a/web/tests/remesh.spec.ts
+++ b/web/tests/remesh.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test";
+import fs from "fs";
+import { fileURLToPath } from "url";
+
+// Regression test for issue #250: clicking "Re-mesh" failed with an opaque
+// "Error: <pointer>". The worker is torn down after every mesh (so Netgen's
+// global state can't reach the MFEM solve), so the re-mesh ran in a fresh WASM
+// module with no STEP geometry loaded and generate_fem_mesh threw. The fix
+// reloads the geometry from the retained STEP bytes before meshing.
+//
+// This drives the worker directly (window.__kofem) and reproduces the real UI
+// sequence exactly: parse_step (import) → volume_mesh (mesh) → resetWorker
+// (what LeftPanel does after each mesh) → volume_mesh (the re-mesh that
+// regressed). Both meshes must produce a non-empty mesh.
+
+const STEP_FILE = fileURLToPath(
+  new URL("./fixtures/tube.stp", import.meta.url),
+);
+
+test("re-mesh succeeds after the worker is reset (issue #250)", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+
+  await page.goto("/app/", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () => !!(window as Window & { __kofem?: unknown }).__kofem,
+    { timeout: 30_000 },
+  );
+
+  const stepBytes = Array.from(fs.readFileSync(STEP_FILE));
+  const result = (await page.evaluate(async (bytes) => {
+    const k = (
+      window as Window & {
+        __kofem: {
+          sendToWorker: (t: string, p: unknown) => Promise<unknown>;
+          resetWorker: () => void;
+        };
+      }
+    ).__kofem;
+    const u8 = new Uint8Array(bytes);
+    const opts = { bytes: u8, maxElementSize: 20, minElementSize: 2 };
+
+    // Import + first mesh.
+    await k.sendToWorker("parse_step", { bytes: u8 });
+    const first = (await k.sendToWorker("volume_mesh", opts)) as {
+      nodes: unknown[];
+    };
+
+    // LeftPanel resets the worker after every successful mesh — so the re-mesh
+    // below runs in a brand-new module with no geometry, the exact #250 setup.
+    k.resetWorker();
+    const second = (await k.sendToWorker("volume_mesh", opts)) as {
+      nodes: unknown[];
+    };
+
+    return { first: first.nodes.length, second: second.nodes.length };
+  }, stepBytes)) as { first: number; second: number };
+
+  expect(result.first).toBeGreaterThan(0);
+  expect(result.second).toBeGreaterThan(0);
+});

--- a/web/tests/remesh.spec.ts
+++ b/web/tests/remesh.spec.ts
@@ -1,4 +1,9 @@
-import { test, expect } from "@playwright/test";
+// Import from ./coverage (not @playwright/test) so the fixture harvests the
+// solver.worker Istanbul counters after each test — these tests exercise the
+// worker directly, so without this their coverage (describeError, the reload
+// guard) is never collected.
+import { test, expect } from "./coverage";
+import { gotoApp } from "./fixtures/app";
 import fs from "fs";
 import { fileURLToPath } from "url";
 
@@ -133,4 +138,42 @@ test("a C++ engine error surfaces as readable text, not a bare pointer (issue #2
   expect(message).not.toBeNull();
   expect(message).toMatch(/[a-zA-Z]/);
   expect(message?.trim()).not.toMatch(/^\d+$/);
+});
+
+// Main-thread guard (LeftPanel.handleVolMesh): a loaded analysis carries a mesh
+// and a tessellated surface but no original STEP bytes, so clicking Re-mesh must
+// show an actionable banner rather than dispatching a doomed mesh. Driven through
+// the rendered UI so the guard is exercised where it lives.
+test("re-meshing without the original STEP shows an actionable banner (issue #250)", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+
+  await gotoApp(page);
+
+  // Reproduce the post-"open saved analysis" state: nodes + surface present,
+  // stepBytes absent.
+  await page.evaluate(() => {
+    const store = (
+      window as unknown as {
+        __kofemStore: { setState(partial: Record<string, unknown>): void };
+      }
+    ).__kofemStore;
+    store.setState({
+      mode: "geometry",
+      nodes: [
+        { id: 0, x: 0, y: 0, z: 0 },
+        { id: 1, x: 1, y: 0, z: 0 },
+      ],
+      elements: [],
+      stepSurface: { points: [[0, 0, 0]], triangles: [[0, 0, 0]] },
+      stepBytes: null,
+    });
+  });
+
+  await page.getByRole("button", { name: /Re-mesh STEP volume/ }).click();
+
+  await expect(page.getByTestId("meshing-error")).toContainText(
+    "original STEP file is no longer available",
+  );
 });


### PR DESCRIPTION
## Problem

Clicking **Re-mesh** failed with an opaque `Error: 12190840` and produced no mesh. Two distinct issues:

1. **Re-mesh had no geometry to mesh.** After each successful mesh, `LeftPanel.handleVolMesh` frees the cached OCCT shape (`free_geometry_cache`) and tears the worker down (`resetWorker`) — deliberately, so Netgen's global state can't corrupt the later MFEM solve. That left a re-mesh running `generate_fem_mesh()` in a **fresh WASM module with no STEP geometry loaded**, which threw.
2. **The error was unreadable.** Under `-fexceptions`, the C++ exception reaches JS as the raw heap pointer of the exception object (a bare number), and the build exported no helper to decode it — hence `Error: 12190840`.

## Fix

- **Reload geometry before meshing** (`modelStore.ts`, `LeftPanel.tsx`, `solver.worker.ts`): retain the imported STEP bytes (`stepBytes`) and, when the worker's module has no geometry, reload it via `tessellate_step` first. Every mesh now reproduces the known-good `import → mesh` sequence in a fresh module, fully preserving the Netgen/MFEM isolation (no risky "mesh twice in one module" path). **Works with the current committed WASM.**
- **Decode C++ exception pointers** (`engine/CMakeLists.txt`, `solver.worker.ts`): add `-sEXPORT_EXCEPTION_HANDLING_HELPERS=1` and a `describeError` helper that turns the pointer into the real `what()` text. Degrades gracefully (`C++ exception (undecoded, ptr …)`) until CI rebuilds the binary, so nothing breaks in the interim.
- Drop the redundant `Error:` prefix from the meshing banner, and guard re-meshing a loaded analysis (which has no original STEP) with a clear message.

## Testing

Adds `web/tests/remesh.spec.ts`, a worker-level regression test that drives the exact UI sequence — `parse_step` → `volume_mesh` → `resetWorker` → `volume_mesh` — and asserts both meshes succeed. Verified locally against the real WASM pipeline:

- `remesh.spec.ts` ✅ passed
- `production-smoke.spec.ts` (existing import + mesh path) ✅ passed
- `tsc` typecheck + prettier ✅ clean

> Note: the exception-decoding half depends on the CI WASM rebuild to take full effect; the re-mesh fix itself does not.

closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5zV6R2cJrfw5uJgci5M6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5zV6R2cJrfw5uJgci5M6w)_