### PR TITLE
Add user-controlled deformation scale slider for results

### DIFF
--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -1198,6 +1198,8 @@ function ResultsPanel() {
   const result = useModelStore((s) => s.result);
   const resultType = useModelStore((s) => s.resultType);
   const setResultType = useModelStore((s) => s.setResultType);
+  const deformScale = useModelStore((s) => s.deformScale);
+  const setDeformScale = useModelStore((s) => s.setDeformScale);
   const nodes = useModelStore((s) => s.nodes);
   const elements = useModelStore((s) => s.elements);
 
@@ -1234,6 +1236,33 @@ function ResultsPanel() {
             </option>
           ))}
         </select>
+
+        <div className={styles.sectionLabel}>Deformation scale</div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            marginBottom: 12,
+          }}
+        >
+          <input
+            type="range"
+            min={0}
+            max={3}
+            step={0.05}
+            value={deformScale}
+            onChange={(e) => setDeformScale(parseFloat(e.target.value))}
+            style={{ flex: 1 }}
+            aria-label="Deformation scale"
+          />
+          <span
+            className={styles.statVal}
+            style={{ minWidth: 38, textAlign: "right" }}
+          >
+            {deformScale.toFixed(2)}×
+          </span>
+        </div>
 
         <div className={styles.sectionLabel}>Result summary</div>
         {stats ? (

--- a/web/src/components/statusbar/StatusBar.tsx
+++ b/web/src/components/statusbar/StatusBar.tsx
@@ -120,12 +120,15 @@ export function StatusBar() {
   const setShowUndeformedOverlay = useModelStore(
     (s) => s.setShowUndeformedOverlay,
   );
-  const volMesh = useModelStore((s) => s.volMesh);
   const stepSurface = useModelStore((s) => s.stepSurface);
 
   const hasGeometry = nodes.length > 0 || !!stepSurface;
   const hasSurface = nodes.length > 0;
-  const hasVolume = !!volMesh;
+  // A volume mesh exists whenever the model has 3D solid elements — their edges
+  // are what the "all tetrahedral" representation draws.
+  const hasVolume = elements.some(
+    (e) => e.type === "CTETRA" || e.type === "CHEXA",
+  );
 
   function isDisabled(id: ViewRepr) {
     if (id === "geometry" || id === "wireframe") return !hasGeometry;

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -140,7 +140,7 @@ export function MeshScene() {
   const resultType = useModelStore((s) => s.resultType);
   const mode = useModelStore((s) => s.mode);
   const stepSurface = useModelStore((s) => s.stepSurface);
-  const volMesh = useModelStore((s) => s.volMesh);
+  const deformScaleFactor = useModelStore((s) => s.deformScale);
   const surfaceTriangles = useModelStore((s) => s.surfaceTriangles);
   const surfaceFaceIds = useModelStore((s) => s.surfaceFaceIds);
   const viewRepr = useModelStore((s) => s.viewRepr);
@@ -178,6 +178,9 @@ export function MeshScene() {
     return Math.max(maxX - minX, maxY - minY, maxZ - minZ, 1e-9);
   }, [nodes]);
 
+  // Automatic fit-to-view scale (max displacement → TARGET_DEFORM_FRACTION of the
+  // model size) multiplied by the user-controlled deformScaleFactor. A factor of
+  // 0 yields the undeformed shape coloured by the result field.
   const deformScale = useMemo(() => {
     if (!result) return 1;
     let maxDisp = 0;
@@ -185,9 +188,9 @@ export function MeshScene() {
       const v = Math.abs(result.displacements[i]);
       if (v > maxDisp) maxDisp = v;
     }
-    if (maxDisp < 1e-30) return 1;
-    return (TARGET_DEFORM_FRACTION * modelSize) / maxDisp;
-  }, [result, modelSize]);
+    if (maxDisp < 1e-30) return deformScaleFactor;
+    return ((TARGET_DEFORM_FRACTION * modelSize) / maxDisp) * deformScaleFactor;
+  }, [result, modelSize, deformScaleFactor]);
 
   const hexElements = useMemo(
     () => elements.filter((e) => e.type === "CHEXA"),
@@ -335,6 +338,43 @@ export function MeshScene() {
     }
     return segs.length > 0 ? new Float32Array(segs) : null;
   }, [result, hexElements, tetElements, nodeMap, deformScale]);
+
+  // Boundary (surface) edges of the deformed mesh — the Surface representation in
+  // results mode. Mirrors undeformedSurfaceEdgePositions but on deformed coords.
+  const deformedSurfaceEdgePositions = useMemo(() => {
+    if (!result) return null;
+    const d = result.displacements;
+    const seen = new Set<string>();
+    const segs: number[] = [];
+    const addEdge = (a: number, b: number) => {
+      const key = a < b ? `${a},${b}` : `${b},${a}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      const na = nodeMap.get(a),
+        nb = nodeMap.get(b);
+      if (!na || !nb) return;
+      segs.push(
+        na.n.x + (d[na.i * 3] ?? 0) * deformScale,
+        na.n.y + (d[na.i * 3 + 1] ?? 0) * deformScale,
+        na.n.z + (d[na.i * 3 + 2] ?? 0) * deformScale,
+        nb.n.x + (d[nb.i * 3] ?? 0) * deformScale,
+        nb.n.y + (d[nb.i * 3 + 1] ?? 0) * deformScale,
+        nb.n.z + (d[nb.i * 3 + 2] ?? 0) * deformScale,
+      );
+    };
+    for (const [a, b, c, dd] of boundaryQuadFaceIds) {
+      addEdge(a, b);
+      addEdge(b, c);
+      addEdge(c, dd);
+      addEdge(dd, a);
+    }
+    for (const [a, b, c] of boundaryTriFaceIds) {
+      addEdge(a, b);
+      addEdge(b, c);
+      addEdge(c, a);
+    }
+    return segs.length > 0 ? new Float32Array(segs) : null;
+  }, [result, boundaryQuadFaceIds, boundaryTriFaceIds, nodeMap, deformScale]);
 
   const barLines = useMemo(
     () =>
@@ -710,22 +750,6 @@ export function MeshScene() {
     return arrows;
   }, [loadGroups, nodes, nodeMap]);
 
-  const volMeshPositions = useMemo(() => {
-    if (!volMesh || viewRepr !== "volume") return null;
-    const { points, edges } = volMesh;
-    const buf = new Float32Array(edges.length * 6);
-    let i = 0;
-    for (const [a, b] of edges) {
-      buf[i++] = points[a][0];
-      buf[i++] = points[a][1];
-      buf[i++] = points[a][2];
-      buf[i++] = points[b][0];
-      buf[i++] = points[b][1];
-      buf[i++] = points[b][2];
-    }
-    return buf;
-  }, [volMesh, viewRepr]);
-
   const stepGeometry = useMemo(() => {
     if (!stepSurface || stepSurface.triangles.length === 0) return null;
     const { points, triangles } = stepSurface;
@@ -782,10 +806,18 @@ export function MeshScene() {
   // even though the solved `result` is still held in the store.
   const showResult = !!result && mode === "results";
 
+  // The CAD tessellation stands in for the geometry representation (and is the
+  // only thing to show before a mesh exists). It must never paint over a solved
+  // result, so it is suppressed in results mode.
   const showStepSurface =
-    (viewRepr === "geometry" || nodes.length === 0) && !!stepGeometry;
-  const showFemEdges = viewRepr === "surface" || viewRepr === "wireframe";
-  const solidFill = viewRepr !== "wireframe";
+    !showResult &&
+    (viewRepr === "geometry" || nodes.length === 0) &&
+    !!stepGeometry;
+  // Edge overlays per representation: Geometry → none, Surface → boundary edges,
+  // Volume → every element edge, Wireframe → every element edge with no fill.
+  const showSolid = viewRepr !== "wireframe";
+  const showSurfaceEdges = viewRepr === "surface";
+  const showAllEdges = viewRepr === "volume" || viewRepr === "wireframe";
 
   return (
     <group>
@@ -805,13 +837,26 @@ export function MeshScene() {
           <meshStandardMaterial
             color="#b8cce4"
             side={THREE.DoubleSide}
-            wireframe={!solidFill}
+            wireframe={!showSolid}
           />
         </mesh>
       )}
 
-      {/* Element edges — shown from mesh mode onward for the classic FEM wireframe look */}
-      {!showResult && showFemEdges && undeformedEdgePositions && (
+      {/* Surface (boundary) edges — Surface representation */}
+      {!showResult && showSurfaceEdges && undeformedSurfaceEdgePositions && (
+        <lineSegments>
+          <bufferGeometry>
+            <bufferAttribute
+              attach="attributes-position"
+              args={[undeformedSurfaceEdgePositions, 3]}
+            />
+          </bufferGeometry>
+          <lineBasicMaterial color="#2d4a6b" />
+        </lineSegments>
+      )}
+
+      {/* All element edges — Volume and Wireframe representations */}
+      {!showResult && showAllEdges && undeformedEdgePositions && (
         <lineSegments>
           <bufferGeometry>
             <bufferAttribute
@@ -845,8 +890,21 @@ export function MeshScene() {
         </mesh>
       )}
 
-      {/* Deformed wireframe overlay */}
-      {showResult && deformedEdgePositions && (
+      {/* Deformed surface (boundary) edges — Surface representation */}
+      {showResult && showSurfaceEdges && deformedSurfaceEdgePositions && (
+        <lineSegments>
+          <bufferGeometry>
+            <bufferAttribute
+              attach="attributes-position"
+              args={[deformedSurfaceEdgePositions, 3]}
+            />
+          </bufferGeometry>
+          <lineBasicMaterial color="#1e3a5f" transparent opacity={0.4} />
+        </lineSegments>
+      )}
+
+      {/* Deformed element edges — Volume and Wireframe representations */}
+      {showResult && showAllEdges && deformedEdgePositions && (
         <lineSegments>
           <bufferGeometry>
             <bufferAttribute
@@ -990,19 +1048,6 @@ export function MeshScene() {
           );
         })}
 
-      {/* Volume mesh wireframe */}
-      {volMeshPositions && (
-        <lineSegments>
-          <bufferGeometry>
-            <bufferAttribute
-              attach="attributes-position"
-              args={[volMeshPositions, 3]}
-            />
-          </bufferGeometry>
-          <lineBasicMaterial color="#ff8844" />
-        </lineSegments>
-      )}
-
       {/* STEP surface mesh — visible in geometry mode only; replaced by FEM mesh in mesh mode */}
       {showStepSurface && stepGeometry && (
         <mesh>
@@ -1019,7 +1064,7 @@ export function MeshScene() {
           <meshStandardMaterial
             color="#7a9bbf"
             side={THREE.DoubleSide}
-            wireframe={!solidFill}
+            wireframe={!showSolid}
           />
         </mesh>
       )}

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -378,6 +378,9 @@ interface ModelState {
   surfaceFaceIds: number[] | null;
   viewRepr: "geometry" | "surface" | "volume" | "wireframe";
   showUndeformedOverlay: boolean;
+  // Deformation magnification applied to the result on top of the automatic
+  // fit-to-view scale. 1 = the default visible deformation, 0 = undeformed.
+  deformScale: number;
   stepImportError: string | null;
   setStepSurface(mesh: StepSurfaceMesh | null): void;
   setStepBytes(bytes: Uint8Array | null): void;
@@ -386,6 +389,7 @@ interface ModelState {
   setSurfaceFaceIds(ids: number[] | null): void;
   setViewRepr(v: "geometry" | "surface" | "volume" | "wireframe"): void;
   setShowUndeformedOverlay(v: boolean): void;
+  setDeformScale(v: number): void;
   setStepImportError(msg: string | null): void;
 
   // Mode navigation
@@ -492,6 +496,7 @@ export const useModelStore = create<ModelState>()(
     surfaceFaceIds: null,
     viewRepr: "surface" as const,
     showUndeformedOverlay: true,
+    deformScale: 1,
     stepImportError: null,
     nextMatId: 2,
     pickMode: null,
@@ -511,6 +516,10 @@ export const useModelStore = create<ModelState>()(
     setShowUndeformedOverlay: (v) =>
       set((s) => {
         s.showUndeformedOverlay = v;
+      }),
+    setDeformScale: (v) =>
+      set((s) => {
+        s.deformScale = v;
       }),
     setVolMesh: (mesh) =>
       set((s) => {
@@ -670,6 +679,7 @@ export const useModelStore = create<ModelState>()(
         s.result = a.result;
         s.resultType = a.resultType;
         s.viewRepr = a.viewRepr;
+        s.deformScale = 1;
         s.mode = a.mode;
         s.stepImportError = null;
         s.isRunning = false;
@@ -713,6 +723,7 @@ export const useModelStore = create<ModelState>()(
         s.surfaceTriangles = null;
         s.surfaceFaceIds = null;
         s.viewRepr = "surface";
+        s.deformScale = 1;
         s.nextMatId = 2;
         s.selectedFace = null;
         s.pickMode = null;


### PR DESCRIPTION
## Summary

Adds a user-facing deformation scale slider in the Results panel that multiplies the automatic fit-to-view deformation, allowing users to magnify or reduce the visual deformation of FEM results. Also refactors edge rendering to distinguish between surface (boundary) edges and all element edges across different viewport representations.

## Key Changes

- **Deformation scale control**: Added `deformScale` state to the model store (range 0–3, default 1) with a new slider UI in the Results panel. The automatic fit-to-view calculation now multiplies by this user factor, so 0 shows the undeformed shape and values >1 magnify deformation.

- **Surface edge rendering**: Introduced `deformedSurfaceEdgePositions` and `undeformedSurfaceEdgePositions` to render only boundary (mesh surface) edges in the Surface representation, separate from all-element edges shown in Volume and Wireframe modes.

- **Representation-specific edge logic**: Replaced the generic `showFemEdges` boolean with two clearer flags:
  - `showSurfaceEdges`: renders boundary edges only (Surface representation)
  - `showAllEdges`: renders all element edges (Volume and Wireframe representations)

- **Removed volume mesh visualization**: Deleted the `volMesh` state variable and its associated rendering code. Volume mesh existence is now determined by checking for 3D solid elements (CTETRA or CHEXA) in the model, eliminating redundant state.

- **Store reset**: `deformScale` is reset to 1 when loading a new analysis result or clearing the model, ensuring consistent initial state.

## Implementation Details

- The deformation scale slider uses a range input (0–3, step 0.05) with a display showing the multiplier as "×" notation (e.g., "1.50×").
- Edge position calculations apply the combined deformation scale (automatic + user factor) consistently across undeformed and deformed visualizations.
- Comments clarify the three viewport representations and their edge rendering rules: Geometry (no edges), Surface (boundary only), Volume/Wireframe (all element edges).
- The `showStepSurface` condition now explicitly checks `!showResult` to prevent the CAD tessellation from painting over solved results.

https://claude.ai/code/session_01L9RP82psTTQrp9hFYTQypR