### PR TITLE
Document per-body materials design (reserved for #317)

### DIFF
--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -18,6 +18,13 @@ export interface Node {
 // such support is actually added.
 export type ElementType = "CTETRA" | "CHEXA";
 
+// Reserved seam for #317 (multibody: per-body materials). Currently
+// write-only — the solver reads `materials[0]` directly (solver.worker.ts)
+// and does not consult `propertyId`/`materialId` to resolve an element's
+// material. Every model still carries exactly one auto-created Property
+// referencing the model's sole material; do not treat this as the current
+// material-assignment mechanism until #317 wires per-element regions
+// through it (see #320).
 export interface Property {
   id: number;
   materialId: number;

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -305,6 +305,9 @@ self.onmessage = async (event: MessageEvent) => {
         nodes: Node[];
         elements: Element[];
         materials: Material[];
+        // Reserved for #317 (per-body materials) — the single-material solve
+        // below reads materials[0] directly and does not resolve elements
+        // through propertyId/materialId (see #320).
         properties: unknown[];
         constraints: Constraint[];
         loads: Load[];


### PR DESCRIPTION
## Summary

Add clarifying comments to `Property` interface and solver worker to document the reserved design for per-body materials support (#317). These are write-only structures at present — the solver reads `materials[0]` directly and does not yet resolve elements through `propertyId`/`materialId`.

closes #320

## Key Changes

**web:**
- Added detailed comment block to `Property` interface explaining its reserved status for #317
- Added comment to solver worker's `properties` field clarifying current single-material behavior and future resolution path

## Notable Implementation Details

The comments document a deliberate architectural gap: the `Property` and `propertyId`/`materialId` fields exist as a placeholder for multi-material support, but the current solver implementation bypasses them entirely. This prevents confusion during code review and future maintenance — developers will understand that:

1. Every model carries exactly one auto-created `Property` referencing the sole material
2. The solver currently reads `materials[0]` directly (see `solver.worker.ts`)
3. Per-element material assignment is blocked on #317 wiring per-body regions through the property mechanism (see #320 for the design discussion)

This is a documentation-only change with no functional impact.

## Checklist

- [x] **No silent fallbacks** — N/A (documentation only)
- [x] Every input accepted by the UI or an API is actually consumed downstream — N/A (documentation only)

https://claude.ai/code/session_01NYnHyXs3sGHyo3z8HxxXaf