### PR TITLE
Add per-node load display toggle for tributary-area visualization

### DIFF
--- a/web/src/components/statusbar/StatusBar.tsx
+++ b/web/src/components/statusbar/StatusBar.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Michael Kofler
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { useModelStore } from "../../store/modelStore";
+import { useModelStore, loadKind } from "../../store/modelStore";
 import { APP_VERSION } from "../../lib/version";
 import styles from "./StatusBar.module.css";
 
@@ -112,6 +112,7 @@ export function StatusBar() {
   const constraints = useModelStore((s) => s.constraints);
   const loads = useModelStore((s) => s.loads);
   const result = useModelStore((s) => s.result);
+  const mode = useModelStore((s) => s.mode);
   const selectedFace = useModelStore((s) => s.selectedFace);
   const pickMode = useModelStore((s) => s.pickMode);
   const viewRepr = useModelStore((s) => s.viewRepr);
@@ -120,6 +121,9 @@ export function StatusBar() {
   const setShowUndeformedOverlay = useModelStore(
     (s) => s.setShowUndeformedOverlay,
   );
+  const loadGroups = useModelStore((s) => s.loadGroups);
+  const loadDisplay = useModelStore((s) => s.loadDisplay);
+  const setLoadDisplay = useModelStore((s) => s.setLoadDisplay);
   const stepSurface = useModelStore((s) => s.stepSurface);
 
   const hasGeometry = nodes.length > 0 || !!stepSurface;
@@ -140,6 +144,13 @@ export function StatusBar() {
   const hexCount = elements.filter((e) => e.type === "CHEXA").length;
   const tetCount = elements.filter((e) => e.type === "CTETRA").length;
   const meshOk = nodes.length > 0;
+
+  // Load glyphs are only drawn outside the deformed-result view, and only
+  // force/pressure groups produce them (moments carry no resultant arrow), so
+  // the resultant/nodal toggle is offered only when such an arrow is on screen.
+  const showingResult = !!result && mode === "results";
+  const showLoadDisplayToggle =
+    !showingResult && loadGroups.some((g) => loadKind(g) !== "moment");
 
   return (
     <div className={styles.bar}>
@@ -247,6 +258,40 @@ export function StatusBar() {
               />
             </svg>
             Undeformed
+          </button>
+        )}
+        {showLoadDisplayToggle && (
+          <button
+            onClick={() =>
+              setLoadDisplay(loadDisplay === "nodal" ? "resultant" : "nodal")
+            }
+            className={`${styles.reprBtn} ${loadDisplay === "nodal" ? styles.reprBtnActive : ""}`}
+            aria-label="Toggle per-node load display"
+            data-tooltip="Show the load on each node instead of a single resultant arrow"
+            style={{
+              width: "auto",
+              padding: "0 7px",
+              borderRadius: 5,
+              border: "1px solid #e2e5ea",
+            }}
+          >
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              width="13"
+              height="13"
+              style={{ marginRight: 4 }}
+            >
+              {/* three small down-arrows — the per-node load field */}
+              <path
+                d="M3 2v8M3 10l-1.6-1.8M3 10l1.6-1.8M8 2v9M8 11l-1.6-1.8M8 11l1.6-1.8M13 2v8M13 10l-1.6-1.8M13 10l1.6-1.8"
+                stroke="currentColor"
+                strokeWidth="1.1"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            Nodal loads
           </button>
         )}
       </div>

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -152,6 +152,7 @@ export function MeshScene() {
   const setPendingFaces = useModelStore((s) => s.setPendingFaces);
   const bcGroups = useModelStore((s) => s.bcGroups);
   const loadGroups = useModelStore((s) => s.loadGroups);
+  const loadDisplay = useModelStore((s) => s.loadDisplay);
   const showUndeformedOverlay = useModelStore((s) => s.showUndeformedOverlay);
 
   const nodeMap = useMemo(
@@ -750,6 +751,157 @@ export function MeshScene() {
     return arrows;
   }, [loadGroups, nodes, nodeMap]);
 
+  // Per-node load glyphs — one arrow at every loaded node, sized by the
+  // work-equivalent load that node carries: its tributary-area share of the
+  // group total (force ⇒ totalForce·Aᵢ/A, pressure ⇒ p·Aᵢ, both in N). This is
+  // what actually reaches the solver as a surface traction, in contrast to the
+  // single statically-equivalent resultant. Shown when loadDisplay === "nodal".
+  // Force arrows point along the applied force; pressure arrows point into the
+  // surface along the per-node inward normal. Moments carry no resultant force
+  // and are skipped, matching the resultant view (issue #196).
+  const nodalLoadArrows = useMemo(() => {
+    if (loadGroups.length === 0 || nodes.length === 0) return [];
+
+    // Model centroid — used to orient pressure arrows inward.
+    let mx = 0,
+      my = 0,
+      mz = 0;
+    for (const n of nodes) {
+      mx += n.x;
+      my += n.y;
+      mz += n.z;
+    }
+    mx /= nodes.length;
+    my /= nodes.length;
+    mz /= nodes.length;
+    const modelCentroid = new THREE.Vector3(mx, my, mz);
+
+    const posOf = (id: number): THREE.Vector3 | null => {
+      const e = nodeMap.get(id);
+      return e ? new THREE.Vector3(e.n.x, e.n.y, e.n.z) : null;
+    };
+
+    // Accumulated per node across all groups: load direction (unit) and
+    // magnitude (N). A node shared by two groups gets the larger arrow.
+    type NodalLoad = { dir: THREE.Vector3; mag: number };
+    const byNode = new Map<number, NodalLoad>();
+
+    for (const g of loadGroups) {
+      const kind = loadKind(g);
+      if (kind === "moment") continue;
+
+      const nodeSet = new Set<number>();
+      for (const f of g.faces) for (const id of f.nodeIds) nodeSet.add(id);
+      if (nodeSet.size === 0) continue;
+
+      // Tributary area per node and (for pressure) accumulated inward normal,
+      // integrated over the boundary faces that lie entirely on the group's
+      // selected faces — the same membership test the solver uses to apply the
+      // surface traction, so the per-node share matches the FE load.
+      const tribArea = new Map<number, number>();
+      const inward = new Map<number, THREE.Vector3>();
+      let totalArea = 0;
+
+      const addFace = (ids: number[]) => {
+        if (!ids.every((id) => nodeSet.has(id))) return;
+        const pts = ids.map(posOf);
+        if (pts.some((p) => p === null)) return;
+        const p = pts as THREE.Vector3[];
+
+        // Area + outward normal: triangle directly, quad via its diagonals.
+        let area: number;
+        const normal = new THREE.Vector3();
+        if (p.length === 3) {
+          normal
+            .copy(p[1])
+            .sub(p[0])
+            .cross(new THREE.Vector3().copy(p[2]).sub(p[0]));
+          area = 0.5 * normal.length();
+        } else {
+          normal
+            .copy(p[2])
+            .sub(p[0])
+            .cross(new THREE.Vector3().copy(p[3]).sub(p[1]));
+          area = 0.5 * normal.length();
+        }
+        if (area < 1e-30) return;
+        normal.normalize();
+        totalArea += area;
+
+        // Orient the face normal inward (positive pressure pushes in).
+        const fc = new THREE.Vector3();
+        for (const v of p) fc.add(v);
+        fc.divideScalar(p.length);
+        if (normal.dot(new THREE.Vector3().copy(modelCentroid).sub(fc)) < 0)
+          normal.negate();
+
+        const share = area / p.length;
+        for (const id of ids) {
+          tribArea.set(id, (tribArea.get(id) ?? 0) + share);
+          if (kind === "pressure") {
+            const acc = inward.get(id) ?? new THREE.Vector3();
+            inward.set(id, acc.addScaledVector(normal, area));
+          }
+        }
+      };
+
+      for (const tri of boundaryTriFaceIds) addFace(tri);
+      for (const quad of boundaryQuadFaceIds) addFace(quad);
+      if (totalArea < 1e-30) continue;
+
+      // Force direction is shared by every node; pressure direction is per-node.
+      const forceDir = new THREE.Vector3();
+      if (kind === "force") {
+        const d = [0, 0, 0];
+        d[g.dof] = g.totalForce;
+        forceDir.set(d[0], d[1], d[2]);
+        if (forceDir.lengthSq() < 1e-30) continue;
+        forceDir.normalize();
+      }
+      const sign = g.totalForce < 0 ? -1 : 1;
+
+      for (const [id, a] of tribArea) {
+        let dir: THREE.Vector3;
+        let mag: number;
+        if (kind === "force") {
+          dir = forceDir;
+          mag = Math.abs(g.totalForce) * (a / totalArea);
+        } else {
+          const acc = inward.get(id);
+          if (!acc || acc.lengthSq() < 1e-30) continue;
+          dir = acc.clone().normalize().multiplyScalar(sign);
+          mag = Math.abs(g.totalForce) * a; // p · Aᵢ
+        }
+        if (mag < 1e-30) continue;
+        const prev = byNode.get(id);
+        if (!prev || mag > prev.mag) byNode.set(id, { dir, mag });
+      }
+    }
+
+    if (byNode.size === 0) return [];
+    let maxMag = 0;
+    for (const { mag } of byNode.values()) if (mag > maxMag) maxMag = mag;
+    if (maxMag < 1e-30) return [];
+
+    const up = new THREE.Vector3(0, 1, 0);
+    const arrows: {
+      pos: [number, number, number];
+      quaternion: THREE.Quaternion;
+      frac: number;
+    }[] = [];
+    for (const [id, { dir, mag }] of byNode) {
+      const e = nodeMap.get(id);
+      if (!e) continue;
+      const q = new THREE.Quaternion().setFromUnitVectors(up, dir);
+      arrows.push({
+        pos: [e.n.x, e.n.y, e.n.z],
+        quaternion: q,
+        frac: mag / maxMag,
+      });
+    }
+    return arrows;
+  }, [loadGroups, nodes, nodeMap, boundaryTriFaceIds, boundaryQuadFaceIds]);
+
   const stepGeometry = useMemo(() => {
     if (!stepSurface || stepSurface.triangles.length === 0) return null;
     const { points, triangles } = stepSurface;
@@ -1027,8 +1179,9 @@ export function MeshScene() {
         </group>
       )}
 
-      {/* Load arrows — one per force/pressure group, cylinder shaft + cone head */}
+      {/* Resultant load arrows — one per force/pressure group, cylinder shaft + cone head */}
       {!showResult &&
+        loadDisplay === "resultant" &&
         loadArrows.map((arrow, i) => {
           const shaftLen = modelSize * 0.22;
           const headLen = modelSize * 0.09;
@@ -1038,6 +1191,32 @@ export function MeshScene() {
             <group key={i} position={arrow.pos} quaternion={arrow.quaternion}>
               <mesh position={[0, shaftLen / 2, 0]}>
                 <cylinderGeometry args={[shaftR, shaftR, shaftLen, 8]} />
+                <meshStandardMaterial color="#d97706" />
+              </mesh>
+              <mesh position={[0, shaftLen + headLen / 2, 0]}>
+                <coneGeometry args={[headR, headLen, 8]} />
+                <meshStandardMaterial color="#d97706" />
+              </mesh>
+            </group>
+          );
+        })}
+
+      {/* Per-node load arrows — one per loaded node, length scaled by the load
+          that node carries (relative to the largest in the model) */}
+      {!showResult &&
+        loadDisplay === "nodal" &&
+        nodalLoadArrows.map((arrow, i) => {
+          // Shortest arrows stay at 35% of the full length so light-loaded
+          // nodes remain visible; radii are fixed so arrows read as a field.
+          const len = modelSize * 0.13 * (0.35 + 0.65 * arrow.frac);
+          const shaftLen = len * 0.68;
+          const headLen = len * 0.32;
+          const shaftR = modelSize * 0.006;
+          const headR = modelSize * 0.018;
+          return (
+            <group key={i} position={arrow.pos} quaternion={arrow.quaternion}>
+              <mesh position={[0, shaftLen / 2, 0]}>
+                <cylinderGeometry args={[shaftR, shaftR, shaftLen, 6]} />
                 <meshStandardMaterial color="#d97706" />
               </mesh>
               <mesh position={[0, shaftLen + headLen / 2, 0]}>

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -124,6 +124,13 @@ export interface NamedBcGroup {
 // loadKind().
 export type LoadKind = "force" | "moment" | "pressure";
 
+// How load glyphs are drawn in the viewport. "resultant" shows one arrow per
+// force/pressure group at the centroid of its loaded nodes (the statically
+// equivalent load the user specifies). "nodal" shows the work-equivalent load
+// each individual node carries — the per-node tributary share of the group total
+// — which is what actually reaches the solver as a surface traction (issue #196).
+export type LoadDisplay = "resultant" | "nodal";
+
 export interface NamedLoadGroup {
   id: number;
   name: string; // e.g. "Load1"
@@ -392,6 +399,9 @@ interface ModelState {
   surfaceFaceIds: number[] | null;
   viewRepr: "geometry" | "surface" | "volume" | "wireframe";
   showUndeformedOverlay: boolean;
+  // Whether load glyphs are drawn as a single resultant per group or as one
+  // arrow per loaded node (issue #196). A transient view setting, not persisted.
+  loadDisplay: LoadDisplay;
   // Deformation magnification applied to the result on top of the automatic
   // fit-to-view scale. 1 = the default visible deformation, 0 = undeformed.
   deformScale: number;
@@ -403,6 +413,7 @@ interface ModelState {
   setSurfaceFaceIds(ids: number[] | null): void;
   setViewRepr(v: "geometry" | "surface" | "volume" | "wireframe"): void;
   setShowUndeformedOverlay(v: boolean): void;
+  setLoadDisplay(v: LoadDisplay): void;
   setDeformScale(v: number): void;
   setStepImportError(msg: string | null): void;
 
@@ -510,6 +521,7 @@ export const useModelStore = create<ModelState>()(
     surfaceFaceIds: null,
     viewRepr: "surface" as const,
     showUndeformedOverlay: true,
+    loadDisplay: "resultant" as LoadDisplay,
     deformScale: 1,
     stepImportError: null,
     nextMatId: 2,
@@ -530,6 +542,10 @@ export const useModelStore = create<ModelState>()(
     setShowUndeformedOverlay: (v) =>
       set((s) => {
         s.showUndeformedOverlay = v;
+      }),
+    setLoadDisplay: (v) =>
+      set((s) => {
+        s.loadDisplay = v;
       }),
     setDeformScale: (v) =>
       set((s) => {


### PR DESCRIPTION
## Summary

Adds a viewport toggle to switch between two load glyph display modes: the existing single resultant arrow per force/pressure group, and a new per-node visualization showing the work-equivalent load each node carries (its tributary-area share of the group total). This addresses issue #196 by making visible the actual per-node surface tractions that reach the FEM solver, in contrast to the statically equivalent resultant the user specifies.

## Changes

- **MeshScene.tsx**: 
  - Added `loadDisplay` state selector from store
  - Implemented `nodalLoadArrows` memo that computes per-node load glyphs by integrating tributary areas over boundary faces and scaling arrow lengths by relative load magnitude
  - Force arrows point along the applied direction; pressure arrows point inward along per-node normals (oriented via model centroid)
  - Moments are skipped (carry no resultant force, matching existing behavior)
  - Conditional rendering: resultant arrows shown when `loadDisplay === "resultant"`, nodal arrows when `loadDisplay === "nodal"`

- **StatusBar.tsx**:
  - Imported `loadKind` utility from store
  - Added `loadDisplay` state and `setLoadDisplay` action selectors
  - Implemented toggle button that appears only when viewing non-result geometry with force/pressure loads
  - Button shows three-arrow icon and label "Nodal loads"

- **modelStore.ts**:
  - Added `LoadDisplay` type: `"resultant" | "nodal"`
  - Added `loadDisplay` state field (transient, not persisted) with default `"resultant"`
  - Added `setLoadDisplay(v: LoadDisplay)` action

## Implementation Details

The nodal load computation:
- Iterates over all load groups, skipping moments
- For each group, identifies the set of nodes on its selected faces
- Integrates tributary area per node over boundary faces that lie entirely within the group's node set (matching the solver's membership test)
- For forces: scales by `totalForce · (Aᵢ / A)` in the force direction
- For pressure: scales by `p · Aᵢ` along the per-node inward normal
- Selects the largest load per node across all groups (nodes shared by multiple groups get the larger arrow)
- Scales arrow lengths from 35% to 100% of a base length so light-loaded nodes remain visible; radii are fixed to read as a field

closes #196

https://claude.ai/code/session_01WBpawuK7SuAjHjF6ktTEHC