### PR TITLE
Apply face loads as work-equivalent surface tractions; add pressure load

### DIFF
--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -1015,7 +1015,7 @@ static std::string solve_linear_elastic(
         for (unsigned i = 0; i < n_surf; ++i) {
             val entry = surf_js[i];
             std::string type = entry["type"].as<std::string>();
-            val faces = entry["triangles"];  // node-index lists (3 = tri, 4 = quad)
+            val faces = entry["faces"];  // node-index lists (3 = tri, 4 = quad)
             unsigned n_faces = faces["length"].as<unsigned>();
 
             int attr = next_attr;

--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -45,7 +45,9 @@
 #include <array>
 #include <cmath>
 #include <cstring>
+#include <deque>
 #include <malloc.h>
+#include <map>
 #include <set>
 #include <sstream>
 #include <stdexcept>
@@ -732,6 +734,33 @@ static std::string generate_volume_mesh(
 
 // ── MFEM: linear-elastic FEM solve ────────────────────────────────────────────
 
+// Traction coefficient for a uniform pressure load: returns -p·n̂ at each
+// boundary quadrature point, where n̂ is the unit outward normal. The integrator
+// (VectorBoundaryLFIntegrator) already multiplies by the surface measure, so the
+// coefficient must return the *unit* normal scaled by the pressure, not the
+// area-weighted one. Positive pressure pushes into the surface (compression).
+class PressureCoefficient : public mfem::VectorCoefficient {
+    double pressure_;
+
+public:
+    PressureCoefficient(int dim, double pressure)
+        : mfem::VectorCoefficient(dim), pressure_(pressure) {}
+
+    void Eval(mfem::Vector& V, mfem::ElementTransformation& T,
+              const mfem::IntegrationPoint& ip) override {
+        V.SetSize(vdim);
+        mfem::Vector nor(vdim);
+        T.SetIntPoint(&ip);
+        // CalcOrtho yields the outward normal of a boundary ElementTransformation
+        // with magnitude equal to the surface Jacobian; normalize to a unit vector.
+        mfem::CalcOrtho(T.Jacobian(), nor);
+        double len = nor.Norml2();
+        if (len > 0.0)
+            nor /= len;
+        V.Set(-pressure_, nor);
+    }
+};
+
 static std::string solve_linear_elastic(
     const std::string& mesh_json,
     const std::string& mat_json,
@@ -940,7 +969,145 @@ static std::string solve_linear_elastic(
         x[pv.first] = pv.second;
 
     LinearForm b(&fespace);
+
+    // ── Surface (traction / pressure) loads ──────────────────────────────────
+    // Work-equivalent surface loads applied through MFEM's boundary linear-form
+    // integrator: f_i = ∫_S N_i · t dS. Unlike splitting a face's total force
+    // equally across its nodes, this weights each node by the shape-function
+    // integral of its tributary surface, so (a) corner/edge nodes get the right
+    // share and (b) the resultant passes through the face's area-centroid no
+    // matter how non-uniformly the face is meshed — no spurious moment.
+    //
+    // Each entry tags the boundary elements covering a set of surface faces
+    // (matched by sorted node-index list) with a unique boundary attribute,
+    // then a VectorBoundaryLFIntegrator restricted to that attribute applies:
+    //   type "force"    — total force F spread as a uniform traction F / A_total
+    //   type "traction" — a traction vector applied directly
+    //   type "pressure" — scalar p applied as -p·n̂ (outward normal; + pushes in)
+    //
+    // The integrators take ownership of their coefficient by reference and the
+    // marker arrays by pointer, so both must outlive b.Assemble(); they are held
+    // in stable-address containers below.
+    std::deque<std::unique_ptr<VectorCoefficient>> surf_coeffs;
+    std::deque<Array<int>> surf_markers;
+
+    val surf_js = bcs_js["surface_loads"];
+    if (!surf_js.isUndefined() && !surf_js.isNull()) {
+        unsigned n_surf = surf_js["length"].as<unsigned>();
+
+        // sorted boundary-face vertex list → boundary element index, over the
+        // auto-generated boundary mesh (its vertex indices equal the input node
+        // IDs). Keyed by a sorted vertex vector so it matches both triangular
+        // (tet) and quadrilateral (hex) boundary faces.
+        std::map<std::vector<int>, int> face_to_be;
+        for (int be = 0; be < mfem_mesh.GetNBE(); ++be) {
+            Array<int> bv;
+            mfem_mesh.GetBdrElementVertices(be, bv);
+            std::vector<int> key(bv.begin(), bv.end());
+            std::sort(key.begin(), key.end());
+            face_to_be[key] = be;
+        }
+
+        struct PendingLoad { int attr; std::unique_ptr<VectorCoefficient> coeff; };
+        std::vector<PendingLoad> pending;
+        int next_attr = 2;  // attribute 1 stays the default (un-loaded) value
+
+        for (unsigned i = 0; i < n_surf; ++i) {
+            val entry = surf_js[i];
+            std::string type = entry["type"].as<std::string>();
+            val faces = entry["triangles"];  // node-index lists (3 = tri, 4 = quad)
+            unsigned n_faces = faces["length"].as<unsigned>();
+
+            int attr = next_attr;
+            int matched = 0;
+            for (unsigned t = 0; t < n_faces; ++t) {
+                val face = faces[t];
+                unsigned fn = face["length"].as<unsigned>();
+                std::vector<int> key(fn);
+                for (unsigned k = 0; k < fn; ++k)
+                    key[k] = face[k].as<int>();
+                std::sort(key.begin(), key.end());
+                auto it = face_to_be.find(key);
+                if (it == face_to_be.end()) continue;
+                mfem_mesh.GetBdrElement(it->second)->SetAttribute(attr);
+                ++matched;
+            }
+            if (matched == 0) {
+                printf("[mfem] surface_load %u (%s): no boundary elements matched "
+                       "%u faces — skipped\n", i, type.c_str(), n_faces);
+                continue;
+            }
+            // This load owns `attr` (its elements are now tagged); reserve the
+            // next number so a later skip can't make two loads share an attribute.
+            ++next_attr;
+
+            std::unique_ptr<VectorCoefficient> coeff;
+            if (type == "pressure") {
+                double p = entry["pressure"].as<double>();
+                coeff = std::make_unique<PressureCoefficient>(dim, p);
+                printf("[mfem] surface_load %u: pressure %g over %d bdr elems\n",
+                       i, p, matched);
+            } else {  // "force" or "traction"
+                Vector tvec(3);
+                tvec[0] = entry["force"][0].as<double>();
+                tvec[1] = entry["force"][1].as<double>();
+                tvec[2] = entry["force"][2].as<double>();
+                if (type == "force") {
+                    // Total force → uniform traction: divide by the integrated area
+                    // of the matched boundary elements — the same surface measure
+                    // the integrator uses, so it is exact for straight-sided faces.
+                    double area = 0.0;
+                    for (int be = 0; be < mfem_mesh.GetNBE(); ++be) {
+                        if (mfem_mesh.GetBdrAttribute(be) != attr) continue;
+                        ElementTransformation* T =
+                            mfem_mesh.GetBdrElementTransformation(be);
+                        const IntegrationRule& ir =
+                            IntRules.Get(mfem_mesh.GetBdrElementGeometry(be), 4);
+                        for (int q = 0; q < ir.GetNPoints(); ++q) {
+                            const IntegrationPoint& ip = ir.IntPoint(q);
+                            T->SetIntPoint(&ip);
+                            area += ip.weight * T->Weight();
+                        }
+                    }
+                    if (area <= 0.0) {
+                        printf("[mfem] surface_load %u: zero matched area — skipped\n", i);
+                        continue;
+                    }
+                    tvec /= area;
+                    printf("[mfem] surface_load %u: force → traction [%g %g %g] over "
+                           "%d bdr elems (A=%g)\n",
+                           i, tvec[0], tvec[1], tvec[2], matched, area);
+                } else {
+                    printf("[mfem] surface_load %u: traction [%g %g %g] over %d bdr elems\n",
+                           i, tvec[0], tvec[1], tvec[2], matched);
+                }
+                coeff = std::make_unique<VectorConstantCoefficient>(tvec);
+            }
+            pending.push_back({ attr, std::move(coeff) });
+        }
+
+        // Refresh the mesh attribute tables now that boundary attributes changed,
+        // so marker arrays can be sized to bdr_attributes.Max().
+        mfem_mesh.SetAttributes();
+        int max_attr = mfem_mesh.bdr_attributes.Size()
+                           ? mfem_mesh.bdr_attributes.Max() : 0;
+        for (auto& pl : pending) {
+            surf_coeffs.push_back(std::move(pl.coeff));
+            surf_markers.emplace_back(max_attr);
+            Array<int>& marker = surf_markers.back();
+            marker = 0;
+            if (pl.attr >= 1 && pl.attr <= max_attr)
+                marker[pl.attr - 1] = 1;
+            b.AddBoundaryIntegrator(
+                new VectorBoundaryLFIntegrator(*surf_coeffs.back()), marker);
+        }
+    }
+
     b.Assemble();
+
+    // Concentrated point loads — applied straight to the assembled load vector.
+    // Still used for explicit nodal forces and for the equivalent nodal forces of
+    // a moment load. Surface (face) forces now flow through surface_loads above.
     for (unsigned i = 0; i < n_loads; ++i) {
         val load  = loads_js[i];
         int vi    = load["vertex"].as<int>();

--- a/examples/validation/cases/index.mjs
+++ b/examples/validation/cases/index.mjs
@@ -10,6 +10,8 @@ import cantilever from "./cantilever-bending.mjs";
 import plateWithHole from "./plate-with-hole.mjs";
 import shaftTorsion from "./shaft-torsion.mjs";
 import cooksMembrane from "./cooks-membrane.mjs";
+import surfaceTraction from "./surface-traction.mjs";
+import surfacePressure from "./surface-pressure.mjs";
 
 export default [
   axialBar,
@@ -17,4 +19,6 @@ export default [
   plateWithHole,
   shaftTorsion,
   cooksMembrane,
+  surfaceTraction,
+  surfacePressure,
 ];

--- a/examples/validation/cases/surface-pressure.mjs
+++ b/examples/validation/cases/surface-pressure.mjs
@@ -50,7 +50,8 @@ export default {
       1,
     );
     return (
-      loaded.reduce((s, v) => s + result.displacements[v * 3], 0) / loaded.length
+      loaded.reduce((s, v) => s + result.displacements[v * 3], 0) /
+      loaded.length
     );
   },
 };

--- a/examples/validation/cases/surface-pressure.mjs
+++ b/examples/validation/cases/surface-pressure.mjs
@@ -43,7 +43,7 @@ export default {
           {
             type: "pressure",
             pressure: p,
-            triangles: boxMaxXQuads(m.nid, nx, ny, nz),
+            faces: boxMaxXQuads(m.nid, nx, ny, nz),
           },
         ],
       },

--- a/examples/validation/cases/surface-pressure.mjs
+++ b/examples/validation/cases/surface-pressure.mjs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Uniform pressure on the end of an axial bar — validates the pressure load path
+// (traction = -p·n̂ over the loaded face) including its sign.
+//
+//   A prismatic bar fixed at x=0 carries a uniform pressure p on the x=L face.
+//   Pressure acts along the inward normal (-x here), so the bar is in uniaxial
+//   compression with σ_xx = -p everywhere, giving tip displacement
+//       u(L) = -p·L / E
+//   independent of the cross-section. A flipped pressure sign (tension) or a
+//   missing area normalisation would put this far outside tolerance.
+
+import { boxHexMesh, nodesWhere, boxMaxXQuads } from "../lib/mesh.mjs";
+
+const E = 210e9; // Pa
+const nu = 0.3;
+const L = 1.0; // m
+const W = 0.1,
+  H = 0.1; // cross-section (m)
+const p = 1.0e6; // pressure (Pa), pushes inward on the x=L face → compression
+
+export default {
+  name: "Surface pressure (axial bar)",
+  quantity: "tip displacement u",
+  unit: "m",
+  reference: -(p * L) / E, // u(L) = -p·L/E (compression)
+  referenceLabel: "u = -p·L / E",
+  tolPct: 2,
+  run(solve) {
+    const nx = 20,
+      ny = 4,
+      nz = 4;
+    const m = boxHexMesh(L, W, H, nx, ny, nz);
+    const fixed = nodesWhere(m.vertices, (x) => x <= 1e-9);
+    const loaded = nodesWhere(m.vertices, (x) => x >= L - 1e-9);
+    const result = solve(
+      { vertices: m.vertices, hexahedra: m.hexahedra },
+      { young_modulus: E, poisson_ratio: nu, density: 7850 },
+      {
+        fixed_vertices: fixed,
+        surface_loads: [
+          {
+            type: "pressure",
+            pressure: p,
+            triangles: boxMaxXQuads(m.nid, nx, ny, nz),
+          },
+        ],
+      },
+      1,
+    );
+    return (
+      loaded.reduce((s, v) => s + result.displacements[v * 3], 0) / loaded.length
+    );
+  },
+};

--- a/examples/validation/cases/surface-traction.mjs
+++ b/examples/validation/cases/surface-traction.mjs
@@ -51,7 +51,8 @@ export default {
       1,
     );
     return (
-      loaded.reduce((s, v) => s + result.displacements[v * 3], 0) / loaded.length
+      loaded.reduce((s, v) => s + result.displacements[v * 3], 0) /
+      loaded.length
     );
   },
 };

--- a/examples/validation/cases/surface-traction.mjs
+++ b/examples/validation/cases/surface-traction.mjs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Axial bar pulled by a surface traction — validates the work-equivalent surface
+// load path (VectorBoundaryLFIntegrator) rather than lumped nodal point loads.
+//
+//   A prismatic bar fixed at x=0 carries a total axial force P spread as a uniform
+//   traction over the x=L face. The engine integrates f_i = ∫ N_i·t dS, so the
+//   resultant equals P and the tip extension matches the closed form δ = P·L/(E·A)
+//   exactly as a point-load distribution would — but without the shape-function
+//   weighting error or the mesh-density-dependent moment of an equal nodal split.
+//
+// Reference: Gere & Goodno, "Mechanics of Materials", axially loaded members.
+
+import { boxHexMesh, nodesWhere, boxMaxXQuads } from "../lib/mesh.mjs";
+
+const E = 210e9; // Pa
+const nu = 0.3;
+const L = 1.0; // m
+const W = 0.1,
+  H = 0.1; // cross-section (m)
+const P = 1.0e6; // total axial force (N), applied as a surface traction
+
+export default {
+  name: "Surface traction (axial bar)",
+  quantity: "tip extension δ",
+  unit: "m",
+  reference: (P * L) / (E * (W * H)), // δ = PL/EA
+  referenceLabel: "δ = P·L / (E·A)",
+  tolPct: 2,
+  run(solve) {
+    const nx = 20,
+      ny = 4,
+      nz = 4;
+    const m = boxHexMesh(L, W, H, nx, ny, nz);
+    const fixed = nodesWhere(m.vertices, (x) => x <= 1e-9);
+    const loaded = nodesWhere(m.vertices, (x) => x >= L - 1e-9);
+    const result = solve(
+      { vertices: m.vertices, hexahedra: m.hexahedra },
+      { young_modulus: E, poisson_ratio: nu, density: 7850 },
+      {
+        fixed_vertices: fixed,
+        surface_loads: [
+          {
+            type: "force",
+            force: [P, 0, 0],
+            triangles: boxMaxXQuads(m.nid, nx, ny, nz),
+          },
+        ],
+      },
+      1,
+    );
+    return (
+      loaded.reduce((s, v) => s + result.displacements[v * 3], 0) / loaded.length
+    );
+  },
+};

--- a/examples/validation/cases/surface-traction.mjs
+++ b/examples/validation/cases/surface-traction.mjs
@@ -44,7 +44,7 @@ export default {
           {
             type: "force",
             force: [P, 0, 0],
-            triangles: boxMaxXQuads(m.nid, nx, ny, nz),
+            faces: boxMaxXQuads(m.nid, nx, ny, nz),
           },
         ],
       },

--- a/examples/validation/lib/mesh.mjs
+++ b/examples/validation/lib/mesh.mjs
@@ -167,6 +167,25 @@ export function nodesWhere(vertices, pred) {
   return out;
 }
 
+/**
+ * Quad boundary faces (4 node ids each) on the x = max face of a
+ * boxHexMesh(…, nx, ny, nz). Vertex order is irrelevant to the engine — it
+ * matches faces by sorted vertex set and integrates area from the element
+ * transformation — so these are handed over as-is for surface_loads.
+ */
+export function boxMaxXQuads(nid, nx, ny, nz) {
+  const quads = [];
+  for (let j = 0; j < ny; j++)
+    for (let k = 0; k < nz; k++)
+      quads.push([
+        nid(nx, j, k),
+        nid(nx, j + 1, k),
+        nid(nx, j + 1, k + 1),
+        nid(nx, j, k + 1),
+      ]);
+  return quads;
+}
+
 /** Distribute a total force vector evenly over the given nodes. */
 export function distributeForce(nodeIds, force) {
   const per = [

--- a/examples/validation/lib/solver.mjs
+++ b/examples/validation/lib/solver.mjs
@@ -24,7 +24,10 @@ const pkg = join(here, "../../../web/src/wasm/pkg");
  *   bcs:      { fixed_vertices:[v...],
  *               fixed_dofs:[{vertex,dofs:[0|1|2,...]}...],   // single-DOF (new)
  *               prescribed_dofs:[{vertex,dof:0|1|2,value}...], // non-zero Dirichlet
- *               point_loads:[{vertex, force:[fx,fy,fz]}...] }
+ *               point_loads:[{vertex, force:[fx,fy,fz]}...],
+ *               surface_loads:[{ type:"force"|"pressure"|"traction",
+ *                                triangles:[[a,b,c]...],
+ *                                force?:[fx,fy,fz], pressure?:p }...] }
  *   order:    FE polynomial order (default 1; order 2 is unreliable with the
  *             engine's loose CG tolerance — keep validation cases at order 1).
  * Returns { displacements:number[] (3/node), von_mises:number[] (1/elem) }.
@@ -51,6 +54,7 @@ export async function loadSolver() {
       fixed_dofs: bcs.fixed_dofs ?? [],
       prescribed_dofs: bcs.prescribed_dofs ?? [],
       point_loads: bcs.point_loads ?? [],
+      surface_loads: bcs.surface_loads ?? [],
     });
     return JSON.parse(
       Module.solve_linear_elastic(

--- a/examples/validation/lib/solver.mjs
+++ b/examples/validation/lib/solver.mjs
@@ -26,7 +26,7 @@ const pkg = join(here, "../../../web/src/wasm/pkg");
  *               prescribed_dofs:[{vertex,dof:0|1|2,value}...], // non-zero Dirichlet
  *               point_loads:[{vertex, force:[fx,fy,fz]}...],
  *               surface_loads:[{ type:"force"|"pressure"|"traction",
- *                                triangles:[[a,b,c]...],
+ *                                faces:[[a,b,c(,d)]...],
  *                                force?:[fx,fy,fz], pressure?:p }...] }
  *   order:    FE polynomial order (default 1; order 2 is unreliable with the
  *             engine's loose CG tolerance — keep validation cases at order 1).

--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -2,11 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useState, useRef, useEffect, type ChangeEvent } from "react";
-import {
-  useModelStore,
-  RESULT_TYPES,
-  loadKind,
-} from "../../store/modelStore";
+import { useModelStore, RESULT_TYPES, loadKind } from "../../store/modelStore";
 import type {
   AppMode,
   Material,

--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useState, useRef, useEffect, type ChangeEvent } from "react";
-import { useModelStore, RESULT_TYPES } from "../../store/modelStore";
+import {
+  useModelStore,
+  RESULT_TYPES,
+  loadKind,
+} from "../../store/modelStore";
 import type {
   AppMode,
   Material,
@@ -590,7 +594,11 @@ function ConstraintsPanel() {
   const [error, setError] = useState<string | null>(null);
 
   const DOF_LABELS = ["Ux", "Uy", "Uz", "Rx", "Ry", "Rz"];
-  const LOAD_LABELS = ["Fx", "Fy", "Fz", "Mx", "My", "Mz"];
+  // Indices 0–5 are direction DOFs (Fx…Mz); index 6 is the directionless pressure
+  // load. Force/pressure loads are applied as work-equivalent surface tractions.
+  const LOAD_LABELS = ["Fx", "Fy", "Fz", "Mx", "My", "Mz", "Pressure"];
+  const PRESSURE_OPTION = 6;
+  const isPressureLoad = loadDof === PRESSURE_OPTION;
 
   // Boundary conditions and loads reference mesh nodes, so they can only be
   // defined once a volume mesh exists.
@@ -667,10 +675,19 @@ function ConstraintsPanel() {
       // discarded. Reject it (and non-finite input) instead of coercing to 0.
       const value = parseFloat(loadForce);
       if (!isFinite(value) || value === 0) {
-        setError("Load force must be a non-zero finite number");
+        setError(
+          isPressureLoad
+            ? "Pressure must be a non-zero finite number"
+            : "Load force must be a non-zero finite number",
+        );
         return;
       }
-      createLoadGroup(faceEntries, loadDof, value);
+      createLoadGroup(
+        faceEntries,
+        isPressureLoad ? 0 : loadDof,
+        value,
+        isPressureLoad ? "pressure" : loadDof <= 2 ? "force" : "moment",
+      );
     }
     setError(null);
     setPickMode(null);
@@ -908,7 +925,11 @@ function ConstraintsPanel() {
                     </div>
                     <div className={styles.formRow}>
                       <span className={styles.formLabel}>
-                        {loadDof <= 2 ? "Total (N)" : "Total (N·m)"}
+                        {isPressureLoad
+                          ? "Pressure (MPa)"
+                          : loadDof <= 2
+                            ? "Total (N)"
+                            : "Total (N·m)"}
                       </span>
                       <input
                         className={styles.formInput}
@@ -919,11 +940,11 @@ function ConstraintsPanel() {
                       />
                     </div>
                     <div className={styles.pickNote}>
-                      {allPickedFaces.reduce((s, f) => s + f.nodeIds.length, 0)}{" "}
-                      nodes →{" "}
-                      {loadDof <= 2
-                        ? `${(parseFloat(loadForce) / allPickedFaces.reduce((s, f) => s + f.nodeIds.length, 0)).toFixed(1)} N/node`
-                        : "distributed as equivalent nodal forces"}
+                      {isPressureLoad
+                        ? "applied as p·n̂ over each face (work-equivalent)"
+                        : loadDof <= 2
+                          ? "applied as a work-equivalent surface traction"
+                          : "distributed as equivalent nodal forces"}
                     </div>
                     <button className={styles.loadBtn} onClick={applyLoad}>
                       Apply Load
@@ -948,8 +969,11 @@ function ConstraintsPanel() {
                   <span className={styles.loadDot} />
                   <span className={styles.bcGroupName}>{g.name}</span>
                   <span className={styles.bcGroupMeta}>
-                    {LOAD_LABELS[g.dof]} = {fmt(g.totalForce)}{" "}
-                    {g.dof <= 2 ? "N" : "N·m"}
+                    {loadKind(g) === "pressure"
+                      ? `p = ${fmt(g.totalForce)} MPa`
+                      : `${LOAD_LABELS[g.dof]} = ${fmt(g.totalForce)} ${
+                          g.dof <= 2 ? "N" : "N·m"
+                        }`}
                   </span>
                   <div className={styles.treeItemActions}>
                     <button
@@ -1003,6 +1027,7 @@ function SolvePanel() {
   const properties = useModelStore((s) => s.properties);
   const constraints = useModelStore((s) => s.constraints);
   const loads = useModelStore((s) => s.loads);
+  const surfaceLoads = useModelStore((s) => s.surfaceLoads);
   const isRunning = useModelStore((s) => s.isRunning);
   const setRunning = useModelStore((s) => s.setRunning);
   const setResult = useModelStore((s) => s.setResult);
@@ -1012,7 +1037,9 @@ function SolvePanel() {
   const meshOk = nodes.length > 0;
   const matOk = materials.length > 0;
   const bcOk = constraints.length > 0;
-  const loadOk = loads.length > 0;
+  // Force/pressure loads now reach the solver as surface tractions, moments as
+  // nodal forces — either kind makes the model loaded.
+  const loadOk = loads.length > 0 || surfaceLoads.length > 0;
   // A non-zero prescribed displacement drives the deformation on its own, so the
   // model is solvable without an applied load. Without either, the solve returns
   // the trivial zero field, so at least one driving action is still required.
@@ -1029,6 +1056,7 @@ function SolvePanel() {
       properties,
       constraints,
       loads,
+      surfaceLoads,
     })
       .then(({ displacements, vonMises }) => {
         setResult({

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -993,11 +993,7 @@ export function MeshScene() {
           const shaftR = modelSize * 0.012;
           const headR = modelSize * 0.038;
           return (
-            <group
-              key={i}
-              position={arrow.pos}
-              quaternion={arrow.quaternion}
-            >
+            <group key={i} position={arrow.pos} quaternion={arrow.quaternion}>
               <mesh position={[0, shaftLen / 2, 0]}>
                 <cylinderGeometry args={[shaftR, shaftR, shaftLen, 8]} />
                 <meshStandardMaterial color="#d97706" />

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import { Line } from "@react-three/drei";
 import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
-import { useModelStore } from "../../store/modelStore";
+import { useModelStore, loadKind } from "../../store/modelStore";
 import type { Node, ResultType } from "../../store/modelStore";
 import { buildBoundaryMeshTopo, pickFaceNodeIds } from "../../lib/facePick";
 import type { Vec3, Tri } from "../../lib/facePick";
@@ -135,7 +135,6 @@ export function MeshScene() {
   const nodes = useModelStore((s) => s.nodes);
   const elements = useModelStore((s) => s.elements);
   const constraints = useModelStore((s) => s.constraints);
-  const loads = useModelStore((s) => s.loads);
   const result = useModelStore((s) => s.result);
   const resultType = useModelStore((s) => s.resultType);
   const mode = useModelStore((s) => s.mode);
@@ -661,48 +660,71 @@ export function MeshScene() {
     return { pos: [cx, cy, cz] as [number, number, number], quaternion: q };
   }, [constraints, nodeMap, nodes]);
 
-  // Load arrow: single resultant of all force DOFs, placed at centroid of loaded nodes
-  const loadArrowData = useMemo(() => {
-    if (loads.length === 0) return null;
-    let cx = 0,
-      cy = 0,
-      cz = 0,
-      nodeCount = 0;
-    let fx = 0,
-      fy = 0,
-      fz = 0;
-    const seen = new Set<number>();
-    for (const l of loads) {
-      if (l.dof === 0) fx += l.value;
-      else if (l.dof === 1) fy += l.value;
-      else if (l.dof === 2) fz += l.value;
-      else continue;
-      if (!seen.has(l.nodeId)) {
-        const e = nodeMap.get(l.nodeId);
-        if (e) {
-          cx += e.n.x;
-          cy += e.n.y;
-          cz += e.n.z;
-          nodeCount++;
-        }
-        seen.add(l.nodeId);
-      }
+  // Load glyphs — one arrow per force/pressure group, at the centroid of its
+  // loaded nodes. Force arrows point along the applied force; pressure arrows
+  // point into the loaded face (positive pressure pushes inward). Driven by
+  // loadGroups because force/pressure loads reach the solver as surface tractions
+  // rather than nodal forces. Moments carry no single resultant, so they are
+  // skipped.
+  const loadArrows = useMemo(() => {
+    if (loadGroups.length === 0 || nodes.length === 0) return [];
+    // Model centroid — used to orient pressure arrows inward.
+    let mx = 0,
+      my = 0,
+      mz = 0;
+    for (const n of nodes) {
+      mx += n.x;
+      my += n.y;
+      mz += n.z;
     }
-    if (nodeCount === 0) return null;
-    const len = Math.sqrt(fx * fx + fy * fy + fz * fz);
-    if (len < 1e-30) return null;
-    const dir = new THREE.Vector3(fx / len, fy / len, fz / len);
-    const q = new THREE.Quaternion();
-    q.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir);
-    return {
-      pos: [cx / nodeCount, cy / nodeCount, cz / nodeCount] as [
-        number,
-        number,
-        number,
-      ],
-      quaternion: q,
-    };
-  }, [loads, nodeMap]);
+    mx /= nodes.length;
+    my /= nodes.length;
+    mz /= nodes.length;
+
+    const up = new THREE.Vector3(0, 1, 0);
+    const arrows: {
+      pos: [number, number, number];
+      quaternion: THREE.Quaternion;
+    }[] = [];
+    for (const g of loadGroups) {
+      const kind = loadKind(g);
+      if (kind === "moment") continue;
+      let cx = 0,
+        cy = 0,
+        cz = 0,
+        count = 0;
+      for (const f of g.faces) {
+        for (const id of f.nodeIds) {
+          const e = nodeMap.get(id);
+          if (e) {
+            cx += e.n.x;
+            cy += e.n.y;
+            cz += e.n.z;
+            count++;
+          }
+        }
+      }
+      if (count === 0) continue;
+      cx /= count;
+      cy /= count;
+      cz /= count;
+
+      let dir: THREE.Vector3;
+      if (kind === "pressure") {
+        dir = new THREE.Vector3(mx - cx, my - cy, mz - cz);
+      } else {
+        const d = [0, 0, 0];
+        d[g.dof] = g.totalForce;
+        dir = new THREE.Vector3(d[0], d[1], d[2]);
+      }
+      if (dir.lengthSq() < 1e-30) continue;
+      dir.normalize();
+      const q = new THREE.Quaternion();
+      q.setFromUnitVectors(up, dir);
+      arrows.push({ pos: [cx, cy, cz], quaternion: q });
+    }
+    return arrows;
+  }, [loadGroups, nodes, nodeMap]);
 
   const volMeshPositions = useMemo(() => {
     if (!volMesh || viewRepr !== "volume") return null;
@@ -963,18 +985,18 @@ export function MeshScene() {
         </group>
       )}
 
-      {/* Load arrow — resultant of all force DOFs, cylinder shaft + cone head */}
+      {/* Load arrows — one per force/pressure group, cylinder shaft + cone head */}
       {!showResult &&
-        loadArrowData &&
-        (() => {
+        loadArrows.map((arrow, i) => {
           const shaftLen = modelSize * 0.22;
           const headLen = modelSize * 0.09;
           const shaftR = modelSize * 0.012;
           const headR = modelSize * 0.038;
           return (
             <group
-              position={loadArrowData.pos}
-              quaternion={loadArrowData.quaternion}
+              key={i}
+              position={arrow.pos}
+              quaternion={arrow.quaternion}
             >
               <mesh position={[0, shaftLen / 2, 0]}>
                 <cylinderGeometry args={[shaftR, shaftR, shaftLen, 8]} />
@@ -986,7 +1008,7 @@ export function MeshScene() {
               </mesh>
             </group>
           );
-        })()}
+        })}
 
       {/* Volume mesh wireframe */}
       {volMeshPositions && (

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -112,12 +112,38 @@ export interface NamedBcGroup {
   faces: BcFaceEntry[];
 }
 
+// A load group's physical kind. "force" and "pressure" are applied to the solver
+// as work-equivalent surface tractions (SurfaceLoad); "moment" is still lumped to
+// equivalent nodal forces (rebuildLoads). For backward-compat with saved analyses
+// that predate this field, `kind` is optional and inferred from `dof` via
+// loadKind().
+export type LoadKind = "force" | "moment" | "pressure";
+
 export interface NamedLoadGroup {
   id: number;
   name: string; // e.g. "Load1"
-  dof: number;
-  totalForce: number; // applied per face, divided equally among the face's nodes
+  dof: number; // force: 0=Fx,1=Fy,2=Fz · moment: 3=Mx,4=My,5=Mz · pressure: unused
+  totalForce: number; // force/moment magnitude (N, N·mm), or pressure magnitude (MPa)
   faces: BcFaceEntry[];
+  kind?: LoadKind;
+}
+
+// Physical kind of a load group, defaulting from `dof` for older payloads that
+// have no explicit `kind` (dof ≤ 2 ⇒ force, dof ≥ 3 ⇒ moment).
+export function loadKind(g: NamedLoadGroup): LoadKind {
+  return g.kind ?? (g.dof <= 2 ? "force" : "moment");
+}
+
+// A work-equivalent surface load handed to the engine's boundary integrator.
+// Each entry covers the surface triangles of one loaded face.
+//   force    — total force vector, spread by the engine as a uniform traction
+//   pressure — scalar magnitude, applied as -p·n̂ (outward normal; + pushes in)
+//   traction — traction vector applied directly (not surfaced in the UI yet)
+export interface SurfaceLoad {
+  type: "force" | "pressure" | "traction";
+  triangles: [number, number, number][];
+  force?: [number, number, number];
+  pressure?: number;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -138,14 +164,10 @@ function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
 
   const result: Load[] = [];
   for (const g of loadGroups) {
-    if (g.dof <= 2) {
-      // Force load — distribute total evenly across face nodes
-      for (const f of g.faces) {
-        const perNode = g.totalForce / f.nodeIds.length;
-        for (const nodeId of f.nodeIds)
-          result.push({ nodeId, dof: g.dof, value: perNode });
-      }
-    } else {
+    // Force and pressure loads are applied as work-equivalent surface tractions
+    // (rebuildSurfaceLoads), not lumped nodal forces — they are skipped here.
+    if (loadKind(g) !== "moment") continue;
+    {
       // Moment load (dof 3=Mx, 4=My, 5=Mz) — convert to equivalent nodal forces.
       // For each face, find the centroid, then apply tangential forces F_i = M/S·(n̂×r_i)
       // where S = Σ|r_i⊥|² (perpendicular distance squared from moment axis).
@@ -210,6 +232,42 @@ function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
   return result;
 }
 
+// Build the work-equivalent surface loads (one per loaded face) for force and
+// pressure groups. The engine integrates these over the face's boundary elements
+// (f_i = ∫ N_i·t dS), which is both shape-function-correct and immune to the
+// spurious moment that equal nodal splitting introduces on a non-uniform mesh.
+//
+// A face's triangles are recovered from the global boundary triangulation by
+// keeping those whose three vertices all belong to the face's node set — the same
+// node-membership matching the mesh pipeline already relies on. Without a meshed
+// surface there is nothing to integrate over, so the result is empty.
+function rebuildSurfaceLoads(
+  loadGroups: NamedLoadGroup[],
+  surfaceTriangles: [number, number, number][] | null,
+): SurfaceLoad[] {
+  if (!surfaceTriangles) return [];
+  const result: SurfaceLoad[] = [];
+  for (const g of loadGroups) {
+    const kind = loadKind(g);
+    if (kind === "moment") continue; // moments stay as equivalent point loads
+    for (const f of g.faces) {
+      const nodeSet = new Set(f.nodeIds);
+      const triangles = surfaceTriangles.filter(
+        (t) => nodeSet.has(t[0]) && nodeSet.has(t[1]) && nodeSet.has(t[2]),
+      );
+      if (triangles.length === 0) continue;
+      if (kind === "pressure") {
+        result.push({ type: "pressure", pressure: g.totalForce, triangles });
+      } else {
+        const force: [number, number, number] = [0, 0, 0];
+        force[g.dof] = g.totalForce;
+        result.push({ type: "force", force, triangles });
+      }
+    }
+  }
+  return result;
+}
+
 // ── Store types ───────────────────────────────────────────────────────────────
 
 export type AppMode = "geometry" | "constraints" | "solve" | "results";
@@ -222,6 +280,8 @@ interface ModelState {
   // flat arrays derived from bcGroups / loadGroups — used by solver and visualization
   constraints: Constraint[];
   loads: Load[];
+  // work-equivalent surface tractions (force/pressure groups) handed to the solver
+  surfaceLoads: SurfaceLoad[];
 
   modelName: string;
   hasStarted: boolean;
@@ -316,6 +376,7 @@ interface ModelState {
     faces: Omit<BcFaceEntry, "id">[],
     dof: number,
     totalForce: number,
+    kind?: LoadKind,
   ): void;
   addFaceToLoadGroup(groupId: number, face: Omit<BcFaceEntry, "id">): void;
   removeFaceFromLoadGroup(groupId: number, faceId: number): void;
@@ -341,6 +402,7 @@ const EMPTY_MODEL = {
   properties: [{ id: 1, type: "PSOLID" as const, materialId: 1 }] as Property[],
   constraints: [] as Constraint[],
   loads: [] as Load[],
+  surfaceLoads: [] as SurfaceLoad[],
   bcGroups: [] as NamedBcGroup[],
   loadGroups: [] as NamedLoadGroup[],
   nextBcGroupId: 1,
@@ -413,6 +475,7 @@ export const useModelStore = create<ModelState>()(
         s.loadGroups = [];
         s.constraints = [];
         s.loads = [];
+        s.surfaceLoads = [];
         s.nextBcGroupId = 1;
         s.nextLoadGroupId = 1;
         s.nextFaceEntryId = 1;
@@ -483,6 +546,7 @@ export const useModelStore = create<ModelState>()(
         s.loadGroups = [];
         s.constraints = [];
         s.loads = [];
+        s.surfaceLoads = [];
         s.nextBcGroupId = 1;
         s.nextLoadGroupId = 1;
         s.nextFaceEntryId = 1;
@@ -513,6 +577,7 @@ export const useModelStore = create<ModelState>()(
         s.loadGroups = a.loadGroups;
         s.constraints = rebuildConstraints(a.bcGroups);
         s.loads = rebuildLoads(a.loadGroups, s.nodes);
+        s.surfaceLoads = rebuildSurfaceLoads(a.loadGroups, a.surfaceTriangles);
         s.nextBcGroupId = a.nextBcGroupId;
         s.nextLoadGroupId = a.nextLoadGroupId;
         s.nextFaceEntryId = a.nextFaceEntryId;
@@ -558,6 +623,7 @@ export const useModelStore = create<ModelState>()(
         s.loadGroups = [];
         s.constraints = [];
         s.loads = [];
+        s.surfaceLoads = [];
         s.nextBcGroupId = 1;
         s.nextLoadGroupId = 1;
         s.nextFaceEntryId = 1;
@@ -681,6 +747,7 @@ export const useModelStore = create<ModelState>()(
       faces: Omit<BcFaceEntry, "id">[],
       dof: number,
       totalForce: number,
+      kind: LoadKind = dof <= 2 ? "force" : "moment",
     ) =>
       set((s) => {
         const faceEntries = faces.map((f) => ({
@@ -694,9 +761,11 @@ export const useModelStore = create<ModelState>()(
           dof,
           totalForce,
           faces: faceEntries,
+          kind,
         });
         s.nextLoadGroupId++;
         s.loads = rebuildLoads(s.loadGroups, s.nodes);
+        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.surfaceTriangles);
         s.result = null;
       }),
 
@@ -707,6 +776,7 @@ export const useModelStore = create<ModelState>()(
         const faceId = s.nextFaceEntryId++;
         g.faces.push({ id: faceId, label: face.label, nodeIds: face.nodeIds });
         s.loads = rebuildLoads(s.loadGroups, s.nodes);
+        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.surfaceTriangles);
         s.result = null;
       }),
 
@@ -718,6 +788,7 @@ export const useModelStore = create<ModelState>()(
         if (g.faces.length === 0)
           s.loadGroups = s.loadGroups.filter((g) => g.id !== groupId);
         s.loads = rebuildLoads(s.loadGroups, s.nodes);
+        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.surfaceTriangles);
         s.result = null;
       }),
 
@@ -725,6 +796,7 @@ export const useModelStore = create<ModelState>()(
       set((s) => {
         s.loadGroups = s.loadGroups.filter((g) => g.id !== id);
         s.loads = rebuildLoads(s.loadGroups, s.nodes);
+        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.surfaceTriangles);
         s.result = null;
       }),
 
@@ -732,6 +804,7 @@ export const useModelStore = create<ModelState>()(
       set((s) => {
         s.loadGroups = [];
         s.loads = [];
+        s.surfaceLoads = [];
         s.result = null;
       }),
   })),

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -135,13 +135,15 @@ export function loadKind(g: NamedLoadGroup): LoadKind {
 }
 
 // A work-equivalent surface load handed to the engine's boundary integrator.
-// Each entry covers the surface triangles of one loaded face.
+// `faces` are the element boundary faces of one loaded face — triangles (tets) or
+// quads (hexes) — each a list of node indices the engine matches to its generated
+// boundary elements by vertex set.
 //   force    — total force vector, spread by the engine as a uniform traction
 //   pressure — scalar magnitude, applied as -p·n̂ (outward normal; + pushes in)
 //   traction — traction vector applied directly (not surfaced in the UI yet)
 export interface SurfaceLoad {
   type: "force" | "pressure" | "traction";
-  triangles: [number, number, number][];
+  faces: number[][];
   force?: [number, number, number];
   pressure?: number;
 }
@@ -156,6 +158,57 @@ function rebuildConstraints(bcGroups: NamedBcGroup[]): Constraint[] {
         for (const dof of g.dofs)
           result.push({ nodeId, dof, prescribedValue: g.value });
   return result;
+}
+
+// Local vertex indices of each boundary face of a solid element, in the node
+// ordering used by both the .inp/fixture meshes and MFEM's AddTet/AddHex (and so
+// by the boundary elements the engine generates). Matching is by vertex set, so
+// only the grouping matters, not the winding.
+const TET_FACE_INDICES = [
+  [0, 1, 2],
+  [0, 1, 3],
+  [0, 2, 3],
+  [1, 2, 3],
+];
+const HEX_FACE_INDICES = [
+  [0, 1, 2, 3],
+  [4, 5, 6, 7],
+  [0, 1, 5, 4],
+  [1, 2, 6, 5],
+  [2, 3, 7, 6],
+  [3, 0, 4, 7],
+];
+
+// The element boundary faces lying on one loaded face: every solid-element face
+// whose nodes all belong to the face's node set — triangles for tets, quads for
+// hexes. The engine matches these to its generated boundary elements by vertex
+// set (and ignores any interior faces that aren't boundaries), so the load is
+// integrated over the real surface, mesh type regardless.
+function loadedFaces(
+  face: { nodeIds: number[] },
+  elements: Element[],
+): number[][] {
+  const nodeSet = new Set(face.nodeIds);
+  const seen = new Set<string>();
+  const faces: number[][] = [];
+  for (const el of elements) {
+    const local =
+      el.type === "CTETRA"
+        ? TET_FACE_INDICES
+        : el.type === "CHEXA"
+          ? HEX_FACE_INDICES
+          : null;
+    if (!local) continue;
+    for (const lf of local) {
+      const verts = lf.map((i) => el.nodeIds[i]);
+      if (!verts.every((v) => nodeSet.has(v))) continue;
+      const key = [...verts].sort((a, b) => a - b).join(",");
+      if (seen.has(key)) continue; // a boundary face is owned by one element
+      seen.add(key);
+      faces.push(verts);
+    }
+  }
+  return faces;
 }
 
 function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
@@ -237,31 +290,26 @@ function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
 // (f_i = ∫ N_i·t dS), which is both shape-function-correct and immune to the
 // spurious moment that equal nodal splitting introduces on a non-uniform mesh.
 //
-// A face's triangles are recovered from the global boundary triangulation by
-// keeping those whose three vertices all belong to the face's node set — the same
-// node-membership matching the mesh pipeline already relies on. Without a meshed
-// surface there is nothing to integrate over, so the result is empty.
+// The loaded faces are derived from the element connectivity (loadedFaces), so a
+// load works on tet meshes (triangle faces) and hex meshes (quad faces) alike,
+// with no dependency on a separately-stored surface triangulation.
 function rebuildSurfaceLoads(
   loadGroups: NamedLoadGroup[],
-  surfaceTriangles: [number, number, number][] | null,
+  elements: Element[],
 ): SurfaceLoad[] {
-  if (!surfaceTriangles) return [];
   const result: SurfaceLoad[] = [];
   for (const g of loadGroups) {
     const kind = loadKind(g);
     if (kind === "moment") continue; // moments stay as equivalent point loads
     for (const f of g.faces) {
-      const nodeSet = new Set(f.nodeIds);
-      const triangles = surfaceTriangles.filter(
-        (t) => nodeSet.has(t[0]) && nodeSet.has(t[1]) && nodeSet.has(t[2]),
-      );
-      if (triangles.length === 0) continue;
+      const faces = loadedFaces(f, elements);
+      if (faces.length === 0) continue;
       if (kind === "pressure") {
-        result.push({ type: "pressure", pressure: g.totalForce, triangles });
+        result.push({ type: "pressure", pressure: g.totalForce, faces });
       } else {
         const force: [number, number, number] = [0, 0, 0];
         force[g.dof] = g.totalForce;
-        result.push({ type: "force", force, triangles });
+        result.push({ type: "force", force, faces });
       }
     }
   }
@@ -577,7 +625,7 @@ export const useModelStore = create<ModelState>()(
         s.loadGroups = a.loadGroups;
         s.constraints = rebuildConstraints(a.bcGroups);
         s.loads = rebuildLoads(a.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(a.loadGroups, a.surfaceTriangles);
+        s.surfaceLoads = rebuildSurfaceLoads(a.loadGroups, a.elements);
         s.nextBcGroupId = a.nextBcGroupId;
         s.nextLoadGroupId = a.nextLoadGroupId;
         s.nextFaceEntryId = a.nextFaceEntryId;
@@ -765,7 +813,7 @@ export const useModelStore = create<ModelState>()(
         });
         s.nextLoadGroupId++;
         s.loads = rebuildLoads(s.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.surfaceTriangles);
+        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
         s.result = null;
       }),
 
@@ -776,7 +824,7 @@ export const useModelStore = create<ModelState>()(
         const faceId = s.nextFaceEntryId++;
         g.faces.push({ id: faceId, label: face.label, nodeIds: face.nodeIds });
         s.loads = rebuildLoads(s.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.surfaceTriangles);
+        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
         s.result = null;
       }),
 
@@ -788,7 +836,7 @@ export const useModelStore = create<ModelState>()(
         if (g.faces.length === 0)
           s.loadGroups = s.loadGroups.filter((g) => g.id !== groupId);
         s.loads = rebuildLoads(s.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.surfaceTriangles);
+        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
         s.result = null;
       }),
 
@@ -796,7 +844,7 @@ export const useModelStore = create<ModelState>()(
       set((s) => {
         s.loadGroups = s.loadGroups.filter((g) => g.id !== id);
         s.loads = rebuildLoads(s.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.surfaceTriangles);
+        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
         s.result = null;
       }),
 

--- a/web/src/wasm/pkg/kofem_wasm.d.ts
+++ b/web/src/wasm/pkg/kofem_wasm.d.ts
@@ -56,7 +56,7 @@ export function generate_volume_mesh(surface_json: string, opts_json: string): s
 /** Run a linear-elastic FEM solve using MFEM.
  *  @param mesh_json JSON-serialised `{ vertices: [number,number,number][], tetrahedra: [number,number,number,number][], hexahedra: [number,number,number,number,number,number,number,number][] }`.
  *  @param mat_json  JSON-serialised `{ young_modulus: number, poisson_ratio: number, density: number }`.
- *  @param bcs_json  JSON-serialised `{ fixed_vertices: number[], point_loads: { vertex: number, force: [number,number,number] }[] }`.
+ *  @param bcs_json  JSON-serialised `{ fixed_vertices: number[], point_loads: { vertex: number, force: [number,number,number] }[], surface_loads?: { type: "force"|"pressure"|"traction", triangles: [number,number,number][], force?: [number,number,number], pressure?: number }[] }`.
  *  @param order     FE polynomial order (1 = linear, 2 = quadratic).
  *  @returns JSON-serialised `{ displacements: number[], von_mises: number[] }`.
  */

--- a/web/src/wasm/pkg/kofem_wasm.d.ts
+++ b/web/src/wasm/pkg/kofem_wasm.d.ts
@@ -56,7 +56,7 @@ export function generate_volume_mesh(surface_json: string, opts_json: string): s
 /** Run a linear-elastic FEM solve using MFEM.
  *  @param mesh_json JSON-serialised `{ vertices: [number,number,number][], tetrahedra: [number,number,number,number][], hexahedra: [number,number,number,number,number,number,number,number][] }`.
  *  @param mat_json  JSON-serialised `{ young_modulus: number, poisson_ratio: number, density: number }`.
- *  @param bcs_json  JSON-serialised `{ fixed_vertices: number[], point_loads: { vertex: number, force: [number,number,number] }[], surface_loads?: { type: "force"|"pressure"|"traction", triangles: [number,number,number][], force?: [number,number,number], pressure?: number }[] }`.
+ *  @param bcs_json  JSON-serialised `{ fixed_vertices: number[], point_loads: { vertex: number, force: [number,number,number] }[], surface_loads?: { type: "force"|"pressure"|"traction", faces: number[][], force?: [number,number,number], pressure?: number }[] }`.
  *  @param order     FE polynomial order (1 = linear, 2 = quadratic).
  *  @returns JSON-serialised `{ displacements: number[], von_mises: number[] }`.
  */

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -109,6 +109,17 @@ interface Load {
   dof: number;
   value: number;
 }
+// A work-equivalent surface load applied by the engine's boundary integrator
+// over the boundary elements covering `triangles` (node-index triples).
+//   force    — total force vector spread as a uniform traction over the face
+//   pressure — scalar magnitude applied as -p·n̂ (outward normal; + pushes in)
+//   traction — traction vector applied directly
+interface SurfaceLoad {
+  type: "force" | "pressure" | "traction";
+  triangles: [number, number, number][];
+  force?: [number, number, number];
+  pressure?: number;
+}
 
 // ── Message handler ───────────────────────────────────────────────────────────
 
@@ -276,14 +287,16 @@ self.onmessage = async (event: MessageEvent) => {
         surfaceFaceIds: dto.surfaceFaceIds ?? null,
       });
     } else if (type === "solve") {
-      const { nodes, elements, materials, constraints, loads } = payload as {
-        nodes: Node[];
-        elements: Element[];
-        materials: Material[];
-        properties: unknown[];
-        constraints: Constraint[];
-        loads: Load[];
-      };
+      const { nodes, elements, materials, constraints, loads, surfaceLoads } =
+        payload as {
+          nodes: Node[];
+          elements: Element[];
+          materials: Material[];
+          properties: unknown[];
+          constraints: Constraint[];
+          loads: Load[];
+          surfaceLoads?: SurfaceLoad[];
+        };
 
       const tetrahedra = elements
         .filter((e) => e.type === "CTETRA")
@@ -357,7 +370,14 @@ self.onmessage = async (event: MessageEvent) => {
         force,
       }));
 
-      const bcs = { fixed_vertices, point_loads, fixed_dofs, prescribed_dofs };
+      const surface_loads = surfaceLoads ?? [];
+      const bcs = {
+        fixed_vertices,
+        point_loads,
+        fixed_dofs,
+        prescribed_dofs,
+        surface_loads,
+      };
       const json = m().solve_linear_elastic(
         JSON.stringify(mesh),
         JSON.stringify(material),

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -110,13 +110,14 @@ interface Load {
   value: number;
 }
 // A work-equivalent surface load applied by the engine's boundary integrator
-// over the boundary elements covering `triangles` (node-index triples).
+// over the boundary elements covering `faces` (node-index lists — triangles for
+// tets, quads for hexes).
 //   force    — total force vector spread as a uniform traction over the face
 //   pressure — scalar magnitude applied as -p·n̂ (outward normal; + pushes in)
 //   traction — traction vector applied directly
 interface SurfaceLoad {
   type: "force" | "pressure" | "traction";
-  triangles: [number, number, number][];
+  faces: number[][];
   force?: [number, number, number];
   pressure?: number;
 }

--- a/web/tests/fixtures/cantilever.ts
+++ b/web/tests/fixtures/cantilever.ts
@@ -148,33 +148,77 @@ export function buildCantilever(): CantileverModel {
 }
 
 // Open the app and inject the cantilever fixture straight into the store (the
-// model is invisible to real users, so there is no UI button to click). Leaves
-// the app in geometry mode with a solver-ready CHEXA8 mesh.
+// model is invisible to real users, so there is no UI button to click). The mesh
+// and materials go in via setState, but the BC and load are built through the
+// real store actions so the load derives exactly as it does after a save→load
+// round-trip (a work-equivalent surface traction over the hex end face), keeping
+// the initial and re-solved fields identical. Leaves the app in geometry mode
+// with a solver-ready CHEXA8 mesh.
 export async function bootstrapCantilever(page: Page): Promise<void> {
   await page.goto("/app/");
   await page.waitForFunction(
     () => !!(window as unknown as { __kofemStore?: unknown }).__kofemStore,
   );
   await page.evaluate((model) => {
+    type FaceArg = { label: string; nodeIds: number[] };
     const store = (
-      window as unknown as { __kofemStore: { setState(s: object): void } }
+      window as unknown as {
+        __kofemStore: {
+          setState(s: object): void;
+          getState(): {
+            createBcGroup(
+              faces: FaceArg[],
+              dofs: number[],
+              value: number,
+            ): void;
+            createLoadGroup(
+              faces: FaceArg[],
+              dof: number,
+              totalForce: number,
+            ): void;
+          };
+        };
+      }
     ).__kofemStore;
     store.setState({
-      ...model,
+      nodes: model.nodes,
+      elements: model.elements,
+      materials: model.materials,
+      properties: model.properties,
       modelName: "Cantilever Beam",
       result: null,
       stepSurface: null,
       volMesh: null,
+      surfaceTriangles: null,
+      surfaceFaceIds: null,
+      bcGroups: [],
+      loadGroups: [],
+      constraints: [],
+      loads: [],
+      surfaceLoads: [],
+      nextBcGroupId: 1,
+      nextLoadGroupId: 1,
+      nextFaceEntryId: 1,
       viewRepr: "surface",
       selectedFace: null,
       pendingFaces: [],
       pickMode: null,
       pickTargetGroupId: null,
-      nextBcGroupId: 2,
-      nextLoadGroupId: 2,
-      nextFaceEntryId: 3,
       hasStarted: true,
       mode: "geometry",
     });
+    const s = store.getState();
+    const bc = model.bcGroups[0];
+    const load = model.loadGroups[0];
+    s.createBcGroup(
+      bc.faces.map((f) => ({ label: f.label, nodeIds: f.nodeIds })),
+      bc.dofs,
+      bc.value,
+    );
+    s.createLoadGroup(
+      load.faces.map((f) => ({ label: f.label, nodeIds: f.nodeIds })),
+      load.dof,
+      load.totalForce,
+    );
   }, buildCantilever());
 }

--- a/web/tests/showcase.spec.ts
+++ b/web/tests/showcase.spec.ts
@@ -175,6 +175,7 @@ test.describe("Full workflow showcase", () => {
             getState(): {
               constraints: unknown[];
               loads: unknown[];
+              surfaceLoads: unknown[];
               isRunning: boolean;
             };
           };
@@ -183,7 +184,9 @@ test.describe("Full workflow showcase", () => {
       const s = store.getState();
       return {
         constraints: s.constraints.length,
-        loads: s.loads.length,
+        // Force/pressure loads reach the solver as surface tractions; moments as
+        // nodal forces. Count both so the gate holds for either kind.
+        loads: s.loads.length + s.surfaceLoads.length,
         isRunning: s.isRunning,
       };
     });
@@ -240,6 +243,7 @@ test.describe("Full workflow showcase", () => {
               nodes: unknown[];
               constraints: unknown[];
               loads: unknown[];
+              surfaceLoads: unknown[];
               isRunning: boolean;
             };
           };
@@ -249,7 +253,7 @@ test.describe("Full workflow showcase", () => {
       return {
         nodes: s.nodes.length,
         constraints: s.constraints.length,
-        loads: s.loads.length,
+        loads: s.loads.length + s.surfaceLoads.length,
         isRunning: s.isRunning,
       };
     });

--- a/web/tests/solve.spec.ts
+++ b/web/tests/solve.spec.ts
@@ -81,6 +81,7 @@ test("results panel switches to von Mises stress", async ({ page }) => {
             properties: unknown[];
             constraints: unknown[];
             loads: unknown[];
+            surfaceLoads: unknown[];
             setResult(r: {
               displacements: Float64Array;
               vonMises?: Float64Array;
@@ -104,6 +105,7 @@ test("results panel switches to von Mises stress", async ({ page }) => {
       properties: s.properties,
       constraints: s.constraints,
       loads: s.loads,
+      surfaceLoads: s.surfaceLoads,
     })) as { displacements: number[]; vonMises: number[] };
     store.getState().setResult({
       displacements: new Float64Array(displacements),

--- a/web/tests/tutorial-capture.spec.ts
+++ b/web/tests/tutorial-capture.spec.ts
@@ -168,11 +168,19 @@ test.describe("Tutorial figure capture", () => {
       const s = (
         window as unknown as {
           __kofemStore: {
-            getState(): { constraints: unknown[]; loads: unknown[] };
+            getState(): {
+              constraints: unknown[];
+              loads: unknown[];
+              surfaceLoads: unknown[];
+            };
           };
         }
       ).__kofemStore.getState();
-      return { constraints: s.constraints.length, loads: s.loads.length };
+      // Force loads now reach the solver as surface tractions, so count both.
+      return {
+        constraints: s.constraints.length,
+        loads: s.loads.length + s.surfaceLoads.length,
+      };
     });
     if (bc.constraints === 0 || bc.loads === 0) {
       throw new Error(


### PR DESCRIPTION
Face force loads were distributed by splitting the total force equally
across the face's nodes (`totalForce / nodeIds.length`). That is wrong in
two ways the user hit in practice:

  1. No shape-function weighting. The consistent nodal load for a surface
     traction is f_i = ∫_S N_i·t dS, which weights each node by its
     tributary surface area. Equal splitting over-loads corner nodes.
  2. Spurious moment on non-uniform meshes. Equal nodal forces put the
     resultant through the arithmetic mean of node positions, so refining
     the mesh on one side drags the load off the face's area-centroid and
     introduces a parasitic moment that changes with mesh density.

Both vanish when the load is integrated by the FE machinery. The engine
now tags the boundary elements covering a loaded face with a unique
boundary attribute and applies a VectorBoundaryLFIntegrator restricted to
it:

  - force    — total force F spread as a uniform traction F / A_total
               (A_total integrated from the element transformation)
  - pressure — scalar p applied as -p·n̂ along the outward normal
  - traction — a traction vector applied directly

This also adds a Pressure load type end to end (store kind, LeftPanel
selector, viewport glyph, persistence). Concentrated point loads and the
equivalent nodal forces of a moment load still flow through point_loads,
so older payloads are unchanged.

Force/pressure groups now produce store.surfaceLoads instead of nodal
loads; the worker forwards them as bcs.surface_loads and the solve gate,
arrows, and E2E load checks account for both arrays. Validation gains a
surface-traction and a surface-pressure case (the latter also pins the
pressure sign as compression).

Note: this changes engine/cpp/engine.cpp, so the committed WASM artifact
must be rebuilt — CI rebuilds it from engine/** and runs the suite against
the fresh binary.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HBBDB4giLzguzzg7zxr5cP