### PR TITLE
Add quadratic (2nd-order) FE elements for better stress resolution

### DIFF
--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -935,12 +935,26 @@ static std::string solve_linear_elastic(
     // fixed_vertices is the full-fixity shorthand: every translational component
     // (Ux, Uy, Uz) of the listed vertex is pinned.
     Array<int> ess_tdof;
+    // Per-vertex Dirichlet record (component mask + value). Used after the
+    // vertex-based loops below to extend each condition to the edge-midpoint DOFs
+    // that order ≥ 2 elements add, so a clamped/prescribed face stays fully
+    // constrained and not just at its corner nodes.
+    struct VDir {
+        std::array<bool, 3>   set{false, false, false};
+        std::array<double, 3> val{0.0, 0.0, 0.0};
+    };
+    std::map<int, VDir> vdir;
     for (unsigned i = 0; i < n_fixed; ++i) {
         int vi = fixed_js[i].as<int>();
         Array<int> vdofs;
         fespace.GetVertexVDofs(vi, vdofs);
         for (int j = 0; j < vdofs.Size(); ++j)
             ess_tdof.Append(vdofs[j]);
+        VDir& vd = vdir[vi];
+        for (int d = 0; d < dim && d < vdofs.Size(); ++d) {
+            vd.set[d] = true;
+            vd.val[d] = 0.0;
+        }
     }
 
     // fixed_dofs pins only the listed components of a vertex, leaving the others
@@ -960,8 +974,12 @@ static std::string solve_linear_elastic(
             fespace.GetVertexVDofs(vi, vdofs);
             for (unsigned c = 0; c < nc; ++c) {
                 int d = comps[c].as<int>();
-                if (d >= 0 && d < vdofs.Size())
+                if (d >= 0 && d < vdofs.Size()) {
                     ess_tdof.Append(vdofs[d]);
+                    VDir& vd = vdir[vi];
+                    vd.set[d] = true;
+                    vd.val[d] = 0.0;
+                }
             }
         }
     }
@@ -988,7 +1006,42 @@ static std::string solve_linear_elastic(
             if (d >= 0 && d < vdofs.Size()) {
                 ess_tdof.Append(vdofs[d]);
                 prescribed_vals.emplace_back(vdofs[d], value);
+                VDir& vd = vdir[vi];
+                vd.set[d] = true;
+                vd.val[d] = value;
             }
+        }
+    }
+
+    // Order-2 elements introduce one interior DOF per edge that the vertex-based
+    // loops above don't reach. Extend each Dirichlet condition to an edge's
+    // interior DOF when BOTH its endpoints carry that condition (in the same
+    // component): the midpoint value is the average of the endpoint values —
+    // exact for a clamped face (0) or a uniform/linear prescribed displacement.
+    // Edges straddling the border of a constrained region (only one endpoint
+    // constrained) stay free, the correct treatment of that border. Tetrahedral
+    // P2 faces carry no face-interior DOF, so this fully constrains a clamped
+    // face on the tet meshes the mesher produces. (A Q2 hex face's center DOF
+    // would be left free — negligible here and avoided in practice.)
+    if (order >= 2) {
+        int n_edges = mfem_mesh.GetNEdges();
+        for (int e = 0; e < n_edges; ++e) {
+            Array<int> ev;
+            mfem_mesh.GetEdgeVertices(e, ev);
+            auto it0 = vdir.find(ev[0]);
+            auto it1 = vdir.find(ev[1]);
+            if (it0 == vdir.end() || it1 == vdir.end()) continue;
+            Array<int> edofs;
+            fespace.GetEdgeInteriorDofs(e, edofs);
+            for (int k = 0; k < edofs.Size(); ++k)
+                for (int d = 0; d < dim; ++d) {
+                    if (!it0->second.set[d] || !it1->second.set[d]) continue;
+                    int vdof = fespace.DofToVDof(edofs[k], d);
+                    ess_tdof.Append(vdof);
+                    double avg = 0.5 * (it0->second.val[d] + it1->second.val[d]);
+                    if (avg != 0.0)
+                        prescribed_vals.emplace_back(vdof, avg);
+                }
         }
     }
 
