### PR TITLE
Rename StepSurfaceMesh to StepTessellation for clarity

### DIFF
--- a/web/src/lib/analysisFile.ts
+++ b/web/src/lib/analysisFile.ts
@@ -11,7 +11,7 @@ import type {
   Node,
   Property,
   ResultType,
-  StepSurfaceMesh,
+  StepTessellation,
   VolMesh,
 } from "../store/modelStore";
 import { RESULT_TYPES } from "../store/modelStore";
@@ -74,7 +74,7 @@ export interface AnalysisState {
   nextLoadGroupId: number;
   nextFaceEntryId: number;
   nextMatId: number;
-  stepSurface: StepSurfaceMesh | null;
+  stepSurface: StepTessellation | null;
   volMesh: VolMesh | null;
   surfaceTriangles: [number, number, number][] | null;
   surfaceFaceIds: number[] | null;
@@ -102,7 +102,7 @@ interface KofemFieldDataV1 {
   nextLoadGroupId: number;
   nextFaceEntryId: number;
   nextMatId: number;
-  stepSurface: StepSurfaceMesh | null;
+  stepSurface: StepTessellation | null;
   volMesh: VolMesh | null;
   surfaceTriangles: [number, number, number][] | null;
   surfaceFaceIds: number[] | null;

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -76,7 +76,7 @@ export type ResultType = (typeof RESULT_TYPES)[number];
 // each mesh), so the reader needs to know which format the retained bytes are.
 export type GeometryFormat = "step" | "iges";
 
-export interface StepSurfaceMesh {
+export interface StepTessellation {
   points: [number, number, number][];
   triangles: [number, number, number][];
 }
@@ -395,7 +395,7 @@ interface ModelState {
   mode: AppMode;
   result: SolverResult | null;
   resultType: ResultType;
-  stepSurface: StepSurfaceMesh | null;
+  stepSurface: StepTessellation | null;
   // Raw bytes of the imported STEP file, retained so the geometry can be
   // reloaded into the mesher for a re-mesh. The worker is torn down after every
   // mesh (resetWorker), discarding the OCCT shape it held, so re-meshing must
@@ -439,7 +439,7 @@ interface ModelState {
   // fit-to-view scale. 1 = the default visible deformation, 0 = undeformed.
   deformScale: number;
   stepImportError: string | null;
-  setStepSurface(mesh: StepSurfaceMesh | null): void;
+  setStepSurface(tessellation: StepTessellation | null): void;
   setStepBytes(bytes: Uint8Array | null): void;
   setGeometryFormat(format: GeometryFormat): void;
   setVolMesh(mesh: VolMesh | null): void;
@@ -609,12 +609,12 @@ export const useModelStore = create<ModelState>()(
       set((s) => {
         s.geometryFormat = format;
       }),
-    setStepSurface: (mesh) =>
+    setStepSurface: (tessellation) =>
       set((s) => {
-        s.stepSurface = mesh;
+        s.stepSurface = tessellation;
         // Clearing the geometry also drops the retained STEP bytes — keeping the
         // invariant "no surface ⇒ nothing left to re-mesh from".
-        if (!mesh) {
+        if (!tessellation) {
           s.stepBytes = null;
           s.geometryFormat = "step";
         }
@@ -632,7 +632,7 @@ export const useModelStore = create<ModelState>()(
         s.nextLoadGroupId = 1;
         s.nextFaceEntryId = 1;
         s.result = null;
-        if (mesh) {
+        if (tessellation) {
           s.fitViewTrigger++;
           s.hasStarted = true;
           s.mode = "geometry";

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -66,7 +66,7 @@ function m(): KofemModule {
 
 // Group a flat typed array (xyz / abc interleaved) into [a, b, c] tuples.
 // tessellate_step now returns binary typed arrays instead of a JSON string;
-// the store's StepSurfaceMesh holds nested tuples, so unpack at this boundary —
+// the store's StepTessellation holds nested tuples, so unpack at this boundary —
 // far cheaper than the previous JSON.parse of a multi-MB text payload.
 function chunk3(flat: Float32Array | Uint32Array): [number, number, number][] {
   const n = (flat.length / 3) | 0;
@@ -148,7 +148,7 @@ self.onmessage = async (event: MessageEvent) => {
       // tessellate_step stores the OCCT shape in the module — record that so a
       // subsequent volume_mesh in this same worker can skip the reload.
       geometryLoaded = true;
-      // Return as {points, triangles} to match the StepSurfaceMesh type used by
+      // Return as {points, triangles} to match the StepTessellation type used by
       // the store; tessellate_step returns flat Float32/Uint32 typed arrays.
       self.postMessage({
         id,


### PR DESCRIPTION
## Summary

Renames the `StepSurfaceMesh` interface to `StepTessellation` throughout the codebase to align with the project's critical terminology conventions. This clarifies that the OCCT-generated triangles are a visual approximation of the CAD surface (tessellation) used for display, not a FEM mesh.

Per the CLAUDE.md conventions, "mesh" is reserved exclusively for FEM data (nodes + elements produced by Netgen). The OCCT output should never be called "mesh" — it is a tessellation that serves as display geometry and optionally as input to the volume mesher.

## Key Changes

**web/src/store/modelStore.ts**
- Renamed `StepSurfaceMesh` interface to `StepTessellation`
- Updated `stepSurface` field type and `setStepSurface()` method signature
- Updated parameter names in `setStepSurface()` implementation from `mesh` to `tessellation`

**web/src/lib/analysisFile.ts**
- Updated import and type references from `StepSurfaceMesh` to `StepTessellation`
- Updated `AnalysisState` and `KofemFieldDataV1` interface field types

**web/src/workers/solver.worker.ts**
- Updated code comments referencing the type name

## Notable Implementation Details

This is a pure rename with no functional changes. All references to the type have been updated consistently across the store, analysis file serialization, and worker comments. The change enforces the terminology convention that distinguishes between:
- **Tessellation**: OCCT-generated triangles for display (this type)
- **Surface mesh**: Quality boundary triangulation from Netgen (separate concept)
- **Volume mesh**: Tetrahedral FEM elements (reserved for solver output)

## Checklist

- [x] **No silent fallbacks** — N/A, this is a rename with no logic changes
- [x] Every input accepted by the UI or an API is actually consumed downstream — N/A, no new inputs

https://claude.ai/code/session_01TTa7Njy55cNVFvsEpDEjC3