### PR TITLE
Replace text logo with SVG image in topbar

### DIFF
--- a/web/src/components/topbar/TopBar.module.css
+++ b/web/src/components/topbar/TopBar.module.css
@@ -23,14 +23,9 @@
 .mark {
   width: 24px;
   height: 24px;
-  background: #1f5fd0;
-  color: #fff;
   border-radius: 5px;
-  display: grid;
-  place-items: center;
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 11px;
-  font-weight: 600;
+  display: block;
+  object-fit: contain;
   flex-shrink: 0;
 }
 

--- a/web/src/components/topbar/TopBar.tsx
+++ b/web/src/components/topbar/TopBar.tsx
@@ -43,7 +43,13 @@ export function TopBar() {
     <header className={styles.bar}>
       {/* Brand */}
       <div className={styles.brand}>
-        <div className={styles.mark}>K</div>
+        <img
+          className={styles.mark}
+          src="/kofem_logo.svg"
+          alt="KoFEM logo"
+          width={24}
+          height={24}
+        />
         <span className={styles.name}>KoFEM</span>
         <span className={styles.crumb}>
           <span className={styles.crumbMuted}>Workspace</span>


### PR DESCRIPTION
## Summary
Replace the text-based "K" logo in the topbar with an SVG image asset (`kofem_logo.svg`), improving visual branding and consistency.

## Changes
- **TopBar.tsx**: Changed the mark element from a `<div>` containing the text "K" to an `<img>` element that loads `/kofem_logo.svg` with appropriate alt text and dimensions
- **TopBar.module.css**: Simplified the `.mark` styles by:
  - Removing text-specific properties (`color`, `font-family`, `font-size`, `font-weight`)
  - Removing grid layout (`display: grid`, `place-items: center`)
  - Replacing with `display: block` and `object-fit: contain` to properly display the image
  - Retaining the fixed dimensions (24×24px), border-radius, and flex-shrink properties

## Implementation Details
The SVG logo is now the source of truth for the brand mark, allowing for better design flexibility and scalability compared to the previous text-based approach. The `object-fit: contain` ensures the image scales appropriately within the fixed 24×24px container.

https://claude.ai/code/session_016ytryCmscAjdqjYvaLhXgx