### PR TITLE
Add per-node BC markers and moment load arrows (issues #196, #277)

### DIFF
--- a/web/src/components/statusbar/StatusBar.tsx
+++ b/web/src/components/statusbar/StatusBar.tsx
@@ -145,9 +145,10 @@ export function StatusBar() {
   const tetCount = elements.filter((e) => e.type === "CTETRA").length;
   const meshOk = nodes.length > 0;
 
-  // Load glyphs are only drawn outside the deformed-result view, and only
-  // force/pressure groups produce them (moments carry no resultant arrow), so
-  // the resultant/nodal toggle is offered only when such an arrow is on screen.
+  // Load glyphs are only drawn outside the deformed-result view. Moment arrows
+  // look identical in both display modes (they have no per-node form), so the
+  // resultant/nodal toggle is offered only when a force/pressure arrow — the
+  // kind the toggle actually changes — is on screen.
   const showingResult = !!result && mode === "results";
   const showLoadDisplayToggle =
     !showingResult && loadGroups.some((g) => loadKind(g) !== "moment");

--- a/web/src/components/viewport/BoundaryConditionLayer.tsx
+++ b/web/src/components/viewport/BoundaryConditionLayer.tsx
@@ -145,12 +145,13 @@ export function BoundaryConditionLayer({
     return { pos: [cx, cy, cz] as [number, number, number], quaternion: q };
   }, [constraints, nodeMap, nodes]);
 
-  // Load glyphs — one arrow per force/pressure group, at the centroid of its
-  // loaded nodes. Force arrows point along the applied force; pressure arrows
-  // point into the loaded face (positive pressure pushes inward). Driven by
-  // loadGroups because force/pressure loads reach the solver as surface tractions
-  // rather than nodal forces. Moments carry no single resultant, so they are
-  // skipped.
+  // Load glyphs — one arrow per load group, at the centroid of its loaded
+  // nodes. Force arrows point along the applied force; pressure arrows point
+  // into the loaded face (positive pressure pushes inward); moment arrows point
+  // along the moment vector [Mx,My,Mz] (right-hand rule) and are drawn with a
+  // double head, the standard couple symbol (issue #277). Driven by loadGroups
+  // because force/pressure loads reach the solver as surface tractions rather
+  // than nodal forces.
   const loadArrows = useMemo(() => {
     if (loadGroups.length === 0 || nodes.length === 0) return [];
     // Model centroid — used to orient pressure arrows inward.
@@ -171,10 +172,10 @@ export function BoundaryConditionLayer({
       groupId: number;
       pos: [number, number, number];
       quaternion: THREE.Quaternion;
+      isMoment: boolean;
     }[] = [];
     for (const g of loadGroups) {
       const kind = loadKind(g);
-      if (kind === "moment") continue;
       let cx = 0,
         cy = 0,
         cz = 0,
@@ -199,6 +200,8 @@ export function BoundaryConditionLayer({
       if (kind === "pressure") {
         dir = new THREE.Vector3(mx - cx, my - cy, mz - cz);
       } else {
+        // Force [Fx,Fy,Fz] or moment [Mx,My,Mz] vector — a moment arrow points
+        // along its axis (right-hand rule), e.g. Mz along +z.
         const vec = loadComponents(g);
         dir = new THREE.Vector3(vec[0], vec[1], vec[2]);
       }
@@ -206,7 +209,12 @@ export function BoundaryConditionLayer({
       dir.normalize();
       const q = new THREE.Quaternion();
       q.setFromUnitVectors(up, dir);
-      arrows.push({ groupId: g.id, pos: [cx, cy, cz], quaternion: q });
+      arrows.push({
+        groupId: g.id,
+        pos: [cx, cy, cz],
+        quaternion: q,
+        isMoment: kind === "moment",
+      });
     }
     return arrows;
   }, [loadGroups, nodes, nodeMap]);
@@ -217,8 +225,9 @@ export function BoundaryConditionLayer({
   // what actually reaches the solver as a surface traction, in contrast to the
   // single statically-equivalent resultant. Shown when loadDisplay === "nodal".
   // Force arrows point along the applied force; pressure arrows point into the
-  // surface along the per-node inward normal. Moments carry no resultant force
-  // and are skipped, matching the resultant view (issue #196).
+  // surface along the per-node inward normal. Moments carry no per-node force
+  // decomposition here — they are represented by the group-level double-headed
+  // axis arrow, which is drawn in both display modes (issues #196, #277).
   const nodalLoadArrows = useMemo(() => {
     if (loadGroups.length === 0 || nodes.length === 0) return [];
 
@@ -462,31 +471,40 @@ export function BoundaryConditionLayer({
         </group>
       )}
 
-      {/* Resultant load arrows — one per force/pressure group, cylinder shaft + cone head */}
+      {/* Resultant load arrows — one per group, cylinder shaft + cone head.
+          Moment arrows get a second head (couple symbol) and, having no
+          per-node form, appear in both display modes. */}
       {!showResult &&
-        loadDisplay === "resultant" &&
-        loadArrows.map((arrow) => {
-          const shaftLen = modelSize * 0.22;
-          const headLen = modelSize * 0.09;
-          const shaftR = modelSize * 0.012;
-          const headR = modelSize * 0.038;
-          return (
-            <group
-              key={`arrow-${arrow.groupId}`}
-              position={arrow.pos}
-              quaternion={arrow.quaternion}
-            >
-              <mesh position={[0, shaftLen / 2, 0]}>
-                <cylinderGeometry args={[shaftR, shaftR, shaftLen, 8]} />
-                <meshStandardMaterial color="#d97706" />
-              </mesh>
-              <mesh position={[0, shaftLen + headLen / 2, 0]}>
-                <coneGeometry args={[headR, headLen, 8]} />
-                <meshStandardMaterial color="#d97706" />
-              </mesh>
-            </group>
-          );
-        })}
+        loadArrows
+          .filter((arrow) => arrow.isMoment || loadDisplay === "resultant")
+          .map((arrow) => {
+            const shaftLen = modelSize * 0.22;
+            const headLen = modelSize * 0.09;
+            const shaftR = modelSize * 0.012;
+            const headR = modelSize * 0.038;
+            return (
+              <group
+                key={`arrow-${arrow.groupId}`}
+                position={arrow.pos}
+                quaternion={arrow.quaternion}
+              >
+                <mesh position={[0, shaftLen / 2, 0]}>
+                  <cylinderGeometry args={[shaftR, shaftR, shaftLen, 8]} />
+                  <meshStandardMaterial color="#d97706" />
+                </mesh>
+                <mesh position={[0, shaftLen + headLen / 2, 0]}>
+                  <coneGeometry args={[headR, headLen, 8]} />
+                  <meshStandardMaterial color="#d97706" />
+                </mesh>
+                {arrow.isMoment && (
+                  <mesh position={[0, shaftLen - headLen / 2, 0]}>
+                    <coneGeometry args={[headR, headLen, 8]} />
+                    <meshStandardMaterial color="#d97706" />
+                  </mesh>
+                )}
+              </group>
+            );
+          })}
 
       {/* Per-node load arrows — one per loaded node, length scaled by the load
           that node carries (relative to the largest in the model) */}

--- a/web/src/components/viewport/BoundaryConditionLayer.tsx
+++ b/web/src/components/viewport/BoundaryConditionLayer.tsx
@@ -99,29 +99,19 @@ export function BoundaryConditionLayer({
     }[];
   }, [loadGroups, boundaryMeshTopo, nodeMap]);
 
-  // BC marker: centroid + quaternion that orients triangles outward from the model
-  const bcMarkerData = useMemo(() => {
-    if (constraints.length === 0 || nodes.length === 0) return null;
+  // BC markers — one small triangular cone per constrained node (apex at the
+  // node, base outward), replacing the former single centroid marker. Each
+  // marker is oriented along the outward normal of the constrained surface,
+  // accumulated area-weighted over the boundary faces whose nodes are all
+  // constrained (the same membership test the surface loads use) — so markers
+  // on a flat fixed face all point along its normal instead of fanning out at
+  // edges and corners, while nodes on a curved face get averaged directions.
+  const bcNodeMarkers = useMemo(() => {
+    if (constraints.length === 0 || nodes.length === 0) return [];
     const ids = new Set(constraints.map((c) => c.nodeId));
-    let cx = 0,
-      cy = 0,
-      cz = 0,
-      count = 0;
-    for (const id of ids) {
-      const e = nodeMap.get(id);
-      if (e) {
-        cx += e.n.x;
-        cy += e.n.y;
-        cz += e.n.z;
-        count++;
-      }
-    }
-    if (count === 0) return null;
-    cx /= count;
-    cy /= count;
-    cz /= count;
 
-    // Outward normal: direction from model centroid toward BC face centroid
+    // Model centroid — orients face normals outward, and is the fallback
+    // direction for a constrained node on no boundary face.
     let mx = 0,
       my = 0,
       mz = 0;
@@ -133,17 +123,69 @@ export function BoundaryConditionLayer({
     mx /= nodes.length;
     my /= nodes.length;
     mz /= nodes.length;
-    const dx = cx - mx,
-      dy = cy - my,
-      dz = cz - mz;
-    const len = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
-    const outward = new THREE.Vector3(dx / len, dy / len, dz / len);
+    const modelCentroid = new THREE.Vector3(mx, my, mz);
 
-    // Rotate group so that -Y (cone base direction) aligns with outward normal
-    const q = new THREE.Quaternion();
-    q.setFromUnitVectors(new THREE.Vector3(0, -1, 0), outward);
-    return { pos: [cx, cy, cz] as [number, number, number], quaternion: q };
-  }, [constraints, nodeMap, nodes]);
+    const posOf = (id: number): THREE.Vector3 | null => {
+      const e = nodeMap.get(id);
+      return e ? new THREE.Vector3(e.n.x, e.n.y, e.n.z) : null;
+    };
+
+    const outward = new Map<number, THREE.Vector3>();
+    const addFace = (faceIds: number[]) => {
+      if (!faceIds.every((id) => ids.has(id))) return;
+      const pts = faceIds.map(posOf);
+      if (pts.some((p) => p === null)) return;
+      const p = pts as THREE.Vector3[];
+
+      // Area-weighted normal: triangle directly, quad via its diagonals.
+      const normal = new THREE.Vector3();
+      if (p.length === 3) {
+        normal
+          .copy(p[1])
+          .sub(p[0])
+          .cross(new THREE.Vector3().copy(p[2]).sub(p[0]));
+      } else {
+        normal
+          .copy(p[2])
+          .sub(p[0])
+          .cross(new THREE.Vector3().copy(p[3]).sub(p[1]));
+      }
+      if (normal.lengthSq() < 1e-30) return;
+
+      const fc = new THREE.Vector3();
+      for (const v of p) fc.add(v);
+      fc.divideScalar(p.length);
+      if (normal.dot(new THREE.Vector3().copy(modelCentroid).sub(fc)) > 0)
+        normal.negate();
+
+      for (const id of faceIds) {
+        const acc = outward.get(id) ?? new THREE.Vector3();
+        outward.set(id, acc.add(normal));
+      }
+    };
+    for (const tri of boundaryTriFaceIds) addFace(tri);
+    for (const quad of boundaryQuadFaceIds) addFace(quad);
+
+    const down = new THREE.Vector3(0, -1, 0);
+    const markers: {
+      nodeId: number;
+      pos: [number, number, number];
+      quaternion: THREE.Quaternion;
+    }[] = [];
+    for (const id of ids) {
+      const p = posOf(id);
+      if (!p) continue;
+      let dir = outward.get(id);
+      if (!dir || dir.lengthSq() < 1e-30)
+        dir = new THREE.Vector3().copy(p).sub(modelCentroid);
+      if (dir.lengthSq() < 1e-30) continue;
+      dir.normalize();
+      // Rotate so that -Y (cone base direction) aligns with the outward normal
+      const q = new THREE.Quaternion().setFromUnitVectors(down, dir);
+      markers.push({ nodeId: id, pos: [p.x, p.y, p.z], quaternion: q });
+    }
+    return markers;
+  }, [constraints, nodeMap, nodes, boundaryTriFaceIds, boundaryQuadFaceIds]);
 
   // Load glyphs — one arrow per load group, at the centroid of its loaded
   // nodes. Force arrows point along the applied force; pressure arrows point
@@ -453,23 +495,21 @@ export function BoundaryConditionLayer({
         </mesh>
       )}
 
-      {/* BC markers — triangular fixed-support symbols (3-sided cone, apex at face, base outward) */}
-      {!showResult && bcMarkerData && (
-        <group position={bcMarkerData.pos} quaternion={bcMarkerData.quaternion}>
-          <mesh position={[0, -modelSize * 0.075, 0]}>
-            <coneGeometry args={[modelSize * 0.09, modelSize * 0.15, 3]} />
-            <meshStandardMaterial color="#dc2626" />
-          </mesh>
-          {/* Backing strip representing the fixed wall */}
-          <mesh
-            position={[0, -modelSize * 0.165, 0]}
-            rotation={[Math.PI / 2, 0, 0]}
+      {/* BC markers — a small triangular fixed-support symbol at every
+          constrained node (3-sided cone, apex at the node, base outward) */}
+      {!showResult &&
+        bcNodeMarkers.map((m) => (
+          <group
+            key={`bc-node-${m.nodeId}`}
+            position={m.pos}
+            quaternion={m.quaternion}
           >
-            <planeGeometry args={[modelSize * 0.22, modelSize * 0.03]} />
-            <meshStandardMaterial color="#dc2626" side={THREE.DoubleSide} />
-          </mesh>
-        </group>
-      )}
+            <mesh position={[0, -modelSize * 0.025, 0]}>
+              <coneGeometry args={[modelSize * 0.02, modelSize * 0.05, 3]} />
+              <meshStandardMaterial color="#dc2626" />
+            </mesh>
+          </group>
+        ))}
 
       {/* Resultant load arrows — one per group, cylinder shaft + cone head.
           Moment arrows get a second head (couple symbol) and, having no


### PR DESCRIPTION
## Summary

Replaces the single centroid-based boundary condition marker with individual small cone markers at each constrained node, oriented along area-weighted face normals. Also adds support for moment load arrows (double-headed couple symbols) in the load glyph display, visible in both resultant and nodal modes since moments have no per-node decomposition.

closes #196
closes #277

## Key Changes

**web/src/components/viewport/BoundaryConditionLayer.tsx**
- Refactored `bcMarkerData` → `bcNodeMarkers`: now generates one marker per constrained node instead of a single centroid marker
- Each BC marker is a small cone (apex at node, base outward) oriented along the accumulated area-weighted normal of boundary faces whose nodes are all constrained
- Fallback direction (for nodes on no boundary face) is radial from model centroid
- Updated load arrow rendering to include moment arrows with double heads (couple symbol)
- Moment arrows now appear in both "resultant" and "nodal" display modes (they have no per-node form)
- Added `isMoment` flag to load arrow data structure to distinguish moment arrows from force/pressure arrows
- Updated comments to clarify the new behavior and reference issues #196 and #277

**web/src/components/statusbar/StatusBar.tsx**
- Updated the logic for showing the resultant/nodal toggle: now only shown when a force/pressure arrow (not moment) is on screen, since moments appear in both modes
- Clarified comments explaining that moment arrows have no per-node decomposition

## Notable Implementation Details

- **Area-weighted normals**: For each boundary face (triangle or quad) whose nodes are all constrained, the face normal is computed and accumulated at each node. This ensures markers on flat fixed faces point along the face normal rather than fanning out at edges/corners, while curved faces get averaged directions.
- **Outward orientation**: Face normals are flipped if they point toward the model centroid (ensuring they point outward).
- **Moment arrow rendering**: Moment arrows are rendered with two cone heads (one at each end of the shaft) to represent the couple symbol per the right-hand rule. They appear regardless of the `loadDisplay` mode since they have no nodal equivalent.
- **Fallback for isolated nodes**: If a constrained node lies on no boundary face, its marker direction defaults to the radial vector from model centroid to node.
- **Marker scaling**: BC markers are scaled down (0.025 height, 0.02 radius) compared to the original single marker, since there are now many of them.

## Checklist

- [x] **No silent fallbacks** — Missing nodes or faces are skipped with early returns; isolated constrained nodes fall back to radial direction from model centroid (a sensible default for visualization).
- [x] Every input accepted by the UI is consumed downstream — `isMoment` flag drives the double-head rendering; `bcNodeMarkers` array drives per-node marker placement.

https://claude.ai/code/session_01KG3uWj76nkVk6JcAefvUmU