### PR TITLE
Make mesh optimization steps configurable via JSON options

### DIFF
--- a/engine/cpp/mesh_netgen.cpp
+++ b/engine/cpp/mesh_netgen.cpp
@@ -105,8 +105,8 @@ std::string generate_fem_mesh(const std::string& opts_json)
     bool   second_ord      = jbool  (opts, "second_order",       false);
     double elems_per_edge  = jdouble(opts, "elementsperedge",     2.0);
     double elems_per_curve = jdouble(opts, "elementspercurve",    2.0);
-    int    optsteps_2d     = jint   (opts, "optsteps_2d",           3);
-    int    optsteps_3d     = jint   (opts, "optsteps_3d",           3);
+    int    optsteps_2d     = jint   (opts, "optsteps_2d",           0);
+    int    optsteps_3d     = jint   (opts, "optsteps_3d",           0);
 
 #ifdef KOFEM_NETGEN_OCC
     // ── OCC path: Netgen meshes the CAD geometry directly ────────────────────
@@ -145,11 +145,12 @@ std::string generate_fem_mesh(const std::string& opts_json)
     mp.meshsize_filename          = nullptr;
     mp.optsurfmeshenable          = 1;
     mp.optvolmeshenable           = 1;
-    // Skip both surface and volume optimisation: for complex CAD (many faces,
-    // short edges) the optimiser reprojects nodes onto OCC surfaces in a loop
-    // that runs for minutes.  The unoptimised mesh is adequate for FEM analysis.
-    mp.optsteps_2d                = 0;
-    mp.optsteps_3d                = 0;
+    // Optimisation defaults to 0 (skipped): for complex CAD (many faces, short
+    // edges) the optimiser reprojects nodes onto OCC surfaces in a loop that
+    // can run for minutes. Callers can opt in via optsteps_2d/optsteps_3d for
+    // a higher-quality (slower) mesh.
+    mp.optsteps_2d                = optsteps_2d;
+    mp.optsteps_3d                = optsteps_3d;
     mp.invert_tets                = 0;
     mp.invert_trigs               = 0;
     mp.check_overlap              = 0;


### PR DESCRIPTION
## Summary

Expose Netgen's 2D and 3D mesh optimization step counts as configurable parameters in the FEM mesh generation API, allowing callers to trade off mesh quality for generation speed.

## Changes

- **Default optimization steps**: Changed `optsteps_2d` and `optsteps_3d` default values from 3 to 0 in the JSON options parser, maintaining the existing behavior of skipping optimization by default for complex CAD geometries.
- **Configurable optimization**: Modified the Netgen mesh parameters to use the parsed `optsteps_2d` and `optsteps_3d` values instead of hardcoded zeros, enabling callers to opt in to higher-quality (slower) mesh generation by passing these options.
- **Documentation**: Updated the comment explaining the optimization strategy to clarify that optimization is now configurable and that callers can enable it for better mesh quality when needed.

## Implementation Details

The change allows the mesh generation pipeline to respect user-provided optimization parameters while maintaining backward compatibility—existing callers that don't specify these options will continue to get fast, unoptimized meshes suitable for FEM analysis on complex CAD models. Callers requiring higher-quality meshes can now pass `"optsteps_2d"` and `"optsteps_3d"` in the options JSON to enable Netgen's surface and volume optimization loops.

https://claude.ai/code/session_01AabNBHkUhKK1uFVs9H5bX5