### PR TITLE
Remove duplicate validation tests from test script

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit",
     "validate": "bun ../examples/validation/run.mjs",
     "examples:generate": "bun ../examples/web-examples/generate.mjs",
-    "test": "bun ../examples/validation/run.mjs && bun ../examples/validation/dof-constraint.test.mjs && bun ../examples/validation/prescribed-displacement.test.mjs && bun tests/test_wall_bracket.mjs 20.0 && bun tests/test_face_pick.mjs && bun ../examples/validation/dof-constraint.test.mjs && bun ../examples/validation/prescribed-displacement.test.mjs && playwright test",
+    "test": "bun ../examples/validation/run.mjs && bun ../examples/validation/dof-constraint.test.mjs && bun ../examples/validation/prescribed-displacement.test.mjs && bun tests/test_wall_bracket.mjs 20.0 && bun tests/test_face_pick.mjs && playwright test",
     "test:coverage": "rm -rf .nyc_output coverage && COVERAGE=1 playwright test && bun run coverage:report",
     "coverage:report": "nyc report && bun scripts/coverage-dead-code.ts",
     "test:ui": "playwright test --ui",


### PR DESCRIPTION
## Summary
Removes duplicate test invocations from the web package test script that were running the same validation tests twice.

## Changes
- Removed redundant `bun ../examples/validation/dof-constraint.test.mjs` and `bun ../examples/validation/prescribed-displacement.test.mjs` invocations that were being executed twice in sequence
- The test script now runs each validation test only once before proceeding to the remaining tests

## Details
The test command was running the DOF constraint and prescribed displacement validation tests twice consecutively, which was unnecessary and increased test execution time without adding value. This cleanup simplifies the test pipeline while maintaining full test coverage.

https://claude.ai/code/session_01FihiszPfBEWyhBeFutr1oH