### PR TITLE
Warn when moment load faces lie entirely on moment axis

### DIFF
--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -231,6 +231,7 @@ function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
       // where S = Σ|r_i⊥|² (perpendicular distance squared from moment axis).
       // This satisfies Σ(r_i × F_i) = M exactly with zero net force.
       const momentAxis = g.dof - 3; // 0=x, 1=y, 2=z
+      let skippedFaces = 0;
       for (const f of g.faces) {
         let cx = 0,
           cy = 0,
@@ -261,7 +262,12 @@ function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
           else if (momentAxis === 1) S += rx * rx + rz * rz;
           else S += rx * rx + ry * ry;
         }
-        if (S === 0) continue; // all nodes on the moment axis — undefined
+        if (S === 0) {
+          // All face nodes lie on the moment axis — the tangential force
+          // direction is undefined, so this face contributes no moment.
+          skippedFaces++;
+          continue;
+        }
 
         const scale = g.totalForce / S;
         for (const nodeId of f.nodeIds) {
@@ -284,6 +290,14 @@ function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
             result.push({ nodeId, dof: 1, value: scale * rx });
           }
         }
+      }
+      if (skippedFaces > 0) {
+        console.warn(
+          `[moment load] "${g.name}": ${skippedFaces} of ${g.faces.length} ` +
+            `face(s) skipped — all of their nodes lie on the moment axis, so ` +
+            `the applied moment is incomplete. Choose a different moment axis ` +
+            `or face selection.`,
+        );
       }
     }
   }

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -294,9 +294,9 @@ function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
       if (skippedFaces > 0) {
         console.warn(
           `[moment load] "${g.name}": ${skippedFaces} of ${g.faces.length} ` +
-            `face(s) skipped — all of their nodes lie on the moment axis, so ` +
-            `the applied moment is incomplete. Choose a different moment axis ` +
-            `or face selection.`,
+            "face(s) skipped — all of their nodes lie on the moment axis, so " +
+            "the applied moment is incomplete. Choose a different moment axis " +
+            "or face selection.",
         );
       }
     }

--- a/web/tests/moment-loads.spec.ts
+++ b/web/tests/moment-loads.spec.ts
@@ -183,6 +183,45 @@ test("My moment produces correct net moment about y and zero net force", async (
   expect(result.netMy).toBeCloseTo(750, 6);
 });
 
+test("moment over a face whose nodes all lie on the moment axis is skipped with a warning", async ({
+  page,
+}) => {
+  await bootstrapCantilever(page);
+
+  const result = await page.evaluate(() => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+
+    const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
+
+    // The y=0, z=0 edge of the cantilever: a line of nodes collinear with the
+    // global x axis. An Mx moment about that axis has zero perpendicular arm at
+    // every node (S = 0), so the face contributes no nodal forces.
+    const axisNodes = store
+      .getState()
+      .nodes.filter((n) => Math.abs(n.y) < 1e-9 && Math.abs(n.z) < 1e-9);
+    store.getState().clearLoads();
+    store.getState().createLoadGroup(
+      [{ label: "x-axis edge", nodeIds: axisNodes.map((n) => n.id) }],
+      3, // Mx — about the very axis the selected edge lies on
+      1000,
+    );
+
+    const loads = store.getState().loads;
+    console.warn = origWarn;
+    return { nodeCount: axisNodes.length, loads, warnings };
+  });
+
+  expect(result.nodeCount).toBeGreaterThan(1); // a real edge, not a single node
+  // A degenerate face yields no nodal forces …
+  expect(result.loads.length).toBe(0);
+  // … but the skip is surfaced, not silent.
+  expect(result.warnings.some((w) => w.includes("skipped"))).toBe(true);
+});
+
 // ── Solve integration ─────────────────────────────────────────────────────────
 
 test("solve worker completes when loads include a moment (Mz)", async ({


### PR DESCRIPTION
## Summary

Add a warning when a moment load is applied to faces whose nodes all lie on the moment axis, making the load degenerate and incomplete. This helps users identify configuration errors where the applied moment cannot be fully realized.

## Changes

- **modelStore.ts**: Track degenerate faces (where all nodes lie on the moment axis) during moment load computation and emit a console warning with actionable guidance
  - Count skipped faces and report the count alongside the load group name
  - Suggest choosing a different moment axis or face selection
  - Preserve existing behavior: degenerate faces still contribute zero forces (S = 0 case)

- **moment-loads.spec.ts**: Add test case verifying the warning is emitted when a moment is applied about an axis that the selected face lies on
  - Selects the y=0, z=0 edge of the cantilever (collinear with x-axis)
  - Applies an Mx moment about that same axis
  - Confirms no nodal forces are generated and a warning is logged

## Implementation Details

The warning is only emitted when `skippedFaces > 0`, avoiding noise for well-formed loads. The message includes the load group name, count of skipped faces, and practical guidance for fixing the configuration.

https://claude.ai/code/session_01EpcoRXWV9aqmKNxWMbFQEM