### PR TITLE
Sew loose IGES surfaces into solids for volume meshing

### DIFF
--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -17,21 +17,30 @@
 #include <emscripten/val.h>
 
 // OCCT
+#include <BRep_Builder.hxx>
 #include <BRep_Tool.hxx>
 #include <BRepBndLib.hxx>
+#include <BRepBuilderAPI_Sewing.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <BRepTools.hxx>
 #include <Bnd_Box.hxx>
 #include <IFSelect_ReturnStatus.hxx>
 #include <IGESControl_Reader.hxx>
 #include <Poly_Triangulation.hxx>
+#include <ShapeFix_Solid.hxx>
 #include <STEPControl_Reader.hxx>
 #include <TopAbs_Orientation.hxx>
+#include <TopExp.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopLoc_Location.hxx>
+#include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
 #include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Edge.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Shape.hxx>
+#include <TopoDS_Shell.hxx>
+#include <TopoDS_Solid.hxx>
 
 // Netgen (C API)
 #include <nglib.h>
@@ -191,6 +200,94 @@ static double shape_bbox_diagonal(const TopoDS_Shape& shape) {
     return std::sqrt(box.SquareExtent());
 }
 
+static int count_subshapes(const TopoDS_Shape& shape, TopAbs_ShapeEnum type) {
+    int n = 0;
+    for (TopExp_Explorer e(shape, type); e.More(); e.Next())
+        ++n;
+    return n;
+}
+
+// A shell bounds a volume only if it is watertight: every non-degenerate edge
+// must be shared by at least two faces (no free boundary). Netgen fills the
+// region enclosed by such a shell; an open shell leaves the volume undefined.
+static bool shell_is_closed(const TopoDS_Shell& shell) {
+    TopTools_IndexedDataMapOfShapeListOfShape edge_faces;
+    TopExp::MapShapesAndAncestors(shell, TopAbs_EDGE, TopAbs_FACE, edge_faces);
+    for (int i = 1; i <= edge_faces.Extent(); ++i) {
+        const TopoDS_Edge& edge = TopoDS::Edge(edge_faces.FindKey(i));
+        if (BRep_Tool::Degenerated(edge))
+            continue;
+        if (edge_faces.FindFromIndex(i).Extent() < 2)
+            return false;  // free edge → open shell
+    }
+    return true;
+}
+
+// IGES (and occasionally STEP) files frequently store only free trimmed
+// surfaces, never a closed solid. Netgen then meshes the boundary fine but has
+// no enclosed region to fill, producing a surface mesh with 0 tetrahedra
+// (issue #276). Sew the loose faces into shells and promote every watertight
+// shell to a solid so the volume mesher has a region to fill.
+//
+// The original shape is returned unchanged when it already contains a solid (the
+// normal STEP case — this is then a no-op) or when no closed shell can be formed
+// (the geometry is genuinely not watertight, and the caller surfaces that).
+static TopoDS_Shape sew_faces_into_solid(const TopoDS_Shape& shape) {
+    if (count_subshapes(shape, TopAbs_SOLID) > 0)
+        return shape;  // already a solid — nothing to do
+
+    const int nfaces = count_subshapes(shape, TopAbs_FACE);
+    if (nfaces == 0)
+        return shape;  // no surfaces to sew
+
+    // Sewing tolerance scales with model size: IGES surface patches typically
+    // have sub-millimetre gaps at trim boundaries that a fixed absolute
+    // tolerance would either miss (too tight) or over-merge (too loose).
+    const double diag = shape_bbox_diagonal(shape);
+    const double tol  = (diag > 0.0) ? diag * 1e-4 : 1e-3;
+
+    BRepBuilderAPI_Sewing sewing(tol);
+    for (TopExp_Explorer e(shape, TopAbs_FACE); e.More(); e.Next())
+        sewing.Add(e.Current());
+    sewing.Perform();
+    TopoDS_Shape sewn = sewing.SewedShape();
+    if (sewn.IsNull())
+        return shape;
+
+    BRep_Builder builder;
+    TopoDS_Compound solids;
+    builder.MakeCompound(solids);
+    int nsolids = 0;
+    for (TopExp_Explorer e(sewn, TopAbs_SHELL); e.More(); e.Next()) {
+        const TopoDS_Shell& shell = TopoDS::Shell(e.Current());
+        if (!shell_is_closed(shell))
+            continue;
+        // SolidFromShell orients the shell so the solid has positive volume,
+        // which Netgen needs to tell inside from outside.
+        TopoDS_Solid solid = ShapeFix_Solid().SolidFromShell(shell);
+        if (solid.IsNull())
+            continue;
+        builder.Add(solids, solid);
+        ++nsolids;
+    }
+
+    if (nsolids == 0) {
+        printf("[occt] sew_faces_into_solid: sewed %d surface faces but found no "
+               "watertight shell — geometry is surface-only and not closed; "
+               "volume meshing cannot fill it (tol=%.4g mm)\n", nfaces, tol);
+        fflush(stdout);
+        return shape;
+    }
+
+    printf("[occt] sew_faces_into_solid: built %d solid(s) from %d surface faces "
+           "(sew tol=%.4g mm)\n", nsolids, nfaces, tol);
+    fflush(stdout);
+
+    if (nsolids == 1)
+        return TopoDS::Solid(TopExp_Explorer(solids, TopAbs_SOLID).Current());
+    return solids;
+}
+
 // ── OCCT: STEP / IGES → surface mesh ──────────────────────────────────────────
 
 // Stored after tessellate_step for reuse by generate_fem_mesh, which builds
