### PR TITLE
Fix node ID remapping in solver to prevent WASM memory trap

### DIFF
--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -311,12 +311,30 @@ self.onmessage = async (event: MessageEvent) => {
         elementOrder?: number;
       };
 
+      // The engine indexes vertices 0-based in the order they are added (mesh
+      // vertices below are emitted in node-array order). Stored node .id values
+      // are NOT those indices — saved analyses number nodes 1-based and .inp
+      // imports use arbitrary ids — so every node reference (element
+      // connectivity, constraints, loads, surface-load faces) must be remapped
+      // to its vertex index before reaching the engine. Passing a raw node id
+      // where the engine expects a vertex index reads past the vertex array and
+      // traps with "memory access out of bounds" (issue #288).
+      const vertexIndexById = new Map(nodes.map((n, i) => [n.id, i]));
+      const vid = (nodeId: number, context: string): number => {
+        const i = vertexIndexById.get(nodeId);
+        if (i === undefined)
+          throw new Error(
+            `${context} references unknown node id ${nodeId} — the model is inconsistent`,
+          );
+        return i;
+      };
+
       const tetrahedra = elements
         .filter((e) => e.type === "CTETRA")
-        .map((e) => e.nodeIds);
+        .map((e) => e.nodeIds.map((id) => vid(id, "CTETRA element")));
       const hexahedra = elements
         .filter((e) => e.type === "CHEXA")
