### PR TITLE
Add "New analysis" button to reset workspace with confirmation

### DIFF
--- a/web/src/components/topbar/TopBar.tsx
+++ b/web/src/components/topbar/TopBar.tsx
@@ -17,9 +17,9 @@ export function TopBar() {
   const loadInputRef = useRef<HTMLInputElement | null>(null);
 
   function handleNewAnalysis() {
-    const s = useModelStore.getState();
+    const store = useModelStore.getState();
     if (
-      s.hasStarted &&
+      store.hasStarted &&
       !window.confirm(
         "Start a new analysis? Unsaved changes will be lost — save the current analysis first if you want to keep it.",
       )
@@ -28,7 +28,7 @@ export function TopBar() {
     // Drop the worker too: it may still hold the imported OCCT shape, and any
     // in-flight mesh/solve belongs to the analysis being discarded.
     resetWorker();
-    s.reset();
+    store.reset();
   }
 
   function handleSave() {

--- a/web/src/components/topbar/TopBar.tsx
+++ b/web/src/components/topbar/TopBar.tsx
@@ -8,12 +8,28 @@ import {
   parseAnalysisFile,
   serializeAnalysis,
 } from "../../lib/analysisFile";
+import { resetWorker } from "../../workers/sharedWorker";
 import styles from "./TopBar.module.css";
 
 export function TopBar() {
   const modelName = useModelStore((s) => s.modelName);
   const loadAnalysis = useModelStore((s) => s.loadAnalysis);
   const loadInputRef = useRef<HTMLInputElement | null>(null);
+
+  function handleNewAnalysis() {
+    const s = useModelStore.getState();
+    if (
+      s.hasStarted &&
+      !window.confirm(
+        "Start a new analysis? Unsaved changes will be lost — save the current analysis first if you want to keep it.",
+      )
+    )
+      return;
+    // Drop the worker too: it may still hold the imported OCCT shape, and any
+    // in-flight mesh/solve belongs to the analysis being discarded.
+    resetWorker();
+    s.reset();
+  }
 
   function handleSave() {
     const s = useModelStore.getState();
@@ -67,6 +83,33 @@ export function TopBar() {
           style={{ display: "none" }}
           onChange={handleLoadFile}
         />
+        <button
+          className={styles.iconBtn}
+          title="New analysis"
+          aria-label="New analysis"
+          onClick={handleNewAnalysis}
+        >
+          <svg width="15" height="15" viewBox="0 0 16 16" fill="none">
+            <path
+              d="M9 2H4a1 1 0 00-1 1v10a1 1 0 001 1h8a1 1 0 001-1V6L9 2z"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M9 2v4h4"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M8 8.5v3M6.5 10h3"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
         <button
           className={styles.iconBtn}
           title="Save analysis (.vtu)"

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -791,6 +791,7 @@ export const useModelStore = create<ModelState>()(
         s.nextFaceEntryId = 1;
         s.modelName = "";
         s.result = null;
+        s.resultType = "Displacement (magnitude)";
         s.stepSurface = null;
         s.stepBytes = null;
         s.geometryFormat = "step";
@@ -799,10 +800,16 @@ export const useModelStore = create<ModelState>()(
         s.surfaceFaceIds = null;
         s.viewRepr = "surface";
         s.deformScale = 1;
+        s.elementOrder = 1;
         s.nextMatId = 2;
         s.selectedFace = null;
+        s.pendingFaces = [];
         s.pickMode = null;
         s.pickTargetGroupId = null;
+        s.mode = "geometry";
+        s.stepImportError = null;
+        s.isRunning = false;
+        s.isMeshing = false;
         s.hasStarted = false;
       }),
 

--- a/web/tests/new-analysis.spec.ts
+++ b/web/tests/new-analysis.spec.ts
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from "./coverage";
+import { gotoApp } from "./fixtures/app";
+
+// Coverage for the TopBar "New analysis" button (issue #189): it confirms with
+// the user when work would be lost, then resets the store to a fresh session.
+
+type StoreSnapshot = {
+  modelName: string;
+  nodes: number;
+  elements: number;
+  hasResult: boolean;
+  hasStarted: boolean;
+  mode: string;
+  bcGroups: number;
+  loadGroups: number;
+};
+
+function readStore(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const s = (
+      window as unknown as {
+        __kofemStore: {
+          getState(): {
+            modelName: string;
+            nodes: unknown[];
+            elements: unknown[];
+            result: unknown;
+            hasStarted: boolean;
+            mode: string;
+            bcGroups: unknown[];
+            loadGroups: unknown[];
+          };
+        };
+      }
+    ).__kofemStore.getState();
+    return {
+      modelName: s.modelName,
+      nodes: s.nodes.length,
+      elements: s.elements.length,
+      hasResult: s.result !== null,
+      hasStarted: s.hasStarted,
+      mode: s.mode,
+      bcGroups: s.bcGroups.length,
+      loadGroups: s.loadGroups.length,
+    } satisfies StoreSnapshot;
+  });
+}
+
+// Load a pre-solved example so the store carries a full analysis to discard.
+async function loadExample(page: import("@playwright/test").Page) {
+  await page.goto("/app/?example=cantilever-beam");
+  await expect(page.locator("nav")).toBeVisible();
+  await expect
+    .poll(async () => (await readStore(page)).nodes, { timeout: 15_000 })
+    .toBeGreaterThan(0);
+}
+
+test("New analysis confirms, then clears the loaded analysis", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+  await loadExample(page);
+
+  let dialogMessage = "";
+  page.on("dialog", (d) => {
+    dialogMessage = d.message();
+    void d.accept();
+  });
+
+  await page.getByRole("button", { name: "New analysis" }).click();
+
+  expect(dialogMessage).toContain("Start a new analysis?");
+  const s = await readStore(page);
+  expect(s).toEqual({
+    modelName: "",
+    nodes: 0,
+    elements: 0,
+    hasResult: false,
+    hasStarted: false,
+    mode: "geometry",
+    bcGroups: 0,
+    loadGroups: 0,
+  } satisfies StoreSnapshot);
+
+  // Back to a fresh workspace: Untitled crumb and the import cards.
+  await expect(page.getByText("Untitled")).toBeVisible();
+  await expect(
+    page.getByRole("button").filter({ hasText: "Import STEP" }),
+  ).toBeVisible();
+});
+
+test("dismissing the confirm keeps the current analysis", async ({ page }) => {
+  test.setTimeout(60_000);
+  await loadExample(page);
+
+  page.on("dialog", (d) => void d.dismiss());
+  await page.getByRole("button", { name: "New analysis" }).click();
+
+  const s = await readStore(page);
+  expect(s.nodes).toBeGreaterThan(0);
+  expect(s.modelName).toBe("Cantilever beam under tip load");
+  expect(s.hasResult).toBe(true);
+});
+
+test("with an empty workspace no confirmation is asked", async ({ page }) => {
+  await gotoApp(page);
+
+  let dialogFired = false;
+  page.on("dialog", (d) => {
+    dialogFired = true;
+    void d.accept();
+  });
+
+  await page.getByRole("button", { name: "New analysis" }).click();
+
+  expect(dialogFired).toBe(false);
+  expect((await readStore(page)).nodes).toBe(0);
+});

--- a/web/tests/new-analysis.spec.ts
+++ b/web/tests/new-analysis.spec.ts
@@ -20,7 +20,7 @@ type StoreSnapshot = {
 
 function readStore(page: import("@playwright/test").Page) {
   return page.evaluate(() => {
-    const s = (
+    const state = (
       window as unknown as {
         __kofemStore: {
           getState(): {
@@ -37,14 +37,14 @@ function readStore(page: import("@playwright/test").Page) {
       }
     ).__kofemStore.getState();
     return {
-      modelName: s.modelName,
-      nodes: s.nodes.length,
-      elements: s.elements.length,
-      hasResult: s.result !== null,
-      hasStarted: s.hasStarted,
-      mode: s.mode,
-      bcGroups: s.bcGroups.length,
-      loadGroups: s.loadGroups.length,
+      modelName: state.modelName,
+      nodes: state.nodes.length,
+      elements: state.elements.length,
+      hasResult: state.result !== null,
+      hasStarted: state.hasStarted,
+      mode: state.mode,
+      bcGroups: state.bcGroups.length,
+      loadGroups: state.loadGroups.length,
     } satisfies StoreSnapshot;
   });
 }
@@ -65,16 +65,16 @@ test("New analysis confirms, then clears the loaded analysis", async ({
   await loadExample(page);
 
   let dialogMessage = "";
-  page.on("dialog", (d) => {
-    dialogMessage = d.message();
-    void d.accept();
+  page.on("dialog", async (dialog) => {
+    dialogMessage = dialog.message();
+    await dialog.accept();
   });
 
   await page.getByRole("button", { name: "New analysis" }).click();
 
   expect(dialogMessage).toContain("Start a new analysis?");
-  const s = await readStore(page);
-  expect(s).toEqual({
+  const snapshot = await readStore(page);
+  expect(snapshot).toEqual({
     modelName: "",
     nodes: 0,
     elements: 0,
@@ -96,22 +96,24 @@ test("dismissing the confirm keeps the current analysis", async ({ page }) => {
   test.setTimeout(60_000);
   await loadExample(page);
 
-  page.on("dialog", (d) => void d.dismiss());
+  page.on("dialog", async (dialog) => {
+    await dialog.dismiss();
+  });
   await page.getByRole("button", { name: "New analysis" }).click();
 
-  const s = await readStore(page);
-  expect(s.nodes).toBeGreaterThan(0);
-  expect(s.modelName).toBe("Cantilever beam under tip load");
-  expect(s.hasResult).toBe(true);
+  const snapshot = await readStore(page);
+  expect(snapshot.nodes).toBeGreaterThan(0);
+  expect(snapshot.modelName).toBe("Cantilever beam under tip load");
+  expect(snapshot.hasResult).toBe(true);
 });
 
 test("with an empty workspace no confirmation is asked", async ({ page }) => {
   await gotoApp(page);
 
   let dialogFired = false;
-  page.on("dialog", (d) => {
+  page.on("dialog", async (dialog) => {
     dialogFired = true;
-    void d.accept();
+    await dialog.accept();
   });
 
   await page.getByRole("button", { name: "New analysis" }).click();


### PR DESCRIPTION
## Summary

Adds a "New analysis" button to the TopBar that allows users to start a fresh analysis session. When clicked, it confirms with the user if work would be lost (i.e., if an analysis has been started), then resets the store to a clean state and terminates the shared worker.

closes #189

## Key Changes

**web/src/components/topbar/TopBar.tsx**
- Added `handleNewAnalysis()` function that:
  - Checks if analysis has started via `hasStarted` flag
  - Shows confirmation dialog if work exists (with clear warning about unsaved changes)
  - Resets the worker via `resetWorker()` to drop any in-flight mesh/solve operations and cached OCCT geometry
  - Calls `s.reset()` to clear the store
- Added new "New analysis" button with document icon to the TopBar

**web/src/store/modelStore.ts**
- Enhanced `reset()` action to fully reinitialize all store fields:
  - Clears analysis data: `modelName`, `result`, `resultType`, geometry/mesh state
  - Resets UI state: `mode` to "geometry", `elementOrder` to 1, `deformScale` to 1
  - Clears transient state: `pendingFaces`, `stepImportError`, `isRunning`, `isMeshing`
  - Ensures a truly fresh workspace matching initial app state

**web/tests/new-analysis.spec.ts** (new)
- Three test cases covering the feature:
  1. Confirms and clears a loaded analysis (verifies dialog, store reset, UI returns to import cards)
  2. Dismissing confirmation preserves the current analysis
  3. Empty workspace skips confirmation dialog entirely

## Notable Implementation Details

- The confirmation dialog only appears if `hasStarted` is true, avoiding unnecessary prompts in a fresh workspace
- `resetWorker()` is called before `s.reset()` to ensure the worker is terminated before the store changes, preventing any race conditions with in-flight operations
- The `reset()` action now comprehensively reinitializes all fields (not just the obvious ones) to guarantee a clean slate. This includes less obvious fields like `resultType`, `elementOrder`, `stepImportError`, and `isMeshing` that could otherwise carry stale state.
- The confirmation message explicitly warns about unsaved changes and suggests saving first, guiding users toward the Save button if they want to preserve work

## Checklist

- [x] **No silent fallbacks** — confirmation dialog is explicit; `reset()` fully reinitializes all state fields
- [x] Every input accepted by the UI is consumed downstream — the button triggers `handleNewAnalysis()` which calls `resetWorker()` and `s.reset()`

https://claude.ai/code/session_01J9XwLbGPpgbSBzgZzJZWmv