@@ -273,7 +370,10 @@ static val tessellate_step(val bytes_val, const std::string& opts_json) {
 
     std::vector<uint8_t> bytes = emscripten::vecFromJSArray<uint8_t>(bytes_val);
 
-    TopoDS_Shape shape = read_cad_shape(bytes, format);
+    // read_cad_shape returns whatever the CAD file stores. IGES (and some STEP)
+    // files store only free surfaces, so sew them into a solid here — once, on
+    // load — and cache the result for both display and meshing (issue #276).
+    TopoDS_Shape shape = sew_faces_into_solid(read_cad_shape(bytes, format));
     g_step_shape     = shape;
     g_has_step_shape = true;
 
@@ -592,6 +692,19 @@ static std::string generate_fem_mesh(const std::string& opts_json)
     int ne = nglib::Ng_GetNE(mesh);
     printf("[netgen] step 4/4: volume mesh done — %d nodes, %d tetrahedra\n", np, ne);
     fflush(stdout);
+
+    // A surface mesh with no tetrahedra means the geometry enclosed no volume:
+    // the boundary surfaces did not sew into a watertight solid (typical of
+    // surface-only IGES — issue #276). Fail loudly rather than handing a
+    // tetrahedron-free mesh to the solver, which can't analyse it.
+    if (ne == 0) {
+        kofem_delete_mesh(mesh);
+        throw std::runtime_error(
+            "Volume meshing produced 0 tetrahedra: the geometry has surfaces but "
+            "no closed solid to fill. This usually means the CAD file (often IGES) "
+            "stores only free surfaces that do not sew into a watertight body. "
+            "Export the model as a solid (closed shell) and reload.");
+    }
 
     std::vector<double> out_verts;
     out_verts.reserve(3 * np);

--- a/engine/cpp/engine.cpp
+++ b/engine/cpp/engine.cpp
@@ -272,16 +272,18 @@ static TopoDS_Shape sew_faces_into_solid(const TopoDS_Shape& shape) {
     }
 
     if (nsolids == 0) {
-        printf("[occt] sew_faces_into_solid: sewed %d surface faces but found no "
-               "watertight shell — geometry is surface-only and not closed; "
-               "volume meshing cannot fill it (tol=%.4g mm)\n", nfaces, tol);
-        fflush(stdout);
+        // Diagnostic output: the printf/fflush return values are intentionally
+        // discarded (void cast) — a failed log write must not abort meshing.
+        (void)printf("[occt] sew_faces_into_solid: sewed %d surface faces but found no "
+                     "watertight shell — geometry is surface-only and not closed; "
+                     "volume meshing cannot fill it (tol=%.4g mm)\n", nfaces, tol);
+        (void)fflush(stdout);
         return shape;
     }
 
-    printf("[occt] sew_faces_into_solid: built %d solid(s) from %d surface faces "
-           "(sew tol=%.4g mm)\n", nsolids, nfaces, tol);
-    fflush(stdout);
+    (void)printf("[occt] sew_faces_into_solid: built %d solid(s) from %d surface faces "
+                 "(sew tol=%.4g mm)\n", nsolids, nfaces, tol);
+    (void)fflush(stdout);
 
     if (nsolids == 1)
         return TopoDS::Solid(TopExp_Explorer(solids, TopAbs_SOLID).Current());


### PR DESCRIPTION
## Summary

IGES files (and some STEP files) frequently store only free trimmed surfaces without a closed solid boundary. Netgen's volume mesher requires an enclosed region to fill, so it produces a surface mesh with 0 tetrahedra when given such geometry. This PR adds automatic surface sewing to promote watertight shells into solids, enabling volume meshing of surface-only CAD files.

## Changes

- **New function `sew_faces_into_solid()`**: Detects when a shape contains only free surfaces (no solids), sews them into shells using `BRepBuilderAPI_Sewing` with adaptive tolerance scaled to model size, and promotes any watertight shells to solids via `ShapeFix_Solid::SolidFromShell()`. Returns the original shape unchanged if it already contains a solid or if no closed shell can be formed.

- **New helper `shell_is_closed()`**: Validates that a shell is watertight by checking that every non-degenerate edge is shared by at least two faces (no free boundary).

- **New helper `count_subshapes()`**: Counts subshapes of a given type for quick topology inspection.

- **Integration in `tessellate_step()`**: Applies `sew_faces_into_solid()` once on CAD file load, caches the result in `g_step_shape`, and reuses it for both display tessellation and FEM meshing.

- **Volume mesh validation in `generate_fem_mesh()`**: Detects and fails loudly if volume meshing produces 0 tetrahedra, with a clear error message directing users to export the model as a closed solid.

- **Header additions**: Includes for `BRep_Builder`, `BRepBuilderAPI_Sewing`, `ShapeFix_Solid`, `TopExp`, `TopTools_IndexedDataMapOfShapeListOfShape`, and shape type headers (`TopoDS_Compound`, `TopoDS_Edge`, `TopoDS_Shell`, `TopoDS_Solid`).

## Implementation Details

- Sewing tolerance is adaptive: `diag × 1e-4` (where `diag` is the bounding box diagonal), with a fallback of `1e-3` for degenerate geometry. This handles sub-millimetre gaps typical of IGES trim boundaries without over-merging.
- The solid promotion step uses `ShapeFix_Solid::SolidFromShell()` to ensure correct orientation (positive volume) so Netgen can distinguish inside from outside.
- Diagnostic output is printed to stdout on both success (number of solids built) and failure (no watertight shell found), aiding troubleshooting.
- The check is performed once at load time, not per-mesh-generation, for efficiency.

closes #276

https://claude.ai/code/session_01NSZqBfeEyw5A1pduRWPCQk