### PR TITLE
Support componentwise force and moment loads (issues #219, #190)

### DIFF
--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -2,10 +2,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useState, useRef, useEffect, type ChangeEvent } from "react";
-import { useModelStore, RESULT_TYPES, loadKind } from "../../store/modelStore";
+import {
+  useModelStore,
+  RESULT_TYPES,
+  loadKind,
+  loadComponents,
+} from "../../store/modelStore";
 import type {
   AppMode,
+  LoadKind,
   Material,
+  NamedLoadGroup,
   Node,
   Element,
   ResultType,
@@ -586,6 +593,19 @@ function GeometryPanel() {
 
 // ── Constraints mode ──────────────────────────────────────────────────────────
 
+// One-line summary of a load group for the group list: pressure magnitude, or
+// the non-zero force/moment components (e.g. "Fx = 100, Fz = -50 N").
+function loadGroupMeta(g: NamedLoadGroup): string {
+  const kind = loadKind(g);
+  if (kind === "pressure") return `p = ${fmt(g.totalForce)} MPa`;
+  const labels = kind === "moment" ? ["Mx", "My", "Mz"] : ["Fx", "Fy", "Fz"];
+  const unit = kind === "moment" ? "N·mm" : "N";
+  const parts = loadComponents(g)
+    .map((v, i) => (v !== 0 ? `${labels[i]} = ${fmt(v)}` : null))
+    .filter((p): p is string => p !== null);
+  return `${parts.join(", ")} ${unit}`;
+}
+
 function ConstraintsPanel() {
   const nodes = useModelStore((s) => s.nodes);
   const bcGroups = useModelStore((s) => s.bcGroups);
@@ -616,17 +636,27 @@ function ConstraintsPanel() {
     false,
     false,
   ]);
-  const [loadDof, setLoadDof] = useState(1);
-  const [loadForce, setLoadForce] = useState("-10000");
+  // A load is defined in two steps (issues #219, #190): pick the kind, then
+  // prescribe each component on its own — like the displacement BC above. Force
+  // and moment carry a [x,y,z] vector; pressure is a single scalar.
+  const [loadKindSel, setLoadKindSel] = useState<LoadKind>("force");
+  const [forceVec, setForceVec] = useState<[string, string, string]>([
+    "0",
+    "-10000",
+    "0",
+  ]);
+  const [momentVec, setMomentVec] = useState<[string, string, string]>([
+    "0",
+    "0",
+    "1000",
+  ]);
+  const [pressureVal, setPressureVal] = useState("10");
   const [bcValue, setBcValue] = useState("0");
   const [error, setError] = useState<string | null>(null);
 
   const DOF_LABELS = ["Ux", "Uy", "Uz", "Rx", "Ry", "Rz"];
-  // Indices 0–5 are direction DOFs (Fx…Mz); index 6 is the directionless pressure
-  // load. Force/pressure loads are applied as work-equivalent surface tractions.
-  const LOAD_LABELS = ["Fx", "Fy", "Fz", "Mx", "My", "Mz", "Pressure"];
-  const PRESSURE_OPTION = 6;
-  const isPressureLoad = loadDof === PRESSURE_OPTION;
+  const FORCE_LABELS = ["Fx", "Fy", "Fz"];
+  const MOMENT_LABELS = ["Mx", "My", "Mz"];
 
   // Boundary conditions and loads reference mesh nodes, so they can only be
   // defined once a volume mesh exists.
@@ -697,25 +727,36 @@ function ConstraintsPanel() {
     }));
     if (targetLoadGroup) {
       for (const fe of faceEntries) addFaceToLoadGroup(targetLoadGroup.id, fe);
-    } else {
-      // A zero force is a no-op load: it contributes nothing to the RHS and the
-      // solver returns a plausible-looking field with the input silently
+    } else if (loadKindSel === "pressure") {
+      // A zero pressure is a no-op load: it contributes nothing to the RHS and
+      // the solver returns a plausible-looking field with the input silently
       // discarded. Reject it (and non-finite input) instead of coercing to 0.
-      const value = parseFloat(loadForce);
-      if (!isFinite(value) || value === 0) {
-        setError(
-          isPressureLoad
-            ? "Pressure must be a non-zero finite number"
-            : "Load force must be a non-zero finite number",
-        );
+      const p = parseFloat(pressureVal);
+      if (!isFinite(p) || p === 0) {
+        setError("Pressure must be a non-zero finite number");
         return;
       }
-      createLoadGroup(
-        faceEntries,
-        isPressureLoad ? 0 : loadDof,
-        value,
-        isPressureLoad ? "pressure" : loadDof <= 2 ? "force" : "moment",
+      createLoadGroup(faceEntries, 0, p, "pressure");
+    } else {
+      // Force / moment, prescribed componentwise. Reject non-finite components
+      // and the all-zero vector (a no-op load that would be silently discarded).
+      const noun = loadKindSel === "moment" ? "moment" : "force";
+      const parsed = (loadKindSel === "moment" ? momentVec : forceVec).map(
+        (v) => parseFloat(v),
       );
+      if (parsed.some((v) => !isFinite(v))) {
+        setError(`Each ${noun} component must be a finite number`);
+        return;
+      }
+      if (parsed.every((v) => v === 0)) {
+        setError(`Specify a non-zero ${noun} component`);
+        return;
+      }
+      createLoadGroup(faceEntries, 0, 0, loadKindSel, [
+        parsed[0],
+        parsed[1],
+        parsed[2],
+      ]);
     }
     setError(null);
     setPickMode(null);
@@ -937,40 +978,75 @@ function ConstraintsPanel() {
 
                 {allPickedFaces.length > 0 && !targetLoadGroup && (
                   <>
+                    {/* Step 1 — pick the load kind. */}
                     <div className={styles.formRow}>
-                      <span className={styles.formLabel}>DOF</span>
+                      <span className={styles.formLabel}>Type</span>
                       <select
                         className={styles.formSelect}
-                        value={loadDof}
-                        onChange={(e) => setLoadDof(Number(e.target.value))}
+                        value={loadKindSel}
+                        onChange={(e) =>
+                          setLoadKindSel(e.target.value as LoadKind)
+                        }
                       >
-                        {LOAD_LABELS.map((d, i) => (
-                          <option key={d} value={i}>
-                            {d}
-                          </option>
-                        ))}
+                        <option value="force">Force</option>
+                        <option value="moment">Moment</option>
+                        <option value="pressure">Pressure</option>
                       </select>
                     </div>
-                    <div className={styles.formRow}>
-                      <span className={styles.formLabel}>
-                        {isPressureLoad
-                          ? "Pressure (MPa)"
-                          : loadDof <= 2
-                            ? "Total (N)"
-                            : "Total (N·m)"}
-                      </span>
-                      <input
-                        className={styles.formInput}
-                        type="number"
-                        value={loadForce}
-                        step="100"
-                        onChange={(e) => setLoadForce(e.target.value)}
-                      />
-                    </div>
+
+                    {/* Step 2 — prescribe each component on its own. */}
+                    {loadKindSel === "pressure" ? (
+                      <div className={styles.formRow}>
+                        <span className={styles.formLabel}>Pressure (MPa)</span>
+                        <input
+                          className={styles.formInput}
+                          type="number"
+                          value={pressureVal}
+                          step="1"
+                          onChange={(e) => setPressureVal(e.target.value)}
+                        />
+                      </div>
+                    ) : (
+                      (loadKindSel === "moment"
+                        ? MOMENT_LABELS
+                        : FORCE_LABELS
+                      ).map((label, i) => {
+                        const vec =
+                          loadKindSel === "moment" ? momentVec : forceVec;
+                        const setVec =
+                          loadKindSel === "moment" ? setMomentVec : setForceVec;
+                        const unit = loadKindSel === "moment" ? "N·mm" : "N";
+                        return (
+                          <div className={styles.formRow} key={label}>
+                            <span className={styles.formLabel}>
+                              {label} ({unit})
+                            </span>
+                            <input
+                              className={styles.formInput}
+                              type="number"
+                              value={vec[i]}
+                              step="100"
+                              onChange={(e) => {
+                                const value = e.target.value;
+                                setVec((p) => {
+                                  const next = [...p] as [
+                                    string,
+                                    string,
+                                    string,
+                                  ];
+                                  next[i] = value;
+                                  return next;
+                                });
+                              }}
+                            />
+                          </div>
+                        );
+                      })
+                    )}
                     <div className={styles.pickNote}>
-                      {isPressureLoad
+                      {loadKindSel === "pressure"
                         ? "applied as p·n̂ over each face (work-equivalent)"
-                        : loadDof <= 2
+                        : loadKindSel === "force"
                           ? "applied as a work-equivalent surface traction"
                           : "distributed as equivalent nodal forces"}
                     </div>
@@ -996,13 +1072,7 @@ function ConstraintsPanel() {
                 <div className={styles.bcGroupHeader}>
                   <span className={styles.loadDot} />
                   <span className={styles.bcGroupName}>{g.name}</span>
-                  <span className={styles.bcGroupMeta}>
-                    {loadKind(g) === "pressure"
-                      ? `p = ${fmt(g.totalForce)} MPa`
-                      : `${LOAD_LABELS[g.dof]} = ${fmt(g.totalForce)} ${
-                          g.dof <= 2 ? "N" : "N·m"
-                        }`}
-                  </span>
+                  <span className={styles.bcGroupMeta}>{loadGroupMeta(g)}</span>
                   <div className={styles.treeItemActions}>
                     <button
                       className={styles.iconBtn}

--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -742,13 +742,13 @@ function ConstraintsPanel() {
       // and the all-zero vector (a no-op load that would be silently discarded).
       const noun = loadKindSel === "moment" ? "moment" : "force";
       const parsed = (loadKindSel === "moment" ? momentVec : forceVec).map(
-        (v) => parseFloat(v),
+        (comp) => parseFloat(comp),
       );
-      if (parsed.some((v) => !isFinite(v))) {
+      if (parsed.some((comp) => !isFinite(comp))) {
         setError(`Each ${noun} component must be a finite number`);
         return;
       }
-      if (parsed.every((v) => v === 0)) {
+      if (parsed.every((comp) => comp === 0)) {
         setError(`Specify a non-zero ${noun} component`);
         return;
       }

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -734,8 +734,8 @@ export function MeshScene() {
       if (kind === "pressure") {
         dir = new THREE.Vector3(mx - cx, my - cy, mz - cz);
       } else {
-        const f = loadComponents(g);
-        dir = new THREE.Vector3(f[0], f[1], f[2]);
+        const vec = loadComponents(g);
+        dir = new THREE.Vector3(vec[0], vec[1], vec[2]);
       }
       if (dir.lengthSq() < 1e-30) continue;
       dir.normalize();

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -4,7 +4,11 @@
 import { useMemo } from "react";
 import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
-import { useModelStore, loadKind } from "../../store/modelStore";
+import {
+  useModelStore,
+  loadKind,
+  loadComponents,
+} from "../../store/modelStore";
 import type { Node, ResultType } from "../../store/modelStore";
 import {
   buildBoundaryMeshTopo,
@@ -730,9 +734,8 @@ export function MeshScene() {
       if (kind === "pressure") {
         dir = new THREE.Vector3(mx - cx, my - cy, mz - cz);
       } else {
-        const d = [0, 0, 0];
-        d[g.dof] = g.totalForce;
-        dir = new THREE.Vector3(d[0], d[1], d[2]);
+        const f = loadComponents(g);
+        dir = new THREE.Vector3(f[0], f[1], f[2]);
       }
       if (dir.lengthSq() < 1e-30) continue;
       dir.normalize();
@@ -842,26 +845,26 @@ export function MeshScene() {
       if (totalArea < 1e-30) continue;
 
       // Force direction is shared by every node; pressure direction is per-node.
+      const force = loadComponents(g);
+      const forceMag = Math.hypot(force[0], force[1], force[2]);
       const forceDir = new THREE.Vector3();
       if (kind === "force") {
-        const d = [0, 0, 0];
-        d[g.dof] = g.totalForce;
-        forceDir.set(d[0], d[1], d[2]);
-        if (forceDir.lengthSq() < 1e-30) continue;
-        forceDir.normalize();
+        if (forceMag < 1e-30) continue;
+        forceDir.set(force[0], force[1], force[2]).normalize();
       }
-      const sign = g.totalForce < 0 ? -1 : 1;
+      // Pressure stores its (signed) magnitude in totalForce; positive pushes in.
+      const pressureSign = g.totalForce < 0 ? -1 : 1;
 
       for (const [id, a] of tribArea) {
         let dir: THREE.Vector3;
         let mag: number;
         if (kind === "force") {
           dir = forceDir;
-          mag = Math.abs(g.totalForce) * (a / totalArea);
+          mag = forceMag * (a / totalArea);
         } else {
           const acc = inward.get(id);
           if (!acc || acc.lengthSq() < 1e-30) continue;
-          dir = acc.clone().normalize().multiplyScalar(sign);
+          dir = acc.clone().normalize().multiplyScalar(pressureSign);
           mag = Math.abs(g.totalForce) * a; // p · Aᵢ
         }
         if (mag < 1e-30) continue;

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -144,12 +144,12 @@ export function loadKind(g: NamedLoadGroup): LoadKind {
 // axis dof−3). Pressure groups have no vector and return zeros.
 export function loadComponents(g: NamedLoadGroup): [number, number, number] {
   if (g.components) return g.components;
-  const v: [number, number, number] = [0, 0, 0];
+  const vec: [number, number, number] = [0, 0, 0];
   const kind = loadKind(g);
-  if (kind === "force" && g.dof >= 0 && g.dof <= 2) v[g.dof] = g.totalForce;
+  if (kind === "force" && g.dof >= 0 && g.dof <= 2) vec[g.dof] = g.totalForce;
   else if (kind === "moment" && g.dof >= 3 && g.dof <= 5)
-    v[g.dof - 3] = g.totalForce;
-  return v;
+    vec[g.dof - 3] = g.totalForce;
+  return vec;
 }
 
 // Legacy single-axis summary (primary axis + signed magnitude) of a componentwise
@@ -161,9 +161,12 @@ function summarizeComponents(
   components: [number, number, number],
   kind: LoadKind,
 ): { dof: number; totalForce: number } {
-  const axis = components.findIndex((v) => v !== 0);
-  const a = axis < 0 ? 0 : axis;
-  return { dof: kind === "moment" ? a + 3 : a, totalForce: components[a] };
+  const found = components.findIndex((value) => value !== 0);
+  const axis = found < 0 ? 0 : found;
+  return {
+    dof: kind === "moment" ? axis + 3 : axis,
+    totalForce: components[axis],
+  };
 }
 
 // A work-equivalent surface load handed to the engine's boundary integrator.

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -121,6 +121,13 @@ export interface NamedLoadGroup {
   name: string; // e.g. "Load1"
   dof: number; // force: 0=Fx,1=Fy,2=Fz · moment: 3=Mx,4=My,5=Mz · pressure: unused
   totalForce: number; // force/moment magnitude (N, N·mm), or pressure magnitude (MPa)
+  // Componentwise force [Fx,Fy,Fz] (N) or moment [Mx,My,Mz] (N·mm) vector
+  // (issues #219, #190). Present on force/moment groups created via the
+  // componentwise UI, where it is the source of truth and supersedes
+  // dof/totalForce. Absent on pressure groups and on payloads saved before
+  // componentwise input existed — those reconstruct the vector from dof +
+  // totalForce via loadComponents().
+  components?: [number, number, number];
   faces: BcFaceEntry[];
   kind?: LoadKind;
 }
@@ -129,6 +136,34 @@ export interface NamedLoadGroup {
 // have no explicit `kind` (dof ≤ 2 ⇒ force, dof ≥ 3 ⇒ moment).
 export function loadKind(g: NamedLoadGroup): LoadKind {
   return g.kind ?? (g.dof <= 2 ? "force" : "moment");
+}
+
+// The force [Fx,Fy,Fz] (N) or moment [Mx,My,Mz] (N·mm) vector of a load group.
+// Uses the explicit componentwise vector when present, else reconstructs the
+// single-axis vector from the legacy dof + totalForce (force: axis 0–2; moment:
+// axis dof−3). Pressure groups have no vector and return zeros.
+export function loadComponents(g: NamedLoadGroup): [number, number, number] {
+  if (g.components) return g.components;
+  const v: [number, number, number] = [0, 0, 0];
+  const kind = loadKind(g);
+  if (kind === "force" && g.dof >= 0 && g.dof <= 2) v[g.dof] = g.totalForce;
+  else if (kind === "moment" && g.dof >= 3 && g.dof <= 5)
+    v[g.dof - 3] = g.totalForce;
+  return v;
+}
+
+// Legacy single-axis summary (primary axis + signed magnitude) of a componentwise
+// vector, stored alongside `components` so older readers and the pre-flight
+// fallback still see a sensible dof/totalForce. For a single non-zero component
+// this reproduces the vector exactly; for a general vector it names the first
+// non-zero axis. `components` remains the source of truth.
+function summarizeComponents(
+  components: [number, number, number],
+  kind: LoadKind,
+): { dof: number; totalForce: number } {
+  const axis = components.findIndex((v) => v !== 0);
+  const a = axis < 0 ? 0 : axis;
+  return { dof: kind === "moment" ? a + 3 : a, totalForce: components[a] };
 }
 
 // A work-equivalent surface load handed to the engine's boundary integrator.
@@ -217,12 +252,16 @@ function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
     // Force and pressure loads are applied as work-equivalent surface tractions
     // (rebuildSurfaceLoads), not lumped nodal forces — they are skipped here.
     if (loadKind(g) !== "moment") continue;
-    {
-      // Moment load (dof 3=Mx, 4=My, 5=Mz) — convert to equivalent nodal forces.
-      // For each face, find the centroid, then apply tangential forces F_i = M/S·(n̂×r_i)
+    // A moment may be specified componentwise [Mx,My,Mz]; each non-zero axis is
+    // converted independently and its nodal forces summed (superposition).
+    const moment = loadComponents(g);
+    for (let momentAxis = 0; momentAxis < 3; momentAxis++) {
+      const momentMag = moment[momentAxis]; // about x (0), y (1) or z (2)
+      if (momentMag === 0) continue;
+      // Moment about one axis — convert to equivalent nodal forces. For each
+      // face, find the centroid, then apply tangential forces F_i = M/S·(n̂×r_i)
       // where S = Σ|r_i⊥|² (perpendicular distance squared from moment axis).
       // This satisfies Σ(r_i × F_i) = M exactly with zero net force.
-      const momentAxis = g.dof - 3; // 0=x, 1=y, 2=z
       let skippedFaces = 0;
       for (const f of g.faces) {
         let cx = 0,
@@ -261,7 +300,7 @@ function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
           continue;
         }
 
-        const scale = g.totalForce / S;
+        const scale = momentMag / S;
         for (const nodeId of f.nodeIds) {
           const n = nodeById.get(nodeId);
           if (!n) continue;
@@ -284,11 +323,12 @@ function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
         }
       }
       if (skippedFaces > 0) {
+        const axisName = ["Mx", "My", "Mz"][momentAxis];
         console.warn(
-          `[moment load] "${g.name}": ${skippedFaces} of ${g.faces.length} ` +
-            "face(s) skipped — all of their nodes lie on the moment axis, so " +
-            "the applied moment is incomplete. Choose a different moment axis " +
-            "or face selection.",
+          `[moment load] "${g.name}" (${axisName}): ${skippedFaces} of ` +
+            `${g.faces.length} face(s) skipped — all of their nodes lie on the ` +
+            "moment axis, so the applied moment is incomplete. Choose a " +
+            "different moment axis or face selection.",
         );
       }
     }
@@ -318,9 +358,7 @@ function rebuildSurfaceLoads(
       if (kind === "pressure") {
         result.push({ type: "pressure", pressure: g.totalForce, faces });
       } else {
-        const force: [number, number, number] = [0, 0, 0];
-        force[g.dof] = g.totalForce;
-        result.push({ type: "force", force, faces });
+        result.push({ type: "force", force: loadComponents(g), faces });
       }
     }
   }
@@ -452,6 +490,7 @@ interface ModelState {
     dof: number,
     totalForce: number,
     kind?: LoadKind,
+    components?: [number, number, number],
   ): void;
   addFaceToLoadGroup(groupId: number, face: Omit<BcFaceEntry, "id">): void;
   removeFaceFromLoadGroup(groupId: number, faceId: number): void;
@@ -849,9 +888,10 @@ export const useModelStore = create<ModelState>()(
     // Load group actions
     createLoadGroup: (
       faces: Omit<BcFaceEntry, "id">[],
-      dof: number,
-      totalForce: number,
-      kind: LoadKind = dof <= 2 ? "force" : "moment",
+      dofArg: number,
+      totalForceArg: number,
+      kind: LoadKind = dofArg <= 2 ? "force" : "moment",
+      components?: [number, number, number],
     ) =>
       set((s) => {
         const faceEntries = faces.map((f) => ({
@@ -859,11 +899,17 @@ export const useModelStore = create<ModelState>()(
           label: f.label,
           nodeIds: f.nodeIds,
         }));
+        // A componentwise force/moment carries its vector in `components` (the
+        // source of truth); dof/totalForce are derived as a legacy summary.
+        const { dof, totalForce } = components
+          ? summarizeComponents(components, kind)
+          : { dof: dofArg, totalForce: totalForceArg };
         s.loadGroups.push({
           id: s.nextLoadGroupId,
           name: `Load${s.nextLoadGroupId}`,
           dof,
           totalForce,
+          ...(components ? { components } : {}),
           faces: faceEntries,
           kind,
         });

--- a/web/tests/componentwise-loads.spec.ts
+++ b/web/tests/componentwise-loads.spec.ts
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from "./coverage";
+import { bootstrapCantilever } from "./fixtures/cantilever";
+
+// Coverage for issues #219 / #190: forces (and moments) specified componentwise
+// — a full [x, y, z] vector instead of a single axis + magnitude.
+
+type Store = {
+  getState(): {
+    nodes: { id: number; x: number; y: number; z: number }[];
+    loads: { nodeId: number; dof: number; value: number }[];
+    surfaceLoads: {
+      type: string;
+      force?: [number, number, number];
+      faces: number[][];
+    }[];
+    loadGroups: {
+      kind?: string;
+      dof: number;
+      totalForce: number;
+      components?: [number, number, number];
+    }[];
+    clearLoads(): void;
+    createLoadGroup(
+      faces: { label: string; nodeIds: number[] }[],
+      dof: number,
+      totalForce: number,
+      kind?: string,
+      components?: [number, number, number],
+    ): void;
+  };
+};
+
+// ── Componentwise force ───────────────────────────────────────────────────────
+
+test("a componentwise force builds surface loads carrying the full vector", async ({
+  page,
+}) => {
+  await bootstrapCantilever(page);
+
+  const result = await page.evaluate(() => {
+    const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
+    const endNodes = store
+      .getState()
+      .nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    store.getState().clearLoads();
+    store
+      .getState()
+      .createLoadGroup(
+        [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
+        0,
+        0,
+        "force",
+        [100, -200, 300],
+      );
+    const s = store.getState();
+    return {
+      group: s.loadGroups[0],
+      surfaceLoads: s.surfaceLoads,
+      nodalLoads: s.loads.length,
+    };
+  });
+
+  // The vector is stored verbatim as the source of truth.
+  expect(result.group.components).toEqual([100, -200, 300]);
+  expect(result.group.kind).toBe("force");
+  // Forces reach the solver as surface tractions, never lumped nodal forces.
+  expect(result.nodalLoads).toBe(0);
+  expect(result.surfaceLoads.length).toBeGreaterThan(0);
+  for (const sl of result.surfaceLoads) {
+    expect(sl.type).toBe("force");
+    expect(sl.force).toEqual([100, -200, 300]);
+  }
+});
+
+test("a single-axis legacy force still maps onto the surface-load vector", async ({
+  page,
+}) => {
+  await bootstrapCantilever(page);
+
+  // The 3-arg createLoadGroup (no components) is the legacy single-axis form
+  // used by older saved analyses and the fixtures; it must reconstruct the
+  // same surface-load vector that componentwise input produces.
+  const result = await page.evaluate(() => {
+    const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
+    const endNodes = store
+      .getState()
+      .nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    store.getState().clearLoads();
+    store
+      .getState()
+      .createLoadGroup(
+        [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
+        1,
+        -5000,
+      );
+    return store.getState().surfaceLoads;
+  });
+
+  expect(result.length).toBeGreaterThan(0);
+  for (const sl of result) expect(sl.force).toEqual([0, -5000, 0]);
+});
+
+// ── Componentwise moment ──────────────────────────────────────────────────────
+
+test("a componentwise moment sums per-axis couples with zero net force", async ({
+  page,
+}) => {
+  await bootstrapCantilever(page);
+
+  const result = await page.evaluate(() => {
+    const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
+    const endNodes = store
+      .getState()
+      .nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    store.getState().clearLoads();
+    // Simultaneous Mx and Mz applied componentwise.
+    store
+      .getState()
+      .createLoadGroup(
+        [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
+        0,
+        0,
+        "moment",
+        [500, 0, 1000],
+      );
+
+    const loads = store.getState().loads;
+    const cx = endNodes.reduce((s, n) => s + n.x, 0) / endNodes.length;
+    const cy = endNodes.reduce((s, n) => s + n.y, 0) / endNodes.length;
+    const cz = endNodes.reduce((s, n) => s + n.z, 0) / endNodes.length;
+
+    const nodeById = new Map(endNodes.map((n) => [n.id, n]));
+    let netFx = 0,
+      netFy = 0,
+      netFz = 0,
+      netMx = 0,
+      netMz = 0;
+    for (const l of loads) {
+      const n = nodeById.get(l.nodeId)!;
+      const rx = n.x - cx,
+        ry = n.y - cy,
+        rz = n.z - cz;
+      if (l.dof === 0) {
+        netFx += l.value;
+        netMz -= ry * l.value;
+      }
+      if (l.dof === 1) {
+        netFy += l.value;
+        netMx -= rz * l.value;
+        netMz += rx * l.value;
+      }
+      if (l.dof === 2) {
+        netFz += l.value;
+        netMx += ry * l.value;
+      }
+    }
+    return { netFx, netFy, netFz, netMx, netMz, loads };
+  });
+
+  // Every resulting load is a force DOF (the moment is lumped to nodal forces).
+  expect(result.loads.every((l) => l.dof <= 2)).toBe(true);
+  // Pure couples: no net force in any direction.
+  expect(result.netFx).toBeCloseTo(0, 9);
+  expect(result.netFy).toBeCloseTo(0, 9);
+  expect(result.netFz).toBeCloseTo(0, 9);
+  // Net moment matches the applied vector on each axis.
+  expect(result.netMx).toBeCloseTo(500, 6);
+  expect(result.netMz).toBeCloseTo(1000, 6);
+});
+
+// ── Solve integration ─────────────────────────────────────────────────────────
+
+test("solve completes with a componentwise force load", async ({ page }) => {
+  await bootstrapCantilever(page);
+
+  const result = (await page.evaluate(async () => {
+    const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
+    const endNodes = store
+      .getState()
+      .nodes.filter((n) => Math.abs(n.x - 1.0) < 1e-9);
+    store.getState().clearLoads();
+    store
+      .getState()
+      .createLoadGroup(
+        [{ label: "End face", nodeIds: endNodes.map((n) => n.id) }],
+        0,
+        0,
+        "force",
+        [3000, -10000, 0],
+      );
+
+    const s = store.getState() as unknown as {
+      nodes: unknown[];
+      elements: unknown[];
+      materials: unknown[];
+      properties: unknown[];
+      constraints: unknown[];
+      loads: unknown[];
+      surfaceLoads: unknown[];
+    };
+    const kofem = (
+      window as unknown as {
+        __kofem: {
+          sendToWorker(name: string, payload: object): Promise<unknown>;
+        };
+      }
+    ).__kofem;
+    return kofem.sendToWorker("solve", {
+      nodes: s.nodes,
+      elements: s.elements,
+      materials: s.materials,
+      properties: s.properties,
+      constraints: s.constraints,
+      loads: s.loads,
+      surfaceLoads: s.surfaceLoads,
+    });
+  })) as { displacements: number[] };
+
+  expect(result.displacements.length).toBeGreaterThan(0);
+  expect(result.displacements.every((v) => Number.isFinite(v))).toBe(true);
+  // A force with both an x and y component must bend the beam in both: the tip
+  // displacement field is non-trivial in both directions.
+  let maxUx = 0,
+    maxUy = 0;
+  for (let i = 0; i < result.displacements.length; i += 3) {
+    maxUx = Math.max(maxUx, Math.abs(result.displacements[i]));
+    maxUy = Math.max(maxUy, Math.abs(result.displacements[i + 1]));
+  }
+  expect(maxUx).toBeGreaterThan(0);
+  expect(maxUy).toBeGreaterThan(0);
+});

--- a/web/tests/componentwise-loads.spec.ts
+++ b/web/tests/componentwise-loads.spec.ts
@@ -55,11 +55,11 @@ test("a componentwise force builds surface loads carrying the full vector", asyn
         "force",
         [100, -200, 300],
       );
-    const s = store.getState();
+    const state = store.getState();
     return {
-      group: s.loadGroups[0],
-      surfaceLoads: s.surfaceLoads,
-      nodalLoads: s.loads.length,
+      group: state.loadGroups[0],
+      surfaceLoads: state.surfaceLoads,
+      nodalLoads: state.loads.length,
     };
   });
 
@@ -139,7 +139,8 @@ test("a componentwise moment sums per-axis couples with zero net force", async (
       netMx = 0,
       netMz = 0;
     for (const l of loads) {
-      const n = nodeById.get(l.nodeId)!;
+      const n = nodeById.get(l.nodeId);
+      if (!n) throw new Error(`load references unknown node ${l.nodeId}`);
       const rx = n.x - cx,
         ry = n.y - cy,
         rz = n.z - cz;
@@ -176,7 +177,7 @@ test("a componentwise moment sums per-axis couples with zero net force", async (
 test("solve completes with a componentwise force load", async ({ page }) => {
   await bootstrapCantilever(page);
 
-  const result = (await page.evaluate(async () => {
+  const result = (await page.evaluate(() => {
     const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
     const endNodes = store
       .getState()
@@ -192,7 +193,7 @@ test("solve completes with a componentwise force load", async ({ page }) => {
         [3000, -10000, 0],
       );
 
-    const s = store.getState() as unknown as {
+    const state = store.getState() as unknown as {
       nodes: unknown[];
       elements: unknown[];
       materials: unknown[];
@@ -209,13 +210,13 @@ test("solve completes with a componentwise force load", async ({ page }) => {
       }
     ).__kofem;
     return kofem.sendToWorker("solve", {
-      nodes: s.nodes,
-      elements: s.elements,
-      materials: s.materials,
-      properties: s.properties,
-      constraints: s.constraints,
-      loads: s.loads,
-      surfaceLoads: s.surfaceLoads,
+      nodes: state.nodes,
+      elements: state.elements,
+      materials: state.materials,
+      properties: state.properties,
+      constraints: state.constraints,
+      loads: state.loads,
+      surfaceLoads: state.surfaceLoads,
     });
   })) as { displacements: number[] };
 


### PR DESCRIPTION
## Summary

Extends the load specification UI to accept force and moment loads as full [x, y, z] vectors instead of a single axis + magnitude. This allows users to apply multi-directional loads in a single operation and simplifies the mental model for load definition.

## Changes

- **UI refactor (LeftPanel.tsx)**: Replaced the single "DOF" dropdown with a two-step load definition:
  1. Pick the load kind (Force / Moment / Pressure)
  2. Prescribe each component independently (Fx, Fy, Fz or Mx, My, Mz or scalar pressure)
  - Added `loadGroupMeta()` helper to display componentwise vectors in the load group list (e.g., "Fx = 100, Fz = -50 N")
  - Validation now rejects non-finite components and all-zero vectors

- **Store schema (modelStore.ts)**: 
  - Added optional `components?: [number, number, number]` field to `NamedLoadGroup` to store the full force/moment vector
  - New `loadComponents()` function extracts the vector from either the explicit `components` field (new loads) or reconstructs it from legacy `dof + totalForce` (backward compatibility)
  - New `summarizeComponents()` helper derives a legacy `dof/totalForce` summary from a componentwise vector for older readers and pre-flight fallback
  - Updated `rebuildLoads()` to handle multi-axis moments by iterating over each non-zero component and summing the equivalent nodal forces (superposition)
  - Updated `rebuildSurfaceLoads()` to use `loadComponents()` for force vectors

- **Viewport (MeshScene.tsx)**: Updated load visualization to use `loadComponents()` instead of reconstructing the vector from `dof + totalForce`

- **Tests (componentwise-loads.spec.ts)**: Comprehensive coverage for:
  - Componentwise force loads produce surface tractions with the full vector
  - Legacy single-axis forces still map correctly to surface loads
  - Componentwise moments distribute as equivalent nodal forces with zero net force and correct moment resultant
  - Solver integration with multi-directional loads produces valid displacements in all affected directions

## Implementation Details

- **Backward compatibility**: Loads saved before componentwise input (or created via the legacy 3-arg `createLoadGroup`) have no `components` field; `loadComponents()` reconstructs the vector from `dof + totalForce` transparently.
- **Moment handling**: A componentwise moment [Mx, My, Mz] is decomposed into three independent single-axis moments, each converted to equivalent nodal forces via the existing couple algorithm. This allows simultaneous moments about multiple axes.
- **Source of truth**: When `components` is present, it is the authoritative load specification; `dof` and `totalForce` are derived summaries for compatibility.

closes #219
closes #190

https://claude.ai/code/session_019Qdjryqxe37qJTQSwv3zMx