### PR TITLE
Add Docker-free WASM deps fetch for sandboxed environments

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Kofler
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# SessionStart hook: make the WASM build toolchain available in Claude Code on the
+# web. Locally and in CI the Docker image (scripts/docker-build-wasm.sh) is used,
+# so this only runs in the remote sandbox where Docker's vfs storage driver can't
+# unpack the dependency image.
+set -euo pipefail
+
+# Only run in the remote (web) sandbox.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+REPO="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+bash "$REPO/scripts/fetch-wasm-deps.sh"
+
+# Persist the build environment for the whole session so `bash scripts/build-wasm.sh`
+# works without re-exporting anything. The node bin dir is globbed so it survives
+# emsdk version bumps in the dependency image.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    NODE_BIN="$(echo /emsdk/node/*/bin)"
+    {
+        echo 'export EMSDK=/emsdk'
+        echo "export PATH=\"/emsdk:/emsdk/upstream/emscripten:${NODE_BIN}:\$PATH\""
+        echo 'export OCCT_WASM_ROOT=/opt/kofem-deps/occt'
+        echo 'export NETGEN_WASM_ROOT=/opt/kofem-deps/netgen'
+        echo 'export MFEM_WASM_ROOT=/opt/kofem-deps/mfem'
+    } >>"$CLAUDE_ENV_FILE"
+fi
+
+# ── Docker Auto-Setup for Constrained Environments ──
+# Makes `docker` usable for general purposes. NOTE: this does NOT enable
+# scripts/docker-build-wasm.sh here — the vfs storage driver can't unpack the
+# dependency image under the sandbox disk quota, which is why the Docker-free
+# fetch above exists. This block only ensures a daemon is running if one isn't.
+if ! command -v docker &>/dev/null || ! docker info &>/dev/null 2>&1; then
+    echo "[docker-setup] Docker not available, attempting setup..."
+
+    # Clean stale docker0 interface (prevents daemon startup failure)
+    if ip link show docker0 &>/dev/null 2>&1; then
+        ip link delete docker0 2>/dev/null || true
+    fi
+
+    # Start dockerd with constrained-environment flags:
+    #   --storage-driver=vfs    : works on kernel 4.4.0 (overlay2 needs newer kernel)
+    #   --iptables=false        : kernel doesn't support iptables in containers
+    #   --ip6tables=false       : same for IPv6
+    dockerd \
+        --iptables=false \
+        --ip6tables=false \
+        --storage-driver=vfs \
+        &>/tmp/dockerd.log &
+
+    # Wait for Docker to be ready (up to 30s)
+    for i in $(seq 1 30); do
+        if docker info &>/dev/null 2>&1; then
+            echo "[docker-setup] Docker ready after ${i}s"
+            break
+        fi
+        sleep 1
+    done
+
+    if ! docker info &>/dev/null 2>&1; then
+        echo "[docker-setup] Docker failed to start. Check /tmp/dockerd.log"
+    fi
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,18 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
+            "statusMessage": "Fetching WASM build deps…",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/scripts/fetch-wasm-deps.sh
+++ b/scripts/fetch-wasm-deps.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Michael Kofler
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# scripts/fetch-wasm-deps.sh
+#
+# Fetch the prebuilt WASM toolchain + dependencies WITHOUT Docker.
+#
+# scripts/docker-build-wasm.sh runs the kofem-dependencies image in a container,
+# which needs a Docker daemon with a copy-on-write storage driver. Sandboxed
+# environments (e.g. Claude Code on the web) often fall back to the `vfs` storage
+# driver, which duplicates every layer on unpack and blows past the disk quota —
+# so the image can never be materialised there.
+#
+# This script sidesteps Docker entirely. It pulls only the two directory trees the
+# build actually needs straight from the ghcr.io layer blobs:
+#
+#   /emsdk           — the Emscripten SDK (self-contained: clang, node, sysroot)
+#   /opt/kofem-deps  — OCCT, Netgen and MFEM prebuilt as WASM static libs
+#
+# They are written to the same absolute paths the image uses, so the toolchain's
+# baked-in paths stay valid. Extraction is linear in the file union (~2 GB), not
+# the O(n^2) layer duplication that vfs incurs.
+#
+# After running, build with:
+#   source /emsdk/emsdk_env.sh
+#   OCCT_WASM_ROOT=/opt/kofem-deps/occt \
+#   NETGEN_WASM_ROOT=/opt/kofem-deps/netgen \
+#   MFEM_WASM_ROOT=/opt/kofem-deps/mfem \
+#   bash scripts/build-wasm.sh
+#
+# (The SessionStart hook in .claude/hooks/session-start.sh runs this automatically
+#  and exports those variables for the whole session.)
+
+set -euo pipefail
+
+# Keep IMAGE_TAG in sync with the image tag in scripts/docker-build-wasm.sh.
+REGISTRY="ghcr.io"
+IMAGE_REPO="mkofler96/kofem-dependencies"
+IMAGE_TAG="${KOFEM_DEPS_TAG:-0.0.2}"
+
+EMSDK_DIR="/emsdk"
+DEPS_DIR="/opt/kofem-deps"
+WANT=(emsdk opt/kofem-deps)
+
+case "$(uname -m)" in
+    x86_64 | amd64) ARCH="amd64" ;;
+    aarch64 | arm64) ARCH="arm64" ;;
+    *)
+        echo "ERROR: unsupported architecture '$(uname -m)'"
+        exit 1
+        ;;
+esac
+
+# ── Idempotency: skip if the requested tag is already extracted ────────────────
+if [ -x "$EMSDK_DIR/upstream/emscripten/emcc" ] &&
+    [ -f "$DEPS_DIR/.kofem-deps-tag" ] &&
+    [ "$(cat "$DEPS_DIR/.kofem-deps-tag")" = "$IMAGE_TAG" ]; then
+    echo "WASM deps already present (${IMAGE_REPO}:${IMAGE_TAG}) — skipping fetch."
+    exit 0
+fi
+
+for tool in curl jq tar; do
+    command -v "$tool" >/dev/null || {
+        echo "ERROR: '$tool' is required but not installed"
+        exit 1
+    }
+done
+
+token() {
+    curl -fsSL "https://${REGISTRY}/token?scope=repository:${IMAGE_REPO}:pull&service=${REGISTRY}" | jq -r .token
+}
+
+echo "==> Fetching ${IMAGE_REPO}:${IMAGE_TAG} (${ARCH}) from ${REGISTRY} without Docker..."
+
+TOK="$(token)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Resolve the per-architecture manifest out of the multi-arch index.
+curl -fsSL -H "Authorization: Bearer $TOK" \
+    -H "Accept: application/vnd.oci.image.index.v1+json" \
+    -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+    "https://${REGISTRY}/v2/${IMAGE_REPO}/manifests/${IMAGE_TAG}" -o "$TMP/index.json"
+
+DIGEST="$(jq -r --arg a "$ARCH" \
+    '.manifests[] | select(.platform.architecture==$a and .platform.os=="linux") | .digest' \
+    "$TMP/index.json")"
+[ -n "$DIGEST" ] && [ "$DIGEST" != "null" ] || {
+    echo "ERROR: no ${ARCH}/linux manifest in ${IMAGE_REPO}:${IMAGE_TAG}"
+    exit 1
+}
+
+curl -fsSL -H "Authorization: Bearer $TOK" \
+    -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+    -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+    "https://${REGISTRY}/v2/${IMAGE_REPO}/manifests/${DIGEST}" -o "$TMP/manifest.json"
+
+mapfile -t LAYERS < <(jq -r '.layers[].digest' "$TMP/manifest.json")
+echo "    ${#LAYERS[@]} layers; extracting ${WANT[*]}"
+
+n=0
+for L in "${LAYERS[@]}"; do
+    n=$((n + 1))
+    blob="$TMP/layer.tgz"
+    TOK="$(token)" # registry tokens expire after ~5 min; refresh per layer
+    curl -fsSL -H "Authorization: Bearer $TOK" \
+        "https://${REGISTRY}/v2/${IMAGE_REPO}/blobs/${L}" -o "$blob"
+
+    present=()
+    for w in "${WANT[@]}"; do
+        if tar -tzf "$blob" "$w" >/dev/null 2>&1 || tar -tzf "$blob" "$w/" >/dev/null 2>&1; then
+            present+=("$w")
+        fi
+    done
+    if [ "${#present[@]}" -gt 0 ]; then
+        echo "    [$n/${#LAYERS[@]}] ${present[*]}"
+        tar -xzf "$blob" -C / "${present[@]}"
+    fi
+    rm -f "$blob"
+done
+
+# ── Validate the extracted layout ──────────────────────────────────────────────
+[ -x "$EMSDK_DIR/upstream/emscripten/emcc" ] || {
+    echo "ERROR: emcc missing under ${EMSDK_DIR} after extract — image layout changed?"
+    exit 1
+}
+for d in occt netgen mfem; do
+    [ -d "$DEPS_DIR/$d/lib" ] || {
+        echo "ERROR: ${DEPS_DIR}/${d}/lib missing after extract"
+        exit 1
+    }
+done
+
+echo "$IMAGE_TAG" >"$DEPS_DIR/.kofem-deps-tag"
+
+echo "==> WASM deps ready:"
+echo "    EMSDK            = ${EMSDK_DIR}"
+echo "    OCCT_WASM_ROOT   = ${DEPS_DIR}/occt"
+echo "    NETGEN_WASM_ROOT = ${DEPS_DIR}/netgen"
+echo "    MFEM_WASM_ROOT   = ${DEPS_DIR}/mfem"
+[ -f "$DEPS_DIR/versions.txt" ] && sed 's/^/    /' "$DEPS_DIR/versions.txt"


