### PR TITLE
Remove Grid component from 3D viewport

### DIFF
--- a/web/src/components/viewport/Viewport.tsx
+++ b/web/src/components/viewport/Viewport.tsx
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { Canvas } from "@react-three/fiber";
-import {
-  OrbitControls,
-  Grid,
-  GizmoHelper,
-  GizmoViewport,
-} from "@react-three/drei";
+import { OrbitControls, GizmoHelper, GizmoViewport } from "@react-three/drei";
 import { MeshScene } from "./MeshScene";
 import { FitCamera } from "./FitCamera";
 import { ColorBar } from "./ColorBar";
@@ -54,14 +49,6 @@ export function Viewport() {
         <directionalLight position={[8, 10, 8]} intensity={0.9} castShadow />
         <directionalLight position={[-5, 5, -5]} intensity={0.3} />
         <MeshScene />
-        <Grid
-          infiniteGrid
-          cellSize={0.5}
-          sectionSize={2}
-          fadeDistance={50}
-          cellColor="#d1d5db"
-          sectionColor="#9ca3af"
-        />
         <OrbitControls makeDefault />
         <FitCamera />
         <GizmoHelper alignment="bottom-right" margin={[72, 72]}>


### PR DESCRIPTION
## Summary
Removes the infinite grid visualization from the 3D viewport, simplifying the scene and reducing visual clutter.

## Changes
- Removed `Grid` import from `@react-three/drei`
- Deleted the `<Grid>` component and its configuration props (`infiniteGrid`, `cellSize`, `sectionSize`, `fadeDistance`, `cellColor`, `sectionColor`) from the Canvas scene

## Details
The grid was providing a reference plane visualization in the viewport but is no longer needed for the current UI/UX design. This change streamlines the 3D scene rendering without affecting camera controls, gizmo helpers, or mesh visualization.

https://claude.ai/code/session_01UA6WRj4vrEvJnQn1714j2t