### PR TITLE
Add validation to reject multi-material models in solver

### DIFF
--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -353,6 +353,12 @@ self.onmessage = async (event: MessageEvent) => {
           "solve: no material assigned — assign a material before running the solver",
         );
       }
+      if (materials.length > 1) {
+        throw new Error(
+          `Multi-material models are not yet supported: ${materials.length} materials defined. ` +
+            "Only a single material can be assigned. Remove all but one material before solving.",
+        );
+      }
       const material = {
         young_modulus: mat.young,
         poisson_ratio: mat.poisson,


### PR DESCRIPTION
## Summary

Add an explicit validation check in the solver worker to reject models with multiple materials, since multi-material FEM analysis is not yet supported. This prevents silent failures or incorrect results when users attempt to solve with more than one material assigned.

## Changes

- Added a check after material validation that throws a descriptive error if more than one material is defined
- Error message clearly indicates the limitation and instructs users to remove all but one material before solving

## Implementation Details

The validation is placed immediately after the existing "no material assigned" check, ensuring we catch the multi-material case before attempting to construct the material object for the solver. The error message follows the existing pattern and provides actionable guidance to users.

https://claude.ai/code/session_01C3W3QhoDmvX6pudaGVsuTf