-        .map((e) => e.nodeIds);
+        .map((e) => e.nodeIds.map((id) => vid(id, "CHEXA element")));
       if (tetrahedra.length === 0 && hexahedra.length === 0) {
         throw new Error(
           "No supported elements found. MFEM requires CTETRA or CHEXA elements — " +
@@ -351,39 +369,50 @@ self.onmessage = async (event: MessageEvent) => {
       // must reach the solver as an inhomogeneous essential BC (prescribed_dofs):
       // folding it into fixed_vertices/fixed_dofs would silently pin the DOF to
       // zero and discard the requested value (issue #216).
+      // Keyed by vertex index (vid), so the essential-DOF sets the engine
+      // receives line up with the remapped mesh connectivity above.
       const dofsByNode = new Map<number, Set<number>>();
       const prescribed_dofs: { vertex: number; dof: number; value: number }[] =
         [];
       for (const c of constraints) {
         if (c.dof > 2) continue;
+        const v = vid(c.nodeId, "constraint");
         const value = c.prescribedValue ?? 0;
         if (value === 0) {
-          if (!dofsByNode.has(c.nodeId)) dofsByNode.set(c.nodeId, new Set());
-          dofsByNode.get(c.nodeId)!.add(c.dof);
+          if (!dofsByNode.has(v)) dofsByNode.set(v, new Set());
+          dofsByNode.get(v)!.add(c.dof);
         } else {
-          prescribed_dofs.push({ vertex: c.nodeId, dof: c.dof, value });
+          prescribed_dofs.push({ vertex: v, dof: c.dof, value });
         }
       }
       const fixed_vertices: number[] = [];
       const fixed_dofs: { vertex: number; dofs: number[] }[] = [];
-      for (const [nodeId, dofSet] of dofsByNode) {
-        if (dofSet.size === 3) fixed_vertices.push(nodeId);
-        else fixed_dofs.push({ vertex: nodeId, dofs: [...dofSet].sort() });
+      for (const [vertex, dofSet] of dofsByNode) {
+        if (dofSet.size === 3) fixed_vertices.push(vertex);
+        else fixed_dofs.push({ vertex, dofs: [...dofSet].sort() });
       }
 
-      // Group translational force loads by node, accumulating into [fx, fy, fz]
+      // Group translational force loads by vertex index, accumulating [fx,fy,fz]
       const loadMap = new Map<number, [number, number, number]>();
       for (const load of loads) {
         if (load.dof > 2) continue;
-        if (!loadMap.has(load.nodeId)) loadMap.set(load.nodeId, [0, 0, 0]);
-        loadMap.get(load.nodeId)![load.dof] += load.value;
+        const v = vid(load.nodeId, "load");
+        if (!loadMap.has(v)) loadMap.set(v, [0, 0, 0]);
+        loadMap.get(v)![load.dof] += load.value;
       }
       const point_loads = [...loadMap.entries()].map(([vertex, force]) => ({
         vertex,
         force,
       }));
 
-      const surface_loads = surfaceLoads ?? [];
+      // Surface-load faces are node-id lists from the store; remap each to the
+      // engine's vertex indices so the boundary-element matcher finds them.
+      const surface_loads = (surfaceLoads ?? []).map((sl) => ({
+        ...sl,
+        faces: sl.faces.map((face) =>
+          face.map((id) => vid(id, "surface load face")),
+        ),
+      }));
       const bcs = {
         fixed_vertices,
         point_loads,

--- a/web/tests/example-load.spec.ts
+++ b/web/tests/example-load.spec.ts
@@ -70,6 +70,64 @@ test("?example= loads a pre-solved example into the app", async ({ page }) => {
   await expect(page.getByText(/Max \|U\|/)).toBeVisible({ timeout: 10_000 });
 });
 
+test("re-solving a loaded example does not trap on its node ids (#288)", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+
+  // The example .vtu numbers nodes 1-based, so a node id is NOT its 0-based
+  // vertex index. Re-running the solve used to hand those ids to the engine as
+  // vertex indices, reading past the vertex array and trapping with "memory
+  // access out of bounds". Load the example, then drive a fresh solve straight
+  // from the restored store state exactly as the Solve button does.
+  await page.goto("/app/?example=cantilever-beam");
+  await expect(page.locator("nav")).toBeVisible();
+  await page.waitForFunction(
+    () => !!(window as unknown as { __kofem?: unknown }).__kofem,
+  );
+  await expect
+    .poll(async () => (await readStore(page)).nodes, { timeout: 15_000 })
+    .toBeGreaterThan(0);
+
+  const outcome = await page.evaluate(async () => {
+    const win = window as unknown as {
+      __kofem: {
+        sendToWorker(name: string, payload: object): Promise<unknown>;
+      };
+      __kofemStore: { getState(): Record<string, unknown> };
+    };
+    const st = win.__kofemStore.getState();
+    try {
+      const r = (await win.__kofem.sendToWorker("solve", {
+        nodes: st.nodes,
+        elements: st.elements,
+        materials: st.materials,
+        properties: st.properties,
+        constraints: st.constraints,
+        loads: st.loads,
+        surfaceLoads: st.surfaceLoads,
+      })) as { displacements: number[]; vonMises: number[] };
+      return {
+        ok: true as const,
+        nNodes: (st.nodes as unknown[]).length,
+        nElems: (st.elements as unknown[]).length,
+        nDisp: r.displacements.length,
+        nVm: r.vonMises.length,
+      };
+    } catch (err) {
+      return { ok: false as const, error: (err as Error).message };
+    }
+  });
+
+  // The solve must complete — no WASM trap — and return one displacement vector
+  // per node and one von Mises scalar per element.
+  expect(outcome.ok).toBe(true);
+  if (outcome.ok) {
+    expect(outcome.nDisp).toBe(outcome.nNodes * 3);
+    expect(outcome.nVm).toBe(outcome.nElems);
+  }
+});
+
 test("?example= with an invalid id is rejected without a fetch", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

Fixes issue #288 where re-solving a loaded example would trap with "memory access out of bounds" in the WASM engine. The root cause was that node IDs from the stored model (which are 1-based or arbitrary) were being passed directly to the FEM engine, which expects 0-based vertex indices.

## Key Changes

- **Added node ID → vertex index remapping** in `solver.worker.ts`:
  - Created a `vertexIndexById` map to translate stored node IDs to engine vertex indices
  - Added a `vid()` helper function that performs the lookup with error checking for consistency
  - Remapped all node references before passing to the engine:
    - Element connectivity (CTETRA and CHEXA)
    - Constraint node IDs
    - Load node IDs
    - Surface load face node IDs

- **Added regression test** in `example-load.spec.ts`:
  - Tests that loading the cantilever-beam example and re-solving via the worker completes without trapping
  - Validates that the solve returns the correct number of displacement vectors (3 per node) and von Mises scalars (1 per element)
  - Includes detailed comments explaining the issue and the fix

## Implementation Details

The engine indexes vertices 0-based in the order they are added to the mesh. However, stored analyses number nodes 1-based (from .vtu files) and .inp imports use arbitrary node IDs. Every node reference in the model (element connectivity, constraints, loads, surface-load faces) must be remapped to its vertex index before reaching the engine. Passing a raw node ID where the engine expects a vertex index causes it to read past the vertex array and trap.

The fix is transparent to the rest of the solver pipeline — the remapping happens at the boundary between the stored model representation and the engine's expected input format.

closes #288

https://claude.ai/code/session_01HwNdqxhMke36oHQTrGk62F