### PR DESCRIPTION
## Summary

Adds a Docker-free alternative for fetching prebuilt WASM toolchain and dependencies in sandboxed environments (e.g., Claude Code on the web) where Docker's `vfs` storage driver cannot unpack the dependency image within disk quotas.

## Changes

- **`scripts/fetch-wasm-deps.sh`** — New script that pulls the Emscripten SDK and prebuilt WASM libraries (OCCT, Netgen, MFEM) directly from OCI layer blobs via the registry API, bypassing Docker entirely. Extracts to the same absolute paths (`/emsdk`, `/opt/kofem-deps`) that the Docker image uses, keeping toolchain paths valid. Includes idempotency checks and validation of extracted layout.

- **`.claude/hooks/session-start.sh`** — New SessionStart hook that:
  - Runs `fetch-wasm-deps.sh` automatically in Claude Code on the web
  - Exports `EMSDK`, `PATH`, and `*_WASM_ROOT` environment variables to `CLAUDE_ENV_FILE` for the entire session
  - Includes Docker auto-setup for constrained environments (starts `dockerd` with `vfs` storage driver and disabled iptables if needed)

- **`.claude/settings.json`** — Registers the SessionStart hook with a 5-minute timeout.

## Implementation Details

- The fetch script resolves the multi-arch OCI image index to the correct platform manifest, then iterates through layers downloading only those containing `/emsdk` or `/opt/kofem-deps`, extracting them in-place.
- Registry authentication tokens are refreshed per-layer (they expire after ~5 min).
- Idempotency is tracked via `.kofem-deps-tag` file; re-running with the same tag skips extraction.
- The hook only activates in remote sandboxes (`CLAUDE_CODE_REMOTE=true`); local and CI builds continue using `scripts/docker-build-wasm.sh`.

https://claude.ai/code/session_01C9Eq8sdvadNBfimY7hPryP