### PR TITLE
Add inline editors for BC and load group values (issue #258)

### DIFF
--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -574,8 +574,8 @@ function BcValueForm({
   function handleSave() {
     // A prescribed displacement of 0 is physically valid (fixed support), so
     // only reject non-finite input — never silently coerce "abc" to 0.
-    const v = parseFloat(value);
-    if (!isFinite(v)) {
+    const parsedValue = parseFloat(value);
+    if (!isFinite(parsedValue)) {
       setError("Prescribed displacement must be a finite number");
       return;
     }
@@ -584,7 +584,7 @@ function BcValueForm({
       setError("Constrain at least one DOF");
       return;
     }
-    onSave(dofs, v);
+    onSave(dofs, parsedValue);
   }
 
   return (
@@ -668,12 +668,12 @@ function LoadValueForm({
       // A zero pressure is a no-op load: it contributes nothing to the RHS and
       // the solver returns a plausible-looking field with the input silently
       // discarded. Reject it (and non-finite input) instead of coercing to 0.
-      const p = parseFloat(pressureVal);
-      if (!isFinite(p) || p === 0) {
+      const pressure = parseFloat(pressureVal);
+      if (!isFinite(pressure) || pressure === 0) {
         setError("Pressure must be a non-zero finite number");
         return;
       }
-      onSave("pressure", p);
+      onSave("pressure", pressure);
       return;
     }
     // Force / moment, prescribed componentwise. Reject non-finite components

--- a/web/src/components/panel/LeftPanel.tsx
+++ b/web/src/components/panel/LeftPanel.tsx
@@ -12,6 +12,7 @@ import type {
   AppMode,
   LoadKind,
   Material,
+  NamedBcGroup,
   NamedLoadGroup,
   Node,
   Element,
@@ -535,6 +536,10 @@ function GeometryPanel() {
 
 // ── Constraints mode ──────────────────────────────────────────────────────────
 
+const DOF_LABELS = ["Ux", "Uy", "Uz", "Rx", "Ry", "Rz"];
+const FORCE_LABELS = ["Fx", "Fy", "Fz"];
+const MOMENT_LABELS = ["Mx", "My", "Mz"];
+
 // One-line summary of a load group for the group list: pressure magnitude, or
 // the non-zero force/moment components (e.g. "Fx = 100, Fz = -50 N").
 function loadGroupMeta(g: NamedLoadGroup): string {
@@ -546,6 +551,213 @@ function loadGroupMeta(g: NamedLoadGroup): string {
     .map((v, i) => (v !== 0 ? `${labels[i]} = ${fmt(v)}` : null))
     .filter((p): p is string => p !== null);
   return `${parts.join(", ")} ${unit}`;
+}
+
+// Inline editor for a BC group's constrained DOFs and prescribed value —
+// opened by the group's ✎ button (issue #258: the values, not just the faces,
+// must be editable after creation).
+function BcValueForm({
+  group,
+  onSave,
+  onCancel,
+}: {
+  group: NamedBcGroup;
+  onSave(dofs: number[], value: number): void;
+  onCancel(): void;
+}) {
+  const [checkedDofs, setCheckedDofs] = useState<boolean[]>(
+    DOF_LABELS.map((_, i) => group.dofs.includes(i)),
+  );
+  const [value, setValue] = useState(String(group.value));
+  const [error, setError] = useState<string | null>(null);
+
+  function handleSave() {
+    // A prescribed displacement of 0 is physically valid (fixed support), so
+    // only reject non-finite input — never silently coerce "abc" to 0.
+    const v = parseFloat(value);
+    if (!isFinite(v)) {
+      setError("Prescribed displacement must be a finite number");
+      return;
+    }
+    const dofs = checkedDofs.map((c, i) => (c ? i : -1)).filter((i) => i >= 0);
+    if (dofs.length === 0) {
+      setError("Constrain at least one DOF");
+      return;
+    }
+    onSave(dofs, v);
+  }
+
+  return (
+    <div className={styles.inlineForm} data-testid="bc-edit-form">
+      {error && (
+        <div className={styles.errorBanner} data-testid="bc-edit-error">
+          <span>{error}</span>
+          <button onClick={() => setError(null)}>×</button>
+        </div>
+      )}
+      <div className={styles.dofGrid}>
+        {/* Solid (H1 displacement) elements have only translational DOFs —
+        Ux, Uy, Uz. Rotational constraints carry no stiffness and are not
+        offered. */}
+        {DOF_LABELS.slice(0, 3).map((d, i) => (
+          <label key={d} className={styles.dofCheck}>
+            <input
+              type="checkbox"
+              checked={checkedDofs[i]}
+              onChange={() =>
+                setCheckedDofs((p) => p.map((v, j) => (j === i ? !v : v)))
+              }
+            />
+            {d}
+          </label>
+        ))}
+      </div>
+      <div className={styles.formRow}>
+        <span className={styles.formLabel}>Value</span>
+        <input
+          className={styles.formInput}
+          type="number"
+          value={value}
+          step="0.001"
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </div>
+      <div className={styles.formBtns}>
+        <button className={styles.cancelBtn} onClick={onCancel}>
+          Cancel
+        </button>
+        <button className={styles.primaryBtn} onClick={handleSave}>
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Inline editor for a load group's kind and values — componentwise force /
+// moment vector or pressure magnitude — opened by the group's ✎ button
+// (issue #258).
+function LoadValueForm({
+  group,
+  onSave,
+  onCancel,
+}: {
+  group: NamedLoadGroup;
+  onSave(
+    kind: LoadKind,
+    totalForce: number,
+    components?: [number, number, number],
+  ): void;
+  onCancel(): void;
+}) {
+  const initialKind = loadKind(group);
+  const initialVec = loadComponents(group);
+  const [kindSel, setKindSel] = useState<LoadKind>(initialKind);
+  const [vec, setVec] = useState<[string, string, string]>([
+    String(initialVec[0]),
+    String(initialVec[1]),
+    String(initialVec[2]),
+  ]);
+  const [pressureVal, setPressureVal] = useState(
+    initialKind === "pressure" ? String(group.totalForce) : "10",
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  function handleSave() {
+    if (kindSel === "pressure") {
+      // A zero pressure is a no-op load: it contributes nothing to the RHS and
+      // the solver returns a plausible-looking field with the input silently
+      // discarded. Reject it (and non-finite input) instead of coercing to 0.
+      const p = parseFloat(pressureVal);
+      if (!isFinite(p) || p === 0) {
+        setError("Pressure must be a non-zero finite number");
+        return;
+      }
+      onSave("pressure", p);
+      return;
+    }
+    // Force / moment, prescribed componentwise. Reject non-finite components
+    // and the all-zero vector (a no-op load that would be silently discarded).
+    const noun = kindSel === "moment" ? "moment" : "force";
+    const parsed = vec.map((comp) => parseFloat(comp));
+    if (parsed.some((comp) => !isFinite(comp))) {
+      setError(`Each ${noun} component must be a finite number`);
+      return;
+    }
+    if (parsed.every((comp) => comp === 0)) {
+      setError(`Specify a non-zero ${noun} component`);
+      return;
+    }
+    onSave(kindSel, 0, [parsed[0], parsed[1], parsed[2]]);
+  }
+
+  const labels = kindSel === "moment" ? MOMENT_LABELS : FORCE_LABELS;
+  const unit = kindSel === "moment" ? "N·mm" : "N";
+
+  return (
+    <div className={styles.inlineForm} data-testid="load-edit-form">
+      {error && (
+        <div className={styles.errorBanner} data-testid="load-edit-error">
+          <span>{error}</span>
+          <button onClick={() => setError(null)}>×</button>
+        </div>
+      )}
+      <div className={styles.formRow}>
+        <span className={styles.formLabel}>Type</span>
+        <select
+          className={styles.formSelect}
+          value={kindSel}
+          onChange={(e) => setKindSel(e.target.value as LoadKind)}
+        >
+          <option value="force">Force</option>
+          <option value="moment">Moment</option>
+          <option value="pressure">Pressure</option>
+        </select>
+      </div>
+      {kindSel === "pressure" ? (
+        <div className={styles.formRow}>
+          <span className={styles.formLabel}>Pressure (MPa)</span>
+          <input
+            className={styles.formInput}
+            type="number"
+            value={pressureVal}
+            step="1"
+            onChange={(e) => setPressureVal(e.target.value)}
+          />
+        </div>
+      ) : (
+        labels.map((label, i) => (
+          <div className={styles.formRow} key={label}>
+            <span className={styles.formLabel}>
+              {label} ({unit})
+            </span>
+            <input
+              className={styles.formInput}
+              type="number"
+              value={vec[i]}
+              step="100"
+              onChange={(e) => {
+                const value = e.target.value;
+                setVec((p) => {
+                  const next = [...p] as [string, string, string];
+                  next[i] = value;
+                  return next;
+                });
+              }}
+            />
+          </div>
+        ))
+      )}
+      <div className={styles.formBtns}>
+        <button className={styles.cancelBtn} onClick={onCancel}>
+          Cancel
+        </button>
+        <button className={styles.primaryBtn} onClick={handleSave}>
+          Save
+        </button>
+      </div>
+    </div>
+  );
 }
 
 function ConstraintsPanel() {
@@ -569,6 +781,12 @@ function ConstraintsPanel() {
     (s) => s.removeFaceFromLoadGroup,
   );
   const deleteLoadGroup = useModelStore((s) => s.deleteLoadGroup);
+  const updateBcGroup = useModelStore((s) => s.updateBcGroup);
+  const updateLoadGroup = useModelStore((s) => s.updateLoadGroup);
+
+  // Group whose values are being edited inline (✎), if any.
+  const [editingBcId, setEditingBcId] = useState<number | null>(null);
+  const [editingLoadId, setEditingLoadId] = useState<number | null>(null);
 
   const [checkedDofs, setCheckedDofs] = useState([
     true,
@@ -595,10 +813,6 @@ function ConstraintsPanel() {
   const [pressureVal, setPressureVal] = useState("10");
   const [bcValue, setBcValue] = useState("0");
   const [error, setError] = useState<string | null>(null);
-
-  const DOF_LABELS = ["Ux", "Uy", "Uz", "Rx", "Ry", "Rz"];
-  const FORCE_LABELS = ["Fx", "Fy", "Fz"];
-  const MOMENT_LABELS = ["Mx", "My", "Mz"];
 
   // Boundary conditions and loads reference mesh nodes, so they can only be
   // defined once a volume mesh exists.
@@ -839,7 +1053,16 @@ function ConstraintsPanel() {
                         setPendingFaces([]);
                       }}
                     >
-                      ✏
+                      +
+                    </button>
+                    <button
+                      className={styles.iconBtn}
+                      title="Edit BC"
+                      onClick={() =>
+                        setEditingBcId(editingBcId === g.id ? null : g.id)
+                      }
+                    >
+                      ✎
                     </button>
                     <button
                       className={`${styles.iconBtn} ${styles.iconBtnDanger}`}
@@ -850,6 +1073,16 @@ function ConstraintsPanel() {
                     </button>
                   </div>
                 </div>
+                {editingBcId === g.id && (
+                  <BcValueForm
+                    group={g}
+                    onSave={(dofs, value) => {
+                      updateBcGroup(g.id, dofs, value);
+                      setEditingBcId(null);
+                    }}
+                    onCancel={() => setEditingBcId(null)}
+                  />
+                )}
                 {g.faces.map((f) => (
                   <div key={f.id} className={styles.bcFaceRow}>
                     <span className={styles.bcFaceIndent}>└</span>
@@ -1025,7 +1258,16 @@ function ConstraintsPanel() {
                         setPendingFaces([]);
                       }}
                     >
-                      ✏
+                      +
+                    </button>
+                    <button
+                      className={styles.iconBtn}
+                      title="Edit load"
+                      onClick={() =>
+                        setEditingLoadId(editingLoadId === g.id ? null : g.id)
+                      }
+                    >
+                      ✎
                     </button>
                     <button
                       className={`${styles.iconBtn} ${styles.iconBtnDanger}`}
@@ -1036,6 +1278,16 @@ function ConstraintsPanel() {
                     </button>
                   </div>
                 </div>
+                {editingLoadId === g.id && (
+                  <LoadValueForm
+                    group={g}
+                    onSave={(kind, totalForce, components) => {
+                      updateLoadGroup(g.id, kind, totalForce, components);
+                      setEditingLoadId(null);
+                    }}
+                    onCancel={() => setEditingLoadId(null)}
+                  />
+                )}
                 {g.faces.map((f) => (
                   <div key={f.id} className={styles.bcFaceRow}>
                     <span className={styles.bcFaceIndent}>└</span>

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -876,10 +876,10 @@ export const useModelStore = create<ModelState>()(
 
     updateBcGroup: (id: number, dofs: number[], value: number) =>
       set((s) => {
-        const g = s.bcGroups.find((g) => g.id === id);
-        if (!g) return;
-        g.dofs = dofs;
-        g.value = value;
+        const group = s.bcGroups.find((g) => g.id === id);
+        if (!group) return;
+        group.dofs = dofs;
+        group.value = value;
         s.constraints = rebuildConstraints(s.bcGroups);
         s.result = null;
       }),
@@ -965,16 +965,16 @@ export const useModelStore = create<ModelState>()(
       components?: [number, number, number],
     ) =>
       set((s) => {
-        const g = s.loadGroups.find((g) => g.id === id);
-        if (!g) return;
+        const group = s.loadGroups.find((g) => g.id === id);
+        if (!group) return;
         const { dof, totalForce } = components
           ? summarizeComponents(components, kind)
           : { dof: 0, totalForce: totalForceArg };
-        g.kind = kind;
-        g.dof = dof;
-        g.totalForce = totalForce;
-        if (components) g.components = components;
-        else delete g.components;
+        group.kind = kind;
+        group.dof = dof;
+        group.totalForce = totalForce;
+        if (components) group.components = components;
+        else delete group.components;
         s.loads = rebuildLoads(s.loadGroups, s.nodes);
         s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
         s.result = null;

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -483,6 +483,7 @@ interface ModelState {
     value: number,
   ): void;
   addFaceToBcGroup(groupId: number, face: Omit<BcFaceEntry, "id">): void;
+  updateBcGroup(id: number, dofs: number[], value: number): void;
   removeFaceFromBcGroup(groupId: number, faceId: number): void;
   deleteBcGroup(id: number): void;
   clearConstraints(): void;
@@ -496,6 +497,12 @@ interface ModelState {
     components?: [number, number, number],
   ): void;
   addFaceToLoadGroup(groupId: number, face: Omit<BcFaceEntry, "id">): void;
+  updateLoadGroup(
+    id: number,
+    kind: LoadKind,
+    totalForce: number,
+    components?: [number, number, number],
+  ): void;
   removeFaceFromLoadGroup(groupId: number, faceId: number): void;
   deleteLoadGroup(id: number): void;
   clearLoads(): void;
@@ -867,6 +874,16 @@ export const useModelStore = create<ModelState>()(
         s.result = null;
       }),
 
+    updateBcGroup: (id: number, dofs: number[], value: number) =>
+      set((s) => {
+        const g = s.bcGroups.find((g) => g.id === id);
+        if (!g) return;
+        g.dofs = dofs;
+        g.value = value;
+        s.constraints = rebuildConstraints(s.bcGroups);
+        s.result = null;
+      }),
+
     removeFaceFromBcGroup: (groupId: number, faceId: number) =>
       set((s) => {
         const g = s.bcGroups.find((g) => g.id === groupId);
@@ -932,6 +949,32 @@ export const useModelStore = create<ModelState>()(
         if (!g) return;
         const faceId = s.nextFaceEntryId++;
         g.faces.push({ id: faceId, label: face.label, nodeIds: face.nodeIds });
+        s.loads = rebuildLoads(s.loadGroups, s.nodes);
+        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
+        s.result = null;
+      }),
+
+    // Replace a load group's values in place, keeping its faces. Mirrors
+    // createLoadGroup: force/moment carry their vector in `components` (the
+    // source of truth, with dof/totalForce derived as the legacy summary);
+    // pressure carries its magnitude in totalForce and has no vector.
+    updateLoadGroup: (
+      id: number,
+      kind: LoadKind,
+      totalForceArg: number,
+      components?: [number, number, number],
+    ) =>
+      set((s) => {
+        const g = s.loadGroups.find((g) => g.id === id);
+        if (!g) return;
+        const { dof, totalForce } = components
+          ? summarizeComponents(components, kind)
+          : { dof: 0, totalForce: totalForceArg };
+        g.kind = kind;
+        g.dof = dof;
+        g.totalForce = totalForce;
+        if (components) g.components = components;
+        else delete g.components;
         s.loads = rebuildLoads(s.loadGroups, s.nodes);
         s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
         s.result = null;

--- a/web/tests/edit-constraint-values.spec.ts
+++ b/web/tests/edit-constraint-values.spec.ts
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from "./coverage";
+import { bootstrapCantilever } from "./fixtures/cantilever";
+import type { Page } from "@playwright/test";
+
+// Coverage for issue #258: the ✎ button on a BC / load group must open an
+// inline editor for the group's values (force components, pressure magnitude,
+// constrained DOFs, prescribed displacement) — not just allow face changes.
+
+type Store = {
+  getState(): {
+    bcGroups: { id: number; dofs: number[]; value: number }[];
+    loadGroups: {
+      id: number;
+      kind?: string;
+      dof: number;
+      totalForce: number;
+      components?: [number, number, number];
+    }[];
+    constraints: { nodeId: number; dof: number; prescribedValue?: number }[];
+    surfaceLoads: {
+      type: string;
+      force?: [number, number, number];
+      pressure?: number;
+    }[];
+    result: unknown;
+    updateLoadGroup(
+      id: number,
+      kind: string,
+      totalForce: number,
+      components?: [number, number, number],
+    ): void;
+    setResult(r: { displacements: Float64Array }): void;
+  };
+  setState(s: object): void;
+};
+
+async function openConstraintsMode(page: Page): Promise<void> {
+  await bootstrapCantilever(page);
+  await page.evaluate(() => {
+    (window as unknown as { __kofemStore: Store }).__kofemStore.setState({
+      mode: "constraints",
+    });
+  });
+}
+
+test("editing a load group's force components updates the surface loads", async ({
+  page,
+}) => {
+  await openConstraintsMode(page);
+
+  await page.getByTitle("Edit load").click();
+  const form = page.getByTestId("load-edit-form");
+  await expect(form).toBeVisible();
+
+  // The form opens pre-filled with the group's current vector (legacy
+  // single-axis Fy = −10000 reconstructed componentwise).
+  const inputs = form.locator("input");
+  await expect(inputs.nth(0)).toHaveValue("0");
+  await expect(inputs.nth(1)).toHaveValue("-10000");
+  await expect(inputs.nth(2)).toHaveValue("0");
+
+  await inputs.nth(0).fill("100");
+  await inputs.nth(1).fill("-200");
+  await inputs.nth(2).fill("300");
+  await form.getByRole("button", { name: "Save" }).click();
+
+  await expect(form).not.toBeVisible();
+  const state = await page.evaluate(() => {
+    const s = (
+      window as unknown as { __kofemStore: Store }
+    ).__kofemStore.getState();
+    return {
+      group: s.loadGroups[0],
+      surfaceLoads: s.surfaceLoads,
+    };
+  });
+  expect(state.group.components).toEqual([100, -200, 300]);
+  expect(state.group.kind).toBe("force");
+  expect(state.surfaceLoads.length).toBeGreaterThan(0);
+  for (const sl of state.surfaceLoads) {
+    expect(sl.type).toBe("force");
+    expect(sl.force).toEqual([100, -200, 300]);
+  }
+});
+
+test("editing a load group can switch its kind to pressure", async ({
+  page,
+}) => {
+  await openConstraintsMode(page);
+
+  await page.getByTitle("Edit load").click();
+  const form = page.getByTestId("load-edit-form");
+  await form.locator("select").selectOption("pressure");
+  await form.locator("input").fill("25");
+  await form.getByRole("button", { name: "Save" }).click();
+
+  const state = await page.evaluate(() => {
+    const s = (
+      window as unknown as { __kofemStore: Store }
+    ).__kofemStore.getState();
+    return { group: s.loadGroups[0], surfaceLoads: s.surfaceLoads };
+  });
+  expect(state.group.kind).toBe("pressure");
+  expect(state.group.totalForce).toBe(25);
+  // Switching to pressure drops the stale force vector.
+  expect(state.group.components).toBeUndefined();
+  for (const sl of state.surfaceLoads) {
+    expect(sl.type).toBe("pressure");
+    expect(sl.pressure).toBe(25);
+  }
+});
+
+test("an all-zero force vector is rejected with an error", async ({ page }) => {
+  await openConstraintsMode(page);
+
+  await page.getByTitle("Edit load").click();
+  const form = page.getByTestId("load-edit-form");
+  const inputs = form.locator("input");
+  await inputs.nth(1).fill("0");
+  await form.getByRole("button", { name: "Save" }).click();
+
+  await expect(page.getByTestId("load-edit-error")).toContainText(
+    "non-zero force component",
+  );
+  // The group is untouched.
+  const group = await page.evaluate(
+    () =>
+      (window as unknown as { __kofemStore: Store }).__kofemStore.getState()
+        .loadGroups[0],
+  );
+  expect(group.totalForce).toBe(-10000);
+});
+
+test("editing a BC group's DOFs and value rebuilds the constraints", async ({
+  page,
+}) => {
+  await openConstraintsMode(page);
+
+  await page.getByTitle("Edit BC").click();
+  const form = page.getByTestId("bc-edit-form");
+  await expect(form).toBeVisible();
+
+  // Pre-filled from the group: Ux, Uy, Uz all fixed at 0.
+  const checks = form.locator("input[type=checkbox]");
+  await expect(checks.nth(0)).toBeChecked();
+  await expect(checks.nth(1)).toBeChecked();
+  await expect(checks.nth(2)).toBeChecked();
+
+  // Release Uz and prescribe Ux = Uy = 0.5.
+  await checks.nth(2).uncheck();
+  await form.locator("input[type=number]").fill("0.5");
+  await form.getByRole("button", { name: "Save" }).click();
+
+  await expect(form).not.toBeVisible();
+  const state = await page.evaluate(() => {
+    const s = (
+      window as unknown as { __kofemStore: Store }
+    ).__kofemStore.getState();
+    return { group: s.bcGroups[0], constraints: s.constraints };
+  });
+  expect(state.group.dofs).toEqual([0, 1]);
+  expect(state.group.value).toBe(0.5);
+  expect(state.constraints.every((c) => c.dof !== 2)).toBe(true);
+  expect(state.constraints.every((c) => c.prescribedValue === 0.5)).toBe(true);
+});
+
+test("unchecking every DOF is rejected with an error", async ({ page }) => {
+  await openConstraintsMode(page);
+
+  await page.getByTitle("Edit BC").click();
+  const form = page.getByTestId("bc-edit-form");
+  const checks = form.locator("input[type=checkbox]");
+  await checks.nth(0).uncheck();
+  await checks.nth(1).uncheck();
+  await checks.nth(2).uncheck();
+  await form.getByRole("button", { name: "Save" }).click();
+
+  await expect(page.getByTestId("bc-edit-error")).toContainText(
+    "at least one DOF",
+  );
+});
+
+test("updating load values invalidates a stale result", async ({ page }) => {
+  await openConstraintsMode(page);
+
+  const resultCleared = await page.evaluate(() => {
+    const store = (window as unknown as { __kofemStore: Store }).__kofemStore;
+    store.getState().setResult({ displacements: new Float64Array(3) });
+    const id = store.getState().loadGroups[0].id;
+    store.getState().updateLoadGroup(id, "force", 0, [0, -20000, 0]);
+    return store.getState().result === null;
+  });
+  expect(resultCleared).toBe(true);
+});

--- a/web/tests/edit-constraint-values.spec.ts
+++ b/web/tests/edit-constraint-values.spec.ts
@@ -69,12 +69,12 @@ test("editing a load group's force components updates the surface loads", async 
 
   await expect(form).not.toBeVisible();
   const state = await page.evaluate(() => {
-    const s = (
+    const storeState = (
       window as unknown as { __kofemStore: Store }
     ).__kofemStore.getState();
     return {
-      group: s.loadGroups[0],
-      surfaceLoads: s.surfaceLoads,
+      group: storeState.loadGroups[0],
+      surfaceLoads: storeState.surfaceLoads,
     };
   });
   expect(state.group.components).toEqual([100, -200, 300]);
@@ -98,10 +98,13 @@ test("editing a load group can switch its kind to pressure", async ({
   await form.getByRole("button", { name: "Save" }).click();
 
   const state = await page.evaluate(() => {
-    const s = (
+    const storeState = (
       window as unknown as { __kofemStore: Store }
     ).__kofemStore.getState();
-    return { group: s.loadGroups[0], surfaceLoads: s.surfaceLoads };
+    return {
+      group: storeState.loadGroups[0],
+      surfaceLoads: storeState.surfaceLoads,
+    };
   });
   expect(state.group.kind).toBe("pressure");
   expect(state.group.totalForce).toBe(25);
@@ -156,10 +159,13 @@ test("editing a BC group's DOFs and value rebuilds the constraints", async ({
 
   await expect(form).not.toBeVisible();
   const state = await page.evaluate(() => {
-    const s = (
+    const storeState = (
       window as unknown as { __kofemStore: Store }
     ).__kofemStore.getState();
-    return { group: s.bcGroups[0], constraints: s.constraints };
+    return {
+      group: storeState.bcGroups[0],
+      constraints: storeState.constraints,
+    };
   });
   expect(state.group.dofs).toEqual([0, 1]);
   expect(state.group.value).toBe(0.5);


### PR DESCRIPTION
## Summary

Implements inline editors for boundary condition and load groups, allowing users to edit constrained DOFs, prescribed displacements, force/moment components, and pressure magnitudes after group creation without recreating them. Addresses issue #258.

closes #258

## Key Changes

**web/src/components/panel/LeftPanel.tsx**
- Extract DOF/force/moment label constants to module scope for reuse
- Add `BcValueForm` component: inline editor for BC group DOFs (Ux, Uy, Uz only; rotational DOFs omitted as they carry no stiffness) and prescribed displacement value with validation
- Add `LoadValueForm` component: inline editor for load group kind (force/moment/pressure) and componentwise values with validation
- Replace pencil (✏) button with plus (+) button for adding faces; add new pencil (✎) button to toggle inline editors
- Render editors conditionally below group headers when active
- Wire editors to `updateBcGroup` and `updateLoadGroup` store actions

**web/src/store/modelStore.ts**
- Add `updateBcGroup(id, dofs, value)` action: updates DOFs and prescribed value in place, rebuilds constraints, invalidates result
- Add `updateLoadGroup(id, kind, totalForce, components?)` action: updates load kind and values in place, mirrors `createLoadGroup` logic (force/moment store vector in `components`; pressure stores magnitude in `totalForce`), rebuilds loads and surface loads, invalidates result

**web/tests/edit-constraint-values.spec.ts** (new)
- Test editing load group force components and verifying surface loads update
- Test switching load kind from force to pressure
- Test rejection of all-zero force vectors with error message
- Test editing BC group DOFs and prescribed value, verifying constraints rebuild
- Test rejection of unchecking all DOFs with error message
- Test that updating load values invalidates stale FEM results

## Notable Implementation Details

- **Validation strategy**: Reject non-finite input and physically invalid cases (zero pressure, all-zero force, no constrained DOFs) with clear error messages rather than silent coercion. A prescribed displacement of 0 is valid (fixed support) and accepted.
- **DOF scope**: Only translational DOFs (Ux, Uy, Uz) are offered in the BC editor. Rotational constraints (Rx, Ry, Rz) are omitted because solid (H1 displacement) elements have no rotational stiffness.
- **Load vector representation**: Force and moment groups store their vector in `components` (source of truth); `dof` and `totalForce` are derived legacy summaries. Pressure groups store magnitude in `totalForce` with no vector. The `updateLoadGroup` action mirrors `createLoadGroup` to maintain consistency.
- **State invalidation**: Both update actions set `result = null` to invalidate cached FEM solutions when constraints or loads change.
- **UI toggle**: Editors open/close by clicking the ✎ button; clicking again closes the editor. The + button remains for adding faces to existing groups.

## Checklist

- [x] **No silent fallbacks** — all input validation explicitly rejects invalid cases with error messages; no coercion to defaults
- [x] Every input accepted by the UI is consumed downstream (form values → store actions → constraint/load rebuild)

https://claude.ai/code/session_01PgbyqKrd99MsKL6jQVQbNd