@@ -1173,10 +1226,19 @@ static std::string solve_linear_elastic(
     // tet systems, producing NaN residuals that crash the WASM worker.
     GSSmoother prec(A_mat);
     CGSolver cg;
-    // 1e-1 tolerance is sufficient for visual FEM and converges in ~20 iterations
-    // (vs ~1000+ for 1e-6), keeping showcase solves under 60 s in WASM.
-    cg.SetRelTol(1e-1);
-    cg.SetMaxIter(1000);
+    // Order 1: a loose 1e-1 tolerance is enough for a visual linear-FEM field and
+    // converges in ~20 iterations (vs ~1000+ for 1e-6), keeping showcase solves
+    // under 60 s in WASM. Order ≥ 2: the quadratic field is only worth its extra
+    // DOFs if it's actually converged — a loose tolerance leaves visible noise in
+    // the recovered stress — so tighten to 1e-6 and allow more iterations. The
+    // user opts into this slower, more accurate solve via the element-order setting.
+    if (order >= 2) {
+        cg.SetRelTol(1e-6);
+        cg.SetMaxIter(5000);
+    } else {
+        cg.SetRelTol(1e-1);
+        cg.SetMaxIter(1000);
+    }
     cg.SetPrintLevel(1);  // print final iteration count to help diagnose convergence
     cg.SetPreconditioner(prec);
     cg.SetOperator(A_mat);

--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -1055,6 +1055,8 @@ function SolvePanel() {
   const setRunning = useModelStore((s) => s.setRunning);
   const setResult = useModelStore((s) => s.setResult);
   const setMode = useModelStore((s) => s.setMode);
+  const elementOrder = useModelStore((s) => s.elementOrder);
+  const setElementOrder = useModelStore((s) => s.setElementOrder);
   const [error, setError] = useState<string | null>(null);
 
   const meshOk = nodes.length > 0;
@@ -1080,6 +1082,7 @@ function SolvePanel() {
       constraints,
       loads,
       surfaceLoads,
+      elementOrder,
     })
       .then(({ displacements, vonMises }) => {
         setResult({
@@ -1163,6 +1166,18 @@ function SolvePanel() {
         <div className={styles.statRow}>
           <span className={styles.statKey}>Output</span>
           <span className={styles.statVal}>U, S, RF</span>
+        </div>
+        <div className={styles.statRow}>
+          <span className={styles.statKey}>Element order</span>
+          <select
+            className={styles.formSelect}
+            style={{ flex: "0 0 auto", width: 168 }}
+            value={elementOrder}
+            onChange={(e) => setElementOrder(Number(e.target.value))}
+          >
+            <option value={1}>Linear (1st order)</option>
+            <option value={2}>Quadratic (2nd order)</option>
+          </select>
         </div>
 
         <button

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -9,6 +9,7 @@ import { useModelStore, loadKind } from "../../store/modelStore";
 import type { Node, ResultType } from "../../store/modelStore";
 import { buildBoundaryMeshTopo, pickFaceNodeIds } from "../../lib/facePick";
 import type { Vec3, Tri } from "../../lib/facePick";
+import { nodeVonMisesField } from "../../lib/resultField";
 
 const TARGET_DEFORM_FRACTION = 0.2;
 
@@ -346,29 +347,12 @@ export function MeshScene() {
     [barElements, nodeMap],
   );
 
-  // Per-node von Mises: average element-level stresses to nodes.
-  const nodeVonMises = useMemo(() => {
-    if (!result?.vonMises || elements.length === 0 || nodes.length === 0)
-      return null;
-    const vm = result.vonMises;
-    const sums = new Float64Array(nodes.length);
-    const counts = new Int32Array(nodes.length);
-    for (let ei = 0; ei < elements.length; ei++) {
-      const vmVal = vm[ei] ?? 0;
-      for (const nodeId of elements[ei].nodeIds) {
-        const entry = nodeMap.get(nodeId);
-        if (entry) {
-          sums[entry.i] += vmVal;
-          counts[entry.i]++;
-        }
-      }
-    }
-    const avg = new Float64Array(nodes.length);
-    for (let i = 0; i < nodes.length; i++) {
-      avg[i] = counts[i] > 0 ? sums[i] / counts[i] : 0;
-    }
-    return avg;
-  }, [result, elements, nodes, nodeMap]);
+  // Per-node von Mises: volume-weighted average of the element-level stresses,
+  // shared with the colorbar range in resultField so the two stay identical.
+  const nodeVonMises = useMemo(
+    () => (result ? nodeVonMisesField(result, nodes, elements) : null),
+    [result, nodes, elements],
+  );
 
   const deformedSurface = useMemo(() => {
     if (!result) return null;

--- a/web/src/lib/resultField.ts
+++ b/web/src/lib/resultField.ts
@@ -16,9 +16,53 @@ export function resultColor(t: number): THREE.Color {
   return new THREE.Color().setHSL(0.667 * (1 - t), 1, 0.5);
 }
 
-// Element-level von Mises stress averaged to nodes, the same averaging used for
-// vertex coloring in MeshScene.
-function nodeVonMisesField(
+// Volume of a 4-node tetrahedron from its node positions: |(b−a)·((c−a)×(d−a))|/6.
+function tetVolume(a: Node, b: Node, c: Node, d: Node): number {
+  const bx = b.x - a.x,
+    by = b.y - a.y,
+    bz = b.z - a.z;
+  const cx = c.x - a.x,
+    cy = c.y - a.y,
+    cz = c.z - a.z;
+  const dx = d.x - a.x,
+    dy = d.y - a.y,
+    dz = d.z - a.z;
+  const det =
+    bx * (cy * dz - cz * dy) -
+    by * (cx * dz - cz * dx) +
+    bz * (cx * dy - cy * dx);
+  return Math.abs(det) / 6;
+}
+
+// Averaging weight for one element: its volume, so a node's averaged stress is
+// dominated by the elements that actually fill the space around it. Tetrahedra
+// use the signed-volume formula; any other element type falls back to unit
+// weight (still counted, just unweighted).
+function elementWeight(
+  el: Element,
+  nodeIndex: Map<number, number>,
+  nodes: Node[],
+): number {
+  if (el.nodeIds.length !== 4) return 1;
+  const a = nodeIndex.get(el.nodeIds[0]);
+  const b = nodeIndex.get(el.nodeIds[1]);
+  const c = nodeIndex.get(el.nodeIds[2]);
+  const d = nodeIndex.get(el.nodeIds[3]);
+  if (a === undefined || b === undefined || c === undefined || d === undefined)
+    return 1;
+  return tetVolume(nodes[a], nodes[b], nodes[c], nodes[d]);
+}
+
+// The solver returns one constant von Mises value per element (evaluated at the
+// element center). This recovers a smooth C⁰ per-node field by volume-weighted
+// averaging: each node takes the volume-weighted mean of the von Mises of the
+// elements touching it. Weighting by volume (rather than a plain element count)
+// down-weights the tiny sliver tetrahedra Netgen leaves at sharp features —
+// those slivers carry extreme, noisy stresses that a plain average lets speckle
+// the colormap at stress concentrations (issue #215). Returned in node-array
+// order; the same field drives the colorbar range here and the vertex coloring
+// in MeshScene, so the two must stay identical.
+export function nodeVonMisesField(
   result: SolverResult,
   nodes: Node[],
   elements: Element[],
@@ -29,20 +73,21 @@ function nodeVonMisesField(
   const nodeIndex = new Map<number, number>();
   for (let i = 0; i < nodes.length; i++) nodeIndex.set(nodes[i].id, i);
   const sums = new Float64Array(nodes.length);
-  const counts = new Int32Array(nodes.length);
+  const weights = new Float64Array(nodes.length);
   for (let ei = 0; ei < elements.length; ei++) {
     const vmVal = vm[ei] ?? 0;
+    const w = elementWeight(elements[ei], nodeIndex, nodes);
     for (const nodeId of elements[ei].nodeIds) {
       const ni = nodeIndex.get(nodeId);
       if (ni !== undefined) {
-        sums[ni] += vmVal;
-        counts[ni]++;
+        sums[ni] += w * vmVal;
+        weights[ni] += w;
       }
     }
   }
   const avg = new Float64Array(nodes.length);
   for (let i = 0; i < nodes.length; i++)
-    avg[i] = counts[i] > 0 ? sums[i] / counts[i] : 0;
+    avg[i] = weights[i] > 0 ? sums[i] / weights[i] : 0;
   return avg;
 }
 

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -351,6 +351,10 @@ interface ModelState {
   geometryFormat: GeometryFormat;
   isRunning: boolean;
   isMeshing: boolean;
+  // FE polynomial order for the solve: 1 = linear, 2 = quadratic (second-order).
+  // Quadratic elements resolve bending and stress gradients far better at the
+  // cost of more DOFs and a slower solve (issue #215).
+  elementOrder: number;
   nextMatId: number;
   pickMode: "bc" | "load" | null;
   pickTargetGroupId: number | null; // null = creating new group; id = adding to existing
@@ -394,6 +398,7 @@ interface ModelState {
   addProperty(prop: Property): void;
   setResult(result: SolverResult): void;
   setResultType(t: ResultType): void;
+  setElementOrder(order: number): void;
   setRunning(v: boolean): void;
   setMeshing(v: boolean): void;
   applyMeshResult(
@@ -479,6 +484,9 @@ export const useModelStore = create<ModelState>()(
     geometryFormat: "step" as GeometryFormat,
     isRunning: false,
     isMeshing: false,
+    // Default to linear: it's fast and reliable for every mesh size. Quadratic is
+    // an opt-in upgrade (Solver settings) — far more accurate but ~8× the DOFs.
+    elementOrder: 1,
     volMesh: null,
     surfaceTriangles: null,
     surfaceFaceIds: null,
@@ -584,6 +592,10 @@ export const useModelStore = create<ModelState>()(
     setResultType: (t) =>
       set((s) => {
         s.resultType = t;
+      }),
+    setElementOrder: (order) =>
+      set((s) => {
+        s.elementOrder = order;
       }),
     setRunning: (v) =>
       set((s) => {

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -292,16 +292,24 @@ self.onmessage = async (event: MessageEvent) => {
         surfaceFaceIds: dto.surfaceFaceIds ?? null,
       });
     } else if (type === "solve") {
-      const { nodes, elements, materials, constraints, loads, surfaceLoads } =
-        payload as {
-          nodes: Node[];
-          elements: Element[];
-          materials: Material[];
-          properties: unknown[];
-          constraints: Constraint[];
-          loads: Load[];
-          surfaceLoads?: SurfaceLoad[];
-        };
+      const {
+        nodes,
+        elements,
+        materials,
+        constraints,
+        loads,
+        surfaceLoads,
+        elementOrder,
+      } = payload as {
+        nodes: Node[];
+        elements: Element[];
+        materials: Material[];
+        properties: unknown[];
+        constraints: Constraint[];
+        loads: Load[];
+        surfaceLoads?: SurfaceLoad[];
+        elementOrder?: number;
+      };
 
       const tetrahedra = elements
         .filter((e) => e.type === "CTETRA")
@@ -383,11 +391,19 @@ self.onmessage = async (event: MessageEvent) => {
         prescribed_dofs,
         surface_loads,
       };
+      // FE polynomial order, chosen in the frontend (Solver settings). Order 2
+      // (quadratic / second-order) adds edge-midpoint DOFs that resolve bending
+      // and stress gradients far better than linear tets, which lock in bending
+      // and smear stress concentrations to a single constant value per element
+      // (issue #215), at the cost of a slower solve. The engine extends the
+      // vertex Dirichlet BCs to the new edge DOFs so clamped/prescribed faces
+      // stay fully constrained. Defaults to 1 (linear) when the payload omits it.
+      const order = elementOrder ?? 1;
       const json = m().solve_linear_elastic(
         JSON.stringify(mesh),
         JSON.stringify(material),
         JSON.stringify(bcs),
-        1,
+        order,
       );
       const result = JSON.parse(json) as {
         displacements: number[];


### PR DESCRIPTION
## Summary

Implements support for quadratic (second-order) finite elements in the MFEM solver, enabling higher-accuracy stress and displacement fields at the cost of additional DOFs and solve time. Users can now select element order (linear or quadratic) in the Solver settings panel.

## Key Changes

**Engine (C++)**
- Extended Dirichlet boundary conditions to edge-midpoint DOFs introduced by order-≥2 elements, ensuring clamped and prescribed faces remain fully constrained (not just at corner nodes)
- Implemented per-vertex Dirichlet record tracking (component mask + value) to propagate conditions to edge interiors when both endpoints carry the same constraint
- Tightened CG solver tolerance from 1e-1 to 1e-6 and increased max iterations to 5000 for order-≥2 solves, since quadratic fields require actual convergence to justify their extra DOFs; loose tolerance leaves visible noise in recovered stress

**Frontend (TypeScript/React)**
- Added `elementOrder` state to model store (defaults to 1 for speed/reliability)
- Exposed element-order selector in Solver settings panel (Linear 1st order / Quadratic 2nd order)
- Passed `elementOrder` to solver worker and through to C++ engine

**Stress field visualization**
- Refactored node von Mises averaging to use volume-weighted averaging instead of simple element count, down-weighting tiny sliver tetrahedra at sharp features that carry extreme noisy stresses (issue #215)
- Extracted `nodeVonMisesField()` to a shared utility so colorbar range and vertex coloring in MeshScene stay identical
- Implemented `tetVolume()` and `elementWeight()` helpers for volume calculation

## Implementation Details

- Edge-interior DOF constraints use the average of endpoint values (exact for clamped faces or uniform/linear prescribed displacement)
- Edges straddling the border of a constrained region (only one endpoint constrained) remain free, correctly treating the boundary
- Tetrahedral P2 elements carry no face-interior DOF, so edge-midpoint extension fully constrains clamped faces on tet meshes
- Volume weighting in stress averaging is computed via the signed-volume formula for tetrahedra; other element types fall back to unit weight

https://claude.ai/code/session_012otjBDiWuet8qWrpQZQDJC