### PR TITLE
Restrict element types to solid elements (CTETRA, CHEXA)

### DIFF
--- a/web/src/components/panel/LeftPanel.module.css
+++ b/web/src/components/panel/LeftPanel.module.css
@@ -300,6 +300,14 @@
   margin-bottom: 8px;
 }
 
+.formNote {
+  font-size: 11px;
+  color: var(--muted);
+  font-style: italic;
+  margin: -4px 0 8px 88px;
+  line-height: 1.4;
+}
+
 .formLabel {
   font-size: 12px;
   color: var(--muted);

--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -106,8 +106,13 @@ function MaterialForm({
           value={density}
           step="1e-9"
           onChange={(e) => setDensity(e.target.value)}
+          title="Stored with the material but not used by the current static solver (reserved for future gravity / inertial loads)."
         />
       </div>
+      <p className={styles.formNote}>
+        Not used by the current static solver — reserved for future gravity /
+        inertial loads.
+      </p>
       <div className={styles.formBtns}>
         <button className={styles.cancelBtn} onClick={onCancel}>
           Cancel

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useMemo } from "react";
-import { Line } from "@react-three/drei";
 import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useModelStore, loadKind } from "../../store/modelStore";
@@ -205,10 +204,6 @@ export function MeshScene() {
     () => elements.filter((e) => e.type === "CTETRA"),
     [elements],
   );
-  const barElements = useMemo(
-    () => elements.filter((e) => e.type === "CBAR" || e.type === "CBEAM"),
-    [elements],
-  );
 
   const boundaryQuadFaceIds = useMemo(
     () => extractBoundaryQuadFaceIds(hexElements),
@@ -380,17 +375,6 @@ export function MeshScene() {
     }
     return segs.length > 0 ? new Float32Array(segs) : null;
   }, [result, boundaryQuadFaceIds, boundaryTriFaceIds, nodeMap, deformScale]);
-
-  const barLines = useMemo(
-    () =>
-      barElements.map((el) =>
-        el.nodeIds.map((id) => {
-          const e = nodeMap.get(id)!;
-          return [e.n.x, e.n.y, e.n.z] as [number, number, number];
-        }),
-      ),
-    [barElements, nodeMap],
-  );
 
   // Per-node von Mises: volume-weighted average of the element-level stresses,
   // shared with the colorbar range in resultField so the two stay identical.
@@ -1027,11 +1011,6 @@ export function MeshScene() {
           <lineBasicMaterial color="#2d4a6b" />
         </lineSegments>
       )}
-
-      {/* Bar elements */}
-      {barLines.map((pts, i) => (
-        <Line key={`b-${i}`} points={pts} color="#1e3a5f" lineWidth={2} />
-      ))}
 
       {/* Deformed solid surface */}
       {showResult && deformedSurface && (

--- a/web/src/lib/analysisFile.ts
+++ b/web/src/lib/analysisFile.ts
@@ -116,6 +116,10 @@ function vtkCellType(type: ElementType, nNodes: number): number {
       return nNodes === 10 ? 24 : 10; // VTK_(QUADRATIC_)TETRA
     case "CHEXA":
       return nNodes === 20 ? 25 : 12; // VTK_(QUADRATIC_)HEXAHEDRON
+    default:
+      throw new Error(
+        `Cannot serialize analysis: unknown element type "${type}"`,
+      );
   }
 }
 

--- a/web/src/lib/analysisFile.ts
+++ b/web/src/lib/analysisFile.ts
@@ -83,9 +83,9 @@ export interface AnalysisState {
 }
 
 // Setup state embedded as JSON in the "KoFEM" FieldData string array.
-// `elementTypes` disambiguates element types that share a VTK cell type
-// (e.g. CBAR vs CBEAM are both VTK_LINE); the mesh itself lives in the
-// native VTU sections.
+// `elementTypes` records the source element type of each cell so the
+// round-trip preserves it independently of the VTK cell-type number; the
+// mesh itself lives in the native VTU sections.
 interface KofemFieldDataV1 {
   format: typeof ANALYSIS_FILE_FORMAT;
   version: 1;
@@ -112,23 +112,8 @@ interface KofemFieldDataV1 {
 
 function vtkCellType(type: ElementType, nNodes: number): number {
   switch (type) {
-    case "CBAR":
-    case "CBEAM":
-      return 3; // VTK_LINE
-    case "CTRIA3":
-      return 5; // VTK_TRIANGLE
-    case "CTRIA6":
-      return 22; // VTK_QUADRATIC_TRIANGLE
-    case "CQUAD4":
-      return 9; // VTK_QUAD
-    case "CQUAD8":
-      return 23; // VTK_QUADRATIC_QUAD
     case "CTETRA":
       return nNodes === 10 ? 24 : 10; // VTK_(QUADRATIC_)TETRA
-    case "CPYRAM":
-      return nNodes === 13 ? 27 : 14; // VTK_(QUADRATIC_)PYRAMID
-    case "CPENTA":
-      return nNodes === 15 ? 26 : 13; // VTK_(QUADRATIC_)WEDGE
     case "CHEXA":
       return nNodes === 20 ? 25 : 12; // VTK_(QUADRATIC_)HEXAHEDRON
   }
@@ -323,18 +308,7 @@ export function analysisFileName(modelName: string): string {
 
 const APP_MODES: AppMode[] = ["geometry", "constraints", "solve", "results"];
 const VIEW_REPRS = ["geometry", "surface", "volume", "wireframe"] as const;
-const ELEMENT_TYPES: ElementType[] = [
-  "CBAR",
-  "CBEAM",
-  "CTRIA3",
-  "CTRIA6",
-  "CQUAD4",
-  "CQUAD8",
-  "CTETRA",
-  "CPENTA",
-  "CHEXA",
-  "CPYRAM",
-];
+const ELEMENT_TYPES: ElementType[] = ["CTETRA", "CHEXA"];
 
 function dataArrayContent(xml: string, name: string): string {
   const m = xml.match(

--- a/web/src/lib/modelDisplay.ts
+++ b/web/src/lib/modelDisplay.ts
@@ -6,11 +6,3 @@ export function fmt(v: number, digits = 3) {
     return v.toExponential(digits);
   return v.toPrecision(digits + 1);
 }
-
-export const PROP_TYPE_LABEL: Record<string, string> = {
-  PSOLID: "3-D Solid",
-  PSHELL: "Shell",
-  PLPLANE: "Plane",
-  PBAR: "Bar/Beam",
-  PBEAM: "Beam",
-};

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -12,30 +12,15 @@ export interface Node {
   z: number;
 }
 
-export type ElementType =
-  | "CBAR"
-  | "CBEAM"
-  | "CTRIA3"
-  | "CTRIA6"
-  | "CQUAD4"
-  | "CQUAD8"
-  | "CTETRA"
-  | "CPENTA"
-  | "CHEXA"
-  | "CPYRAM";
-
-export type PropertyType = "PBAR" | "PBEAM" | "PSHELL" | "PLPLANE" | "PSOLID";
+// The live OCCT → Netgen → MFEM pipeline only ever produces solid elements:
+// tetrahedra (CTETRA) and hexahedra (CHEXA). 1D (beam) and 2D (shell/plane)
+// element types are not modelled — restore the relevant variants here when
+// such support is actually added.
+export type ElementType = "CTETRA" | "CHEXA";
 
 export interface Property {
   id: number;
-  type: PropertyType;
   materialId: number;
-  thickness?: number;
-  planeFormulation?: "PlaneStress" | "PlaneStrain";
-  area?: number;
-  i1?: number;
-  i2?: number;
-  j?: number;
 }
 
 export interface Element {
@@ -489,7 +474,7 @@ const EMPTY_MODEL = {
     // loads (N), and results (mm, MPa) must share this system to stay consistent.
     { id: 1, name: "Steel", young: 210000, poisson: 0.3, density: 7.85e-9 },
   ] as Material[],
-  properties: [{ id: 1, type: "PSOLID" as const, materialId: 1 }] as Property[],
+  properties: [{ id: 1, materialId: 1 }] as Property[],
   constraints: [] as Constraint[],
   loads: [] as Load[],
   surfaceLoads: [] as SurfaceLoad[],
@@ -673,9 +658,9 @@ export const useModelStore = create<ModelState>()(
         s.modelName = name;
         s.viewRepr = "surface";
         s.fitViewTrigger++;
-        if (!s.properties.find((p) => p.type === "PSOLID")) {
+        if (s.properties.length === 0) {
           const matId = s.materials[0]?.id ?? 1;
-          s.properties = [{ id: 1, type: "PSOLID", materialId: matId }];
+          s.properties = [{ id: 1, materialId: matId }];
         }
       }),
 
@@ -735,7 +720,7 @@ export const useModelStore = create<ModelState>()(
             density: 7.85e-9,
           },
         ];
-        s.properties = [{ id: 1, type: "PSOLID", materialId: 1 }];
+        s.properties = [{ id: 1, materialId: 1 }];
         s.bcGroups = [];
         s.loadGroups = [];
         s.constraints = [];

--- a/web/tests/fixtures/cantilever.ts
+++ b/web/tests/fixtures/cantilever.ts
@@ -26,7 +26,7 @@ export interface CantileverModel {
     poisson: number;
     density: number;
   }[];
-  properties: { id: number; type: "PSOLID"; materialId: number }[];
+  properties: { id: number; materialId: number }[];
   bcGroups: {
     id: number;
     name: string;
@@ -92,7 +92,7 @@ export function buildCantilever(): CantileverModel {
   const materials = [
     { id: 1, name: "Steel", young: 210e9, poisson: 0.3, density: 7850 },
   ];
-  const properties = [{ id: 1, type: "PSOLID" as const, materialId: 1 }];
+  const properties = [{ id: 1, materialId: 1 }];
 
   // Fixed support at x=0
   const bcNodeIds: number[] = [];


### PR DESCRIPTION
## Summary

Simplify the codebase by removing support for 1D (beam) and 2D (shell/plane) element types. The live OCCT → Netgen → MFEM pipeline only ever produces solid tetrahedral (CTETRA) and hexahedral (CHEXA) elements. Beam and shell element types are not modelled by the current geometry-to-mesh workflow and can be restored later if such support is actually added.

## Key Changes

- **Element type restrictions:**
  - Reduced `ElementType` union to only `"CTETRA" | "CHEXA"` in `modelStore.ts`
  - Updated `ELEMENT_TYPES` constant to match in `analysisFile.ts`
  - Removed element type cases from `vtkCellType()` function (CBAR, CBEAM, CTRIA3, CTRIA6, CQUAD4, CQUAD8, CPYRAM, CPENTA)

- **Property type simplification:**
  - Removed `PropertyType` union (PBAR, PBEAM, PSHELL, PLPLANE, PSOLID)
  - Simplified `Property` interface to only store `id` and `materialId`
  - Removed property-specific fields: `type`, `thickness`, `planeFormulation`, `area`, `i1`, `i2`, `j`

- **UI and display updates:**
  - Removed bar element rendering logic from `MeshScene.tsx` (barElements filter, barLines computation, Line component rendering)
  - Removed unused `Line` import from `@react-three/drei`
  - Removed `PROP_TYPE_LABEL` mapping from `modelDisplay.ts`
  - Updated property initialization in model store to omit `type` field
  - Added `.formNote` CSS class for informational text about density field

- **Documentation:**
  - Updated KofemFieldDataV1 comment to clarify that `elementTypes` records source element type for round-trip preservation
  - Added comment in `modelStore.ts` explaining the restriction and when support can be restored
  - Added tooltip and note to density field explaining it's reserved for future gravity/inertial loads

- **Test fixtures:**
  - Updated `cantilever.ts` fixture to remove `type: "PSOLID"` from property definitions

## Implementation Details

The changes maintain backward compatibility in the analysis file format (KofemFieldDataV1) by keeping the `elementTypes` field, which now serves purely as a round-trip preservation mechanism rather than disambiguation. All model initialization and property handling code has been updated to work with the simplified property structure.

https://claude.ai/code/session_01CuXp222iWXD6rp1YhKqkHB