### PR TITLE
Add toggleFaceSelection to support face deselection (#264)

### DIFF
--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -7,7 +7,11 @@ import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useModelStore, loadKind } from "../../store/modelStore";
 import type { Node, ResultType } from "../../store/modelStore";
-import { buildBoundaryMeshTopo, pickFaceNodeIds } from "../../lib/facePick";
+import {
+  buildBoundaryMeshTopo,
+  pickFaceNodeIds,
+  toggleFaceSelection,
+} from "../../lib/facePick";
 import type { Vec3, Tri } from "../../lib/facePick";
 import { nodeVonMisesField } from "../../lib/resultField";
 
@@ -625,18 +629,22 @@ export function MeshScene() {
       isMax = normal.z > 0;
     }
 
-    const newFace = {
+    // Current selection = accumulated pending faces plus the active one.
+    // Re-selecting an already-picked face toggles it off instead of adding a
+    // duplicate (#264).
+    const current = selectedFace
+      ? [...pendingFaces, selectedFace]
+      : pendingFaces;
+    const next = toggleFaceSelection(current, {
       nodeIds: faceNodeIds,
-      label: `Face ${pendingFaces.length + 1} (${faceNodeIds.length} nodes)`,
       axis,
       isMax,
-    };
+      label: "",
+    });
 
-    // Every click adds to the selection; accumulate into pendingFaces.
-    if (selectedFace) {
-      setPendingFaces([...pendingFaces, selectedFace]);
-    }
-    setSelectedFace(newFace);
+    // Re-split into pending faces + the active (last) selection.
+    setPendingFaces(next.slice(0, -1));
+    setSelectedFace(next.length > 0 ? next[next.length - 1] : null);
   }
 
   // BC marker: centroid + quaternion that orients triangles outward from the model

--- a/web/src/lib/facePick.ts
+++ b/web/src/lib/facePick.ts
@@ -37,6 +37,47 @@ export interface BoundaryMeshTopo {
   faceIds?: number[]; // OCC face index per triangle (1-based); present when mesh came from STEP
 }
 
+export interface PickedFace {
+  nodeIds: number[];
+  axis: "X" | "Y" | "Z";
+  isMax: boolean;
+  label: string;
+}
+
+// Two picked faces are the same when they reference the same set of nodes.
+// pickFaceNodeIds returns a deterministic node-id set for a given CAD face, so a
+// set comparison is enough to detect re-selecting an already-picked face.
+export function sameFaceNodes(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((id) => set.has(id));
+}
+
+/**
+ * Fold a freshly picked face into the current selection.
+ *
+ * Re-selecting a face that is already in the selection removes it instead of
+ * adding a duplicate (#264); otherwise the face is appended. Faces are
+ * identified by their node-id set (see `sameFaceNodes`). The result is
+ * relabeled "Face 1..N" by position so labels stay contiguous after a toggle.
+ */
+export function toggleFaceSelection(
+  current: PickedFace[],
+  picked: PickedFace,
+): PickedFace[] {
+  const existingIdx = current.findIndex((f) =>
+    sameFaceNodes(f.nodeIds, picked.nodeIds),
+  );
+  const next =
+    existingIdx >= 0
+      ? current.filter((_, i) => i !== existingIdx)
+      : [...current, picked];
+  return next.map((f, i) => ({
+    ...f,
+    label: `Face ${i + 1} (${f.nodeIds.length} nodes)`,
+  }));
+}
+
 export function buildEdgeToTris(triangles: Tri[]): Map<string, number[]> {
   const edgeToTris = new Map<string, number[]>();
   for (let i = 0; i < triangles.length; i++) {

--- a/web/tests/test_face_pick.mjs
+++ b/web/tests/test_face_pick.mjs
@@ -12,7 +12,11 @@
 //
 // Run: bun tests/test_face_pick.mjs   (from the web/ directory)
 
-import { buildBoundaryMeshTopo, pickFaceNodeIds } from "../src/lib/facePick.ts";
+import {
+  buildBoundaryMeshTopo,
+  pickFaceNodeIds,
+  toggleFaceSelection,
+} from "../src/lib/facePick.ts";
 
 // ── Geometry helpers ─────────────────────────────────────────────────────────
 
@@ -241,6 +245,44 @@ assert(
   "BFS: top cap does not bleed onto inner mantle nodes",
   innerOnlyNodes.every((v) => !pickedTop.has(v)),
 );
+
+// ── Test 5: toggleFaceSelection adds, toggles off, and relabels (#264) ────────
+
+console.log("\nTest 5: toggleFaceSelection (#264)");
+
+const faceA = { nodeIds: [1, 2, 3], axis: "X", isMax: true, label: "" };
+const faceB = { nodeIds: [4, 5, 6], axis: "Y", isMax: false, label: "" };
+
+// Picking two distinct faces accumulates both.
+let sel = toggleFaceSelection([], faceA);
+sel = toggleFaceSelection(sel, faceB);
+assert("two distinct picks accumulate", sel.length === 2);
+assert(
+  "faces relabeled by position",
+  sel[0].label === "Face 1 (3 nodes)" && sel[1].label === "Face 2 (3 nodes)",
+);
+
+// Re-picking the first face (same node set, any node order) removes it.
+const faceAReordered = {
+  nodeIds: [3, 1, 2],
+  axis: "X",
+  isMax: true,
+  label: "",
+};
+sel = toggleFaceSelection(sel, faceAReordered);
+assert("re-selecting a face removes it", sel.length === 1);
+assert(
+  "remaining face is the other one",
+  setsEqual(new Set(sel[0].nodeIds), new Set(faceB.nodeIds)),
+);
+assert(
+  "remaining face relabeled to Face 1",
+  sel[0].label === "Face 1 (3 nodes)",
+);
+
+// Toggling the last remaining face off empties the selection.
+sel = toggleFaceSelection(sel, faceB);
+assert("toggling the last face off clears selection", sel.length === 0);
 
 // ── Summary ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Implement face deselection in the boundary condition picker by adding a `toggleFaceSelection` function that allows users to remove already-picked faces by re-selecting them, rather than accumulating duplicates.

## Changes

- **New `PickedFace` interface** in `facePick.ts`: Defines the structure for a picked face with node IDs, axis, max flag, and label.
- **New `sameFaceNodes` helper**: Compares two node-id sets to detect when the same face is re-selected (node order independent).
- **New `toggleFaceSelection` function**: Implements toggle semantics—re-selecting an existing face removes it; otherwise appends the new face. Automatically relabels all faces as "Face 1..N" to keep labels contiguous after removal.
- **Updated `MeshScene.tsx`**: Refactored face picking logic to use `toggleFaceSelection`, treating the current selection as pending faces plus the active face, then splitting the result back into those two states.
- **Added comprehensive test suite** (`test_face_pick.mjs`): Test 5 validates that faces accumulate, toggle off on re-selection, and relabel correctly.

## Implementation Details

The toggle logic treats the UI state (pending faces + active selection) as a single list, applies `toggleFaceSelection`, and then splits the result back into pending and active. This ensures consistent labeling and simplifies the deselection logic. Face identity is determined by node-id set equality, which is robust to node ordering since `pickFaceNodeIds` returns a deterministic set for each CAD face.

closes #264

https://claude.ai/code/session_019kNthx3428WLW9UMRyU8UT