### PR TITLE
Validate displacement array length before rendering deformed mesh

### DIFF
--- a/web/src/components/viewport/FemMeshLayer.tsx
+++ b/web/src/components/viewport/FemMeshLayer.tsx
@@ -85,12 +85,17 @@ export function FemMeshLayer({
   const deformedEdgePositions = useMemo(() => {
     if (!result) return null;
     const d = result.displacements;
+    // A remesh can change the node count/ids after a solve completes but
+    // before `result` is invalidated. Rendering `d` against a mismatched
+    // nodeMap would silently zero-fill out-of-range nodes and draw a
+    // plausible-looking but wrong deformed shape — bail instead.
+    if (d.length !== nodeMap.size * 3) return null;
     const coord = (id: number) => {
       const { n, i } = nodeMap.get(id)!;
       return [
-        n.x + (d[i * 3] ?? 0) * deformScale,
-        n.y + (d[i * 3 + 1] ?? 0) * deformScale,
-        n.z + (d[i * 3 + 2] ?? 0) * deformScale,
+        n.x + d[i * 3] * deformScale,
+        n.y + d[i * 3 + 1] * deformScale,
+        n.z + d[i * 3 + 2] * deformScale,
       ];
     };
     const segs: number[] = [];
@@ -112,6 +117,7 @@ export function FemMeshLayer({
   const deformedSurfaceEdgePositions = useMemo(() => {
     if (!result) return null;
     const d = result.displacements;
+    if (d.length !== nodeMap.size * 3) return null;
     const seen = new Set<string>();
     const segs: number[] = [];
     const addEdge = (a: number, b: number) => {
@@ -122,12 +128,12 @@ export function FemMeshLayer({
         nb = nodeMap.get(b);
       if (!na || !nb) return;
       segs.push(
-        na.n.x + (d[na.i * 3] ?? 0) * deformScale,
-        na.n.y + (d[na.i * 3 + 1] ?? 0) * deformScale,
-        na.n.z + (d[na.i * 3 + 2] ?? 0) * deformScale,
-        nb.n.x + (d[nb.i * 3] ?? 0) * deformScale,
-        nb.n.y + (d[nb.i * 3 + 1] ?? 0) * deformScale,
-        nb.n.z + (d[nb.i * 3 + 2] ?? 0) * deformScale,
+        na.n.x + d[na.i * 3] * deformScale,
+        na.n.y + d[na.i * 3 + 1] * deformScale,
+        na.n.z + d[na.i * 3 + 2] * deformScale,
+        nb.n.x + d[nb.i * 3] * deformScale,
+        nb.n.y + d[nb.i * 3 + 1] * deformScale,
+        nb.n.z + d[nb.i * 3 + 2] * deformScale,
       );
     };
     for (const [a, b, c, dd] of boundaryQuadFaceIds) {

--- a/web/src/components/viewport/ResultsColormap.tsx
+++ b/web/src/components/viewport/ResultsColormap.tsx
@@ -45,22 +45,27 @@ export function ResultsColormap({
     if (!hasQuads && !hasTris) return null;
 
     const d = result.displacements;
+    // A remesh can change the node count/ids after a solve completes but
+    // before `result` is invalidated. Rendering `d` against a mismatched
+    // nodeMap would silently zero-fill out-of-range nodes and draw a
+    // plausible-looking but wrong colormap/deformed shape — bail instead.
+    if (d.length !== nodeMap.size * 3) return null;
 
     // Compute per-node scalar value for the selected result type
     const nodeValue = (i: number, rt: ResultType): number => {
       switch (rt) {
         case "Ux":
-          return d[i * 3] ?? 0;
+          return d[i * 3];
         case "Uy":
-          return d[i * 3 + 1] ?? 0;
+          return d[i * 3 + 1];
         case "Uz":
-          return d[i * 3 + 2] ?? 0;
+          return d[i * 3 + 2];
         case "Von Mises stress":
           return nodeVonMises?.[i] ?? 0;
         default: {
-          const ux = d[i * 3] ?? 0,
-            uy = d[i * 3 + 1] ?? 0,
-            uz = d[i * 3 + 2] ?? 0;
+          const ux = d[i * 3],
+            uy = d[i * 3 + 1],
+            uz = d[i * 3 + 2];
           return Math.sqrt(ux * ux + uy * uy + uz * uz);
         }
       }
@@ -81,9 +86,9 @@ export function ResultsColormap({
     const deformedPos = (id: number): [number, number, number] => {
       const { n, i } = nodeMap.get(id)!;
       return [
-        n.x + (d[i * 3] ?? 0) * deformScale,
-        n.y + (d[i * 3 + 1] ?? 0) * deformScale,
-        n.z + (d[i * 3 + 2] ?? 0) * deformScale,
+        n.x + d[i * 3] * deformScale,
+        n.y + d[i * 3 + 1] * deformScale,
+        n.z + d[i * 3 + 2] * deformScale,
       ];
     };
     const nodeColor = (id: number): [number, number, number] => {


### PR DESCRIPTION
## Summary

Add validation to prevent silent rendering errors when a remesh changes node count/IDs after a solve completes but before the result is invalidated. Previously, accessing out-of-range displacement indices would silently zero-fill and produce a plausible-looking but incorrect deformed shape.

closes #

## Key Changes

**web/src/components/viewport/FemMeshLayer.tsx**
- Add length check `d.length !== nodeMap.size * 3` in `deformedEdgePositions` and `deformedSurfaceEdgePositions` memos; return `null` if mismatched
- Remove defensive `?? 0` nullish coalescing operators from displacement array accesses (now guaranteed in-bounds)

**web/src/components/viewport/ResultsColormap.tsx**
- Add length check `d.length !== nodeMap.size * 3` in colormap computation memo; return `null` if mismatched
- Remove defensive `?? 0` operators from displacement array accesses in `nodeValue()` and `deformedPos()` functions
- Keep `?? 0` only for `nodeVonMises` (genuinely optional field)

## Notable Implementation Details

A remesh triggered during or after a solve can change the node count and node ID mapping. If `result` is not yet invalidated, rendering displacement data `d` against a stale `nodeMap` would cause out-of-range array accesses. JavaScript silently returns `undefined` for these, which the `?? 0` fallback converts to zero displacement — producing a visually plausible but incorrect deformed shape.

The fix validates that the displacement array length matches the expected size (`nodeMap.size * 3`) before rendering. If mismatched, the memos return `null`, preventing incorrect visualization. This follows the "no silent fallbacks" principle: data mismatches are caught explicitly rather than masked by defensive defaults.

The removal of `?? 0` operators is safe because the length check guarantees all accessed indices are in bounds.

## Checklist

- [x] **No silent fallbacks** — length validation replaces silent zero-fill behavior; `?? 0` removed from guaranteed in-bounds accesses; `?? 0` retained only for `nodeVonMises` (genuinely optional)
- [x] Every input accepted by the UI is consumed downstream (displacement array validated before use)

https://claude.ai/code/session_01XSG3hCu6NjUHib8jXpUah3