### PR TITLE
Refactor modelStore into focused slices (issue #202)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "format:check": "prettier --check src tests eslint-rules eslint.config.js \"../*.md\" \"../.github/**/*.md\"",
     "validate": "bun ../examples/validation/run.mjs",
     "examples:generate": "bun ../examples/web-examples/generate.mjs",
-    "test": "bun ../examples/validation/run.mjs && bun ../examples/validation/dof-constraint.test.mjs && bun ../examples/validation/prescribed-displacement.test.mjs && bun tests/test_wall_bracket.mjs 20.0 && bun tests/test_face_pick.mjs && playwright test",
+    "test": "bun ../examples/validation/run.mjs && bun ../examples/validation/dof-constraint.test.mjs && bun ../examples/validation/prescribed-displacement.test.mjs && bun tests/test_wall_bracket.mjs 20.0 && bun tests/test_face_pick.mjs && bun tests/test_moment_load.mjs && playwright test",
     "test:coverage": "rm -rf .nyc_output coverage && COVERAGE=1 playwright test && bun run coverage:report",
     "coverage:report": "nyc report && bun scripts/coverage-dead-code.ts",
     "test:ui": "playwright test --ui",

--- a/web/src/store/boundarySlice.ts
+++ b/web/src/store/boundarySlice.ts
@@ -351,10 +351,14 @@ export const createBoundarySlice: SliceCreator<BoundarySlice> = (set) => ({
 
   addFaceToBcGroup: (groupId: number, face: Omit<BcFaceEntry, "id">) =>
     set((s) => {
-      const g = s.bcGroups.find((g) => g.id === groupId);
-      if (!g) return;
+      const group = s.bcGroups.find((g) => g.id === groupId);
+      if (!group) return;
       const faceId = s.nextFaceEntryId++;
-      g.faces.push({ id: faceId, label: face.label, nodeIds: face.nodeIds });
+      group.faces.push({
+        id: faceId,
+        label: face.label,
+        nodeIds: face.nodeIds,
+      });
       s.constraints = rebuildConstraints(s.bcGroups);
       s.result = null;
     }),
@@ -371,10 +375,10 @@ export const createBoundarySlice: SliceCreator<BoundarySlice> = (set) => ({
 
   removeFaceFromBcGroup: (groupId: number, faceId: number) =>
     set((s) => {
-      const g = s.bcGroups.find((g) => g.id === groupId);
-      if (!g) return;
-      g.faces = g.faces.filter((f) => f.id !== faceId);
-      if (g.faces.length === 0)
+      const group = s.bcGroups.find((g) => g.id === groupId);
+      if (!group) return;
+      group.faces = group.faces.filter((f) => f.id !== faceId);
+      if (group.faces.length === 0)
         s.bcGroups = s.bcGroups.filter((g) => g.id !== groupId);
       s.constraints = rebuildConstraints(s.bcGroups);
       s.result = null;
@@ -430,10 +434,14 @@ export const createBoundarySlice: SliceCreator<BoundarySlice> = (set) => ({
 
   addFaceToLoadGroup: (groupId: number, face: Omit<BcFaceEntry, "id">) =>
     set((s) => {
-      const g = s.loadGroups.find((g) => g.id === groupId);
-      if (!g) return;
+      const group = s.loadGroups.find((g) => g.id === groupId);
+      if (!group) return;
       const faceId = s.nextFaceEntryId++;
-      g.faces.push({ id: faceId, label: face.label, nodeIds: face.nodeIds });
+      group.faces.push({
+        id: faceId,
+        label: face.label,
+        nodeIds: face.nodeIds,
+      });
       s.loads = rebuildLoads(s.loadGroups, s.nodes);
       s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
       s.result = null;
@@ -467,10 +475,10 @@ export const createBoundarySlice: SliceCreator<BoundarySlice> = (set) => ({
 
   removeFaceFromLoadGroup: (groupId: number, faceId: number) =>
     set((s) => {
-      const g = s.loadGroups.find((g) => g.id === groupId);
-      if (!g) return;
-      g.faces = g.faces.filter((f) => f.id !== faceId);
-      if (g.faces.length === 0)
+      const group = s.loadGroups.find((g) => g.id === groupId);
+      if (!group) return;
+      group.faces = group.faces.filter((f) => f.id !== faceId);
+      if (group.faces.length === 0)
         s.loadGroups = s.loadGroups.filter((g) => g.id !== groupId);
       s.loads = rebuildLoads(s.loadGroups, s.nodes);
       s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);

--- a/web/src/store/boundarySlice.ts
+++ b/web/src/store/boundarySlice.ts
@@ -1,0 +1,495 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Boundary slice: named BC / load groups (the primary source of truth), the
+// flat constraint/load arrays derived from them for the solver, and the
+// face-pick session state used to build groups in the viewport.
+
+import type { SliceCreator } from "./modelStore";
+import type { Element, Node } from "./geometrySlice";
+import { momentToNodalForces } from "./momentLoad";
+
+export interface Constraint {
+  nodeId: number;
+  dof: number; // 0=Ux 1=Uy 2=Uz 3=Rx 4=Ry 5=Rz
+  prescribedValue?: number;
+}
+
+export interface Load {
+  nodeId: number;
+  dof: number;
+  value: number;
+}
+
+export interface FaceSelection {
+  nodeIds: number[];
+  label: string; // e.g. "Min X face (9 nodes)"
+  axis: "X" | "Y" | "Z";
+  isMax: boolean;
+}
+
+// ── Named BC / Load groups ────────────────────────────────────────────────────
+
+export interface BcFaceEntry {
+  id: number;
+  label: string; // e.g. "Face 1"
+  nodeIds: number[];
+}
+
+export interface NamedBcGroup {
+  id: number;
+  name: string; // e.g. "BC1"
+  dofs: number[];
+  value: number;
+  faces: BcFaceEntry[];
+}
+
+// A load group's physical kind. "force" and "pressure" are applied to the solver
+// as work-equivalent surface tractions (SurfaceLoad); "moment" is still lumped to
+// equivalent nodal forces (rebuildLoads). For backward-compat with saved analyses
+// that predate this field, `kind` is optional and inferred from `dof` via
+// loadKind().
+export type LoadKind = "force" | "moment" | "pressure";
+
+export interface NamedLoadGroup {
+  id: number;
+  name: string; // e.g. "Load1"
+  dof: number; // force: 0=Fx,1=Fy,2=Fz · moment: 3=Mx,4=My,5=Mz · pressure: unused
+  totalForce: number; // force/moment magnitude (N, N·mm), or pressure magnitude (MPa)
+  // Componentwise force [Fx,Fy,Fz] (N) or moment [Mx,My,Mz] (N·mm) vector
+  // (issues #219, #190). Present on force/moment groups created via the
+  // componentwise UI, where it is the source of truth and supersedes
+  // dof/totalForce. Absent on pressure groups and on payloads saved before
+  // componentwise input existed — those reconstruct the vector from dof +
+  // totalForce via loadComponents().
+  components?: [number, number, number];
+  faces: BcFaceEntry[];
+  kind?: LoadKind;
+}
+
+// Physical kind of a load group, defaulting from `dof` for older payloads that
+// have no explicit `kind` (dof ≤ 2 ⇒ force, dof ≥ 3 ⇒ moment).
+export function loadKind(g: NamedLoadGroup): LoadKind {
+  return g.kind ?? (g.dof <= 2 ? "force" : "moment");
+}
+
+// The force [Fx,Fy,Fz] (N) or moment [Mx,My,Mz] (N·mm) vector of a load group.
+// Uses the explicit componentwise vector when present, else reconstructs the
+// single-axis vector from the legacy dof + totalForce (force: axis 0–2; moment:
+// axis dof−3). Pressure groups have no vector and return zeros.
+export function loadComponents(g: NamedLoadGroup): [number, number, number] {
+  if (g.components) return g.components;
+  const vec: [number, number, number] = [0, 0, 0];
+  const kind = loadKind(g);
+  if (kind === "force" && g.dof >= 0 && g.dof <= 2) vec[g.dof] = g.totalForce;
+  else if (kind === "moment" && g.dof >= 3 && g.dof <= 5)
+    vec[g.dof - 3] = g.totalForce;
+  return vec;
+}
+
+// Legacy single-axis summary (primary axis + signed magnitude) of a componentwise
+// vector, stored alongside `components` so older readers and the pre-flight
+// fallback still see a sensible dof/totalForce. For a single non-zero component
+// this reproduces the vector exactly; for a general vector it names the first
+// non-zero axis. `components` remains the source of truth.
+function summarizeComponents(
+  components: [number, number, number],
+  kind: LoadKind,
+): { dof: number; totalForce: number } {
+  const found = components.findIndex((value) => value !== 0);
+  const axis = found < 0 ? 0 : found;
+  return {
+    dof: kind === "moment" ? axis + 3 : axis,
+    totalForce: components[axis],
+  };
+}
+
+// A work-equivalent surface load handed to the engine's boundary integrator.
+// `faces` are the element boundary faces of one loaded face — triangles (tets) or
+// quads (hexes) — each a list of node indices the engine matches to its generated
+// boundary elements by vertex set.
+//   force    — total force vector, spread by the engine as a uniform traction
+//   pressure — scalar magnitude, applied as -p·n̂ (outward normal; + pushes in)
+//   traction — traction vector applied directly (not surfaced in the UI yet)
+export interface SurfaceLoad {
+  type: "force" | "pressure" | "traction";
+  faces: number[][];
+  force?: [number, number, number];
+  pressure?: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+export function rebuildConstraints(bcGroups: NamedBcGroup[]): Constraint[] {
+  const result: Constraint[] = [];
+  for (const g of bcGroups)
+    for (const f of g.faces)
+      for (const nodeId of f.nodeIds)
+        for (const dof of g.dofs)
+          result.push({ nodeId, dof, prescribedValue: g.value });
+  return result;
+}
+
+// Local vertex indices of each boundary face of a solid element, in the node
+// ordering used by both the .inp/fixture meshes and MFEM's AddTet/AddHex (and so
+// by the boundary elements the engine generates). Matching is by vertex set, so
+// only the grouping matters, not the winding.
+const TET_FACE_INDICES = [
+  [0, 1, 2],
+  [0, 1, 3],
+  [0, 2, 3],
+  [1, 2, 3],
+];
+const HEX_FACE_INDICES = [
+  [0, 1, 2, 3],
+  [4, 5, 6, 7],
+  [0, 1, 5, 4],
+  [1, 2, 6, 5],
+  [2, 3, 7, 6],
+  [3, 0, 4, 7],
+];
+
+// The element boundary faces lying on one loaded face: every solid-element face
+// whose nodes all belong to the face's node set — triangles for tets, quads for
+// hexes. The engine matches these to its generated boundary elements by vertex
+// set (and ignores any interior faces that aren't boundaries), so the load is
+// integrated over the real surface, mesh type regardless.
+function loadedFaces(
+  face: { nodeIds: number[] },
+  elements: Element[],
+): number[][] {
+  const nodeSet = new Set(face.nodeIds);
+  const seen = new Set<string>();
+  const faces: number[][] = [];
+  for (const el of elements) {
+    const local =
+      el.type === "CTETRA"
+        ? TET_FACE_INDICES
+        : el.type === "CHEXA"
+          ? HEX_FACE_INDICES
+          : null;
+    if (!local) continue;
+    for (const lf of local) {
+      const verts = lf.map((i) => el.nodeIds[i]);
+      if (!verts.every((v) => nodeSet.has(v))) continue;
+      const key = [...verts].sort((a, b) => a - b).join(",");
+      if (seen.has(key)) continue; // a boundary face is owned by one element
+      seen.add(key);
+      faces.push(verts);
+    }
+  }
+  return faces;
+}
+
+export function rebuildLoads(
+  loadGroups: NamedLoadGroup[],
+  nodes: Node[],
+): Load[] {
+  const nodeById = new Map<number, Node>();
+  for (const n of nodes) nodeById.set(n.id, n);
+
+  const result: Load[] = [];
+  for (const g of loadGroups) {
+    // Force and pressure loads are applied as work-equivalent surface tractions
+    // (rebuildSurfaceLoads), not lumped nodal forces — they are skipped here.
+    if (loadKind(g) !== "moment") continue;
+    result.push(
+      ...momentToNodalForces(loadComponents(g), g.faces, nodeById, g.name),
+    );
+  }
+  return result;
+}
+
+// Build the work-equivalent surface loads (one per loaded face) for force and
+// pressure groups. The engine integrates these over the face's boundary elements
+// (f_i = ∫ N_i·t dS), which is both shape-function-correct and immune to the
+// spurious moment that equal nodal splitting introduces on a non-uniform mesh.
+//
+// The loaded faces are derived from the element connectivity (loadedFaces), so a
+// load works on tet meshes (triangle faces) and hex meshes (quad faces) alike,
+// with no dependency on a separately-stored surface triangulation.
+export function rebuildSurfaceLoads(
+  loadGroups: NamedLoadGroup[],
+  elements: Element[],
+): SurfaceLoad[] {
+  const result: SurfaceLoad[] = [];
+  for (const g of loadGroups) {
+    const kind = loadKind(g);
+    if (kind === "moment") continue; // moments stay as equivalent point loads
+    for (const f of g.faces) {
+      const faces = loadedFaces(f, elements);
+      if (faces.length === 0) continue;
+      if (kind === "pressure") {
+        result.push({ type: "pressure", pressure: g.totalForce, faces });
+      } else {
+        result.push({ type: "force", force: loadComponents(g), faces });
+      }
+    }
+  }
+  return result;
+}
+
+// ── Slice ─────────────────────────────────────────────────────────────────────
+
+export interface BoundarySlice {
+  // flat arrays derived from bcGroups / loadGroups — used by solver and visualization
+  constraints: Constraint[];
+  loads: Load[];
+  // work-equivalent surface tractions (force/pressure groups) handed to the solver
+  surfaceLoads: SurfaceLoad[];
+
+  // Named BC / Load groups (primary source of truth for constraints & loads)
+  bcGroups: NamedBcGroup[];
+  loadGroups: NamedLoadGroup[];
+  nextBcGroupId: number;
+  nextLoadGroupId: number;
+  nextFaceEntryId: number;
+
+  pickMode: "bc" | "load" | null;
+  pickTargetGroupId: number | null; // null = creating new group; id = adding to existing
+  selectedFace: FaceSelection | null;
+  pendingFaces: FaceSelection[]; // faces accumulated via shift-click within a pick session
+
+  // Pick mode / face selection
+  setPickMode(mode: "bc" | "load" | null, targetGroupId?: number | null): void;
+  setSelectedFace(face: FaceSelection | null): void;
+  setPendingFaces(faces: FaceSelection[]): void;
+
+  // BC group actions
+  createBcGroup(
+    faces: Omit<BcFaceEntry, "id">[],
+    dofs: number[],
+    value: number,
+  ): void;
+  addFaceToBcGroup(groupId: number, face: Omit<BcFaceEntry, "id">): void;
+  updateBcGroup(id: number, dofs: number[], value: number): void;
+  removeFaceFromBcGroup(groupId: number, faceId: number): void;
+  deleteBcGroup(id: number): void;
+  clearConstraints(): void;
+
+  // Load group actions
+  createLoadGroup(
+    faces: Omit<BcFaceEntry, "id">[],
+    dof: number,
+    totalForce: number,
+    kind?: LoadKind,
+    components?: [number, number, number],
+  ): void;
+  addFaceToLoadGroup(groupId: number, face: Omit<BcFaceEntry, "id">): void;
+  updateLoadGroup(
+    id: number,
+    kind: LoadKind,
+    totalForce: number,
+    components?: [number, number, number],
+  ): void;
+  removeFaceFromLoadGroup(groupId: number, faceId: number): void;
+  deleteLoadGroup(id: number): void;
+  clearLoads(): void;
+}
+
+export const createBoundarySlice: SliceCreator<BoundarySlice> = (set) => ({
+  constraints: [],
+  loads: [],
+  surfaceLoads: [],
+  bcGroups: [],
+  loadGroups: [],
+  nextBcGroupId: 1,
+  nextLoadGroupId: 1,
+  nextFaceEntryId: 1,
+  pickMode: null,
+  pickTargetGroupId: null,
+  selectedFace: null,
+  pendingFaces: [],
+
+  // Pick mode / face selection
+  setPickMode: (
+    mode: "bc" | "load" | null,
+    targetGroupId: number | null = null,
+  ) =>
+    set((s) => {
+      s.pickMode = mode;
+      s.pickTargetGroupId = mode !== null ? (targetGroupId ?? null) : null;
+      if (mode === null) {
+        s.selectedFace = null;
+        s.pendingFaces = [];
+      }
+    }),
+
+  setSelectedFace: (face: FaceSelection | null) =>
+    set((s) => {
+      s.selectedFace = face;
+    }),
+
+  setPendingFaces: (faces: FaceSelection[]) =>
+    set((s) => {
+      s.pendingFaces = faces;
+    }),
+
+  // BC group actions
+  createBcGroup: (
+    faces: Omit<BcFaceEntry, "id">[],
+    dofs: number[],
+    value: number,
+  ) =>
+    set((s) => {
+      const faceEntries = faces.map((f) => ({
+        id: s.nextFaceEntryId++,
+        label: f.label,
+        nodeIds: f.nodeIds,
+      }));
+      s.bcGroups.push({
+        id: s.nextBcGroupId,
+        name: `BC${s.nextBcGroupId}`,
+        dofs,
+        value,
+        faces: faceEntries,
+      });
+      s.nextBcGroupId++;
+      s.constraints = rebuildConstraints(s.bcGroups);
+      s.result = null;
+    }),
+
+  addFaceToBcGroup: (groupId: number, face: Omit<BcFaceEntry, "id">) =>
+    set((s) => {
+      const g = s.bcGroups.find((g) => g.id === groupId);
+      if (!g) return;
+      const faceId = s.nextFaceEntryId++;
+      g.faces.push({ id: faceId, label: face.label, nodeIds: face.nodeIds });
+      s.constraints = rebuildConstraints(s.bcGroups);
+      s.result = null;
+    }),
+
+  updateBcGroup: (id: number, dofs: number[], value: number) =>
+    set((s) => {
+      const group = s.bcGroups.find((g) => g.id === id);
+      if (!group) return;
+      group.dofs = dofs;
+      group.value = value;
+      s.constraints = rebuildConstraints(s.bcGroups);
+      s.result = null;
+    }),
+
+  removeFaceFromBcGroup: (groupId: number, faceId: number) =>
+    set((s) => {
+      const g = s.bcGroups.find((g) => g.id === groupId);
+      if (!g) return;
+      g.faces = g.faces.filter((f) => f.id !== faceId);
+      if (g.faces.length === 0)
+        s.bcGroups = s.bcGroups.filter((g) => g.id !== groupId);
+      s.constraints = rebuildConstraints(s.bcGroups);
+      s.result = null;
+    }),
+
+  deleteBcGroup: (id: number) =>
+    set((s) => {
+      s.bcGroups = s.bcGroups.filter((g) => g.id !== id);
+      s.constraints = rebuildConstraints(s.bcGroups);
+      s.result = null;
+    }),
+
+  clearConstraints: () =>
+    set((s) => {
+      s.bcGroups = [];
+      s.constraints = [];
+      s.result = null;
+    }),
+
+  // Load group actions
+  createLoadGroup: (
+    faces: Omit<BcFaceEntry, "id">[],
+    dofArg: number,
+    totalForceArg: number,
+    kind: LoadKind = dofArg <= 2 ? "force" : "moment",
+    components?: [number, number, number],
+  ) =>
+    set((s) => {
+      const faceEntries = faces.map((f) => ({
+        id: s.nextFaceEntryId++,
+        label: f.label,
+        nodeIds: f.nodeIds,
+      }));
+      // A componentwise force/moment carries its vector in `components` (the
+      // source of truth); dof/totalForce are derived as a legacy summary.
+      const { dof, totalForce } = components
+        ? summarizeComponents(components, kind)
+        : { dof: dofArg, totalForce: totalForceArg };
+      s.loadGroups.push({
+        id: s.nextLoadGroupId,
+        name: `Load${s.nextLoadGroupId}`,
+        dof,
+        totalForce,
+        ...(components ? { components } : {}),
+        faces: faceEntries,
+        kind,
+      });
+      s.nextLoadGroupId++;
+      s.loads = rebuildLoads(s.loadGroups, s.nodes);
+      s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
+      s.result = null;
+    }),
+
+  addFaceToLoadGroup: (groupId: number, face: Omit<BcFaceEntry, "id">) =>
+    set((s) => {
+      const g = s.loadGroups.find((g) => g.id === groupId);
+      if (!g) return;
+      const faceId = s.nextFaceEntryId++;
+      g.faces.push({ id: faceId, label: face.label, nodeIds: face.nodeIds });
+      s.loads = rebuildLoads(s.loadGroups, s.nodes);
+      s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
+      s.result = null;
+    }),
+
+  // Replace a load group's values in place, keeping its faces. Mirrors
+  // createLoadGroup: force/moment carry their vector in `components` (the
+  // source of truth, with dof/totalForce derived as the legacy summary);
+  // pressure carries its magnitude in totalForce and has no vector.
+  updateLoadGroup: (
+    id: number,
+    kind: LoadKind,
+    totalForceArg: number,
+    components?: [number, number, number],
+  ) =>
+    set((s) => {
+      const group = s.loadGroups.find((g) => g.id === id);
+      if (!group) return;
+      const { dof, totalForce } = components
+        ? summarizeComponents(components, kind)
+        : { dof: 0, totalForce: totalForceArg };
+      group.kind = kind;
+      group.dof = dof;
+      group.totalForce = totalForce;
+      if (components) group.components = components;
+      else delete group.components;
+      s.loads = rebuildLoads(s.loadGroups, s.nodes);
+      s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
+      s.result = null;
+    }),
+
+  removeFaceFromLoadGroup: (groupId: number, faceId: number) =>
+    set((s) => {
+      const g = s.loadGroups.find((g) => g.id === groupId);
+      if (!g) return;
+      g.faces = g.faces.filter((f) => f.id !== faceId);
+      if (g.faces.length === 0)
+        s.loadGroups = s.loadGroups.filter((g) => g.id !== groupId);
+      s.loads = rebuildLoads(s.loadGroups, s.nodes);
+      s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
+      s.result = null;
+    }),
+
+  deleteLoadGroup: (id: number) =>
+    set((s) => {
+      s.loadGroups = s.loadGroups.filter((g) => g.id !== id);
+      s.loads = rebuildLoads(s.loadGroups, s.nodes);
+      s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
+      s.result = null;
+    }),
+
+  clearLoads: () =>
+    set((s) => {
+      s.loadGroups = [];
+      s.loads = [];
+      s.surfaceLoads = [];
+      s.result = null;
+    }),
+});

--- a/web/src/store/geometrySlice.ts
+++ b/web/src/store/geometrySlice.ts
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Geometry slice: FEM nodes/elements, the imported CAD geometry (tessellation
+// + retained source bytes), and the meshing pipeline state.
+
+import type { SliceCreator } from "./modelStore";
+
+export interface Node {
+  id: number;
+  x: number;
+  y: number;
+  z: number;
+}
+
+// The live OCCT → Netgen → MFEM pipeline only ever produces solid elements:
+// tetrahedra (CTETRA) and hexahedra (CHEXA). 1D (beam) and 2D (shell/plane)
+// element types are not modelled — restore the relevant variants here when
+// such support is actually added.
+export type ElementType = "CTETRA" | "CHEXA";
+
+// Reserved seam for #317 (multibody: per-body materials). Currently
+// write-only — the solver reads `materials[0]` directly (solver.worker.ts)
+// and does not consult `propertyId`/`materialId` to resolve an element's
+// material. Every model still carries exactly one auto-created Property
+// referencing the model's sole material; do not treat this as the current
+// material-assignment mechanism until #317 wires per-element regions
+// through it (see #320).
+export interface Property {
+  id: number;
+  materialId: number;
+}
+
+export interface Element {
+  id: number;
+  type: ElementType;
+  nodeIds: number[];
+  propertyId: number;
+}
+
+// CAD geometry source format. The import pipeline reads STEP and IGES into the
+// same OCCT shape, but a re-mesh reloads the file (the worker is torn down after
+// each mesh), so the reader needs to know which format the retained bytes are.
+export type GeometryFormat = "step" | "iges";
+
+export interface StepTessellation {
+  points: [number, number, number][];
+  triangles: [number, number, number][];
+}
+
+export interface VolMesh {
+  points: [number, number, number][];
+  edges: [number, number][];
+}
+
+export interface GeometrySlice {
+  nodes: Node[];
+  elements: Element[];
+  properties: Property[];
+  modelName: string;
+  stepSurface: StepTessellation | null;
+  // Raw bytes of the imported STEP file, retained so the geometry can be
+  // reloaded into the mesher for a re-mesh. The worker is torn down after every
+  // mesh (resetWorker), discarding the OCCT shape it held, so re-meshing must
+  // re-supply the original file. Not persisted in saved analyses (no STEP there).
+  stepBytes: Uint8Array | null;
+  // Format of the retained stepBytes — selects the OCCT reader on re-mesh.
+  geometryFormat: GeometryFormat;
+  isMeshing: boolean;
+  volMesh: VolMesh | null;
+  // Netgen surface element vertex indices (0-based, same node IDs as the volume
+  // mesh) and their OCC face indices (1-based).  Both arrays have one entry per
+  // surface triangle and are in Netgen surface-element order — NOT in the order
+  // produced by the frontend's tet boundary extraction.  MeshScene builds a
+  // sorted-vertex-key lookup to match them to tet boundary triangles correctly.
+  surfaceTriangles: [number, number, number][] | null;
+  surfaceFaceIds: number[] | null;
+  stepImportError: string | null;
+
+  addNode(node: Node): void;
+  addElement(el: Element): void;
+  addProperty(prop: Property): void;
+  setStepSurface(tessellation: StepTessellation | null): void;
+  setStepBytes(bytes: Uint8Array | null): void;
+  setGeometryFormat(format: GeometryFormat): void;
+  setVolMesh(mesh: VolMesh | null): void;
+  setSurfaceFaceIds(ids: number[] | null): void;
+  setMeshing(v: boolean): void;
+  setStepImportError(msg: string | null): void;
+  applyMeshResult(
+    nodes: Node[],
+    elements: Element[],
+    modelName: string,
+    surfaceTriangles?: [number, number, number][] | null,
+    surfaceFaceIds?: number[] | null,
+  ): void;
+}
+
+export const createGeometrySlice: SliceCreator<GeometrySlice> = (set) => ({
+  nodes: [],
+  elements: [],
+  properties: [{ id: 1, materialId: 1 }],
+  modelName: "",
+  stepSurface: null,
+  stepBytes: null,
+  geometryFormat: "step",
+  isMeshing: false,
+  volMesh: null,
+  surfaceTriangles: null,
+  surfaceFaceIds: null,
+  stepImportError: null,
+
+  addNode: (node) =>
+    set((s) => {
+      s.nodes.push(node);
+    }),
+  addElement: (el) =>
+    set((s) => {
+      s.elements.push(el);
+    }),
+  addProperty: (prop) =>
+    set((s) => {
+      s.properties.push(prop);
+    }),
+  setStepBytes: (bytes) =>
+    set((s) => {
+      s.stepBytes = bytes;
+    }),
+  setGeometryFormat: (format) =>
+    set((s) => {
+      s.geometryFormat = format;
+    }),
+  setStepSurface: (tessellation) =>
+    set((s) => {
+      s.stepSurface = tessellation;
+      // Clearing the geometry also drops the retained STEP bytes — keeping the
+      // invariant "no surface ⇒ nothing left to re-mesh from".
+      if (!tessellation) {
+        s.stepBytes = null;
+        s.geometryFormat = "step";
+      }
+      s.volMesh = null;
+      s.viewRepr = "geometry";
+      s.stepImportError = null;
+      s.nodes = [];
+      s.elements = [];
+      s.bcGroups = [];
+      s.loadGroups = [];
+      s.constraints = [];
+      s.loads = [];
+      s.surfaceLoads = [];
+      s.nextBcGroupId = 1;
+      s.nextLoadGroupId = 1;
+      s.nextFaceEntryId = 1;
+      s.result = null;
+      if (tessellation) {
+        s.fitViewTrigger++;
+        s.hasStarted = true;
+        s.mode = "geometry";
+      }
+    }),
+  setVolMesh: (mesh) =>
+    set((s) => {
+      s.volMesh = mesh;
+      if (mesh) s.viewRepr = "volume";
+    }),
+  setSurfaceFaceIds: (ids) =>
+    set((s) => {
+      s.surfaceFaceIds = ids;
+    }),
+  setMeshing: (v) =>
+    set((s) => {
+      s.isMeshing = v;
+    }),
+  setStepImportError: (msg) =>
+    set((s) => {
+      s.stepImportError = msg;
+    }),
+
+  applyMeshResult: (nodes, elements, name, surfaceTriangles, surfaceFaceIds) =>
+    set((s) => {
+      s.nodes = nodes;
+      s.elements = elements;
+      s.surfaceTriangles = surfaceTriangles ?? null;
+      s.surfaceFaceIds = surfaceFaceIds ?? null;
+      s.bcGroups = [];
+      s.loadGroups = [];
+      s.constraints = [];
+      s.loads = [];
+      s.surfaceLoads = [];
+      s.nextBcGroupId = 1;
+      s.nextLoadGroupId = 1;
+      s.nextFaceEntryId = 1;
+      s.result = null;
+      s.selectedFace = null;
+      s.pendingFaces = [];
+      s.pickMode = null;
+      s.pickTargetGroupId = null;
+      s.modelName = name;
+      s.viewRepr = "surface";
+      s.fitViewTrigger++;
+      if (s.properties.length === 0) {
+        const mat = s.materials[0];
+        if (!mat)
+          throw new Error(
+            "Cannot create a default property: the model has no materials",
+          );
+        s.properties = [{ id: 1, materialId: mat.id }];
+      }
+    }),
+});

--- a/web/src/store/materialSlice.ts
+++ b/web/src/store/materialSlice.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Material slice: material definitions and their CRUD actions.
+
+import type { SliceCreator } from "./modelStore";
+
+export interface Material {
+  id: number;
+  name: string;
+  young: number;
+  poisson: number;
+  density: number;
+}
+
+// Canonical unit system: N · mm · MPa · tonne. Steel: E = 210 GPa = 210000 MPa,
+// ρ = 7850 kg/m³ = 7.85e-9 t/mm³. STEP geometry imports in mm, so materials,
+// loads (N), and results (mm, MPa) must share this system to stay consistent.
+export const DEFAULT_MATERIAL: Material = {
+  id: 1,
+  name: "Steel",
+  young: 210000,
+  poisson: 0.3,
+  density: 7.85e-9,
+};
+
+export interface MaterialSlice {
+  materials: Material[];
+  nextMatId: number;
+
+  addMaterial(mat: Material): void;
+  createMaterial(mat: Omit<Material, "id">): void;
+  updateMaterial(id: number, patch: Partial<Omit<Material, "id">>): void;
+  deleteMaterial(id: number): void;
+}
+
+export const createMaterialSlice: SliceCreator<MaterialSlice> = (set) => ({
+  materials: [DEFAULT_MATERIAL],
+  nextMatId: 2,
+
+  addMaterial: (mat) =>
+    set((s) => {
+      s.materials.push(mat);
+    }),
+
+  createMaterial: (mat) =>
+    set((s) => {
+      s.materials.push({ ...mat, id: s.nextMatId++ });
+    }),
+
+  updateMaterial: (id, patch) =>
+    set((s) => {
+      const idx = s.materials.findIndex((m) => m.id === id);
+      if (idx >= 0) Object.assign(s.materials[idx], patch);
+    }),
+
+  deleteMaterial: (id) =>
+    set((s) => {
+      s.materials = s.materials.filter((m) => m.id !== id);
+    }),
+});

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -1,1026 +1,180 @@
 // SPDX-FileCopyrightText: 2026 Michael Kofler
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+// Thin combiner (issue #202): the model store is assembled from focused
+// slices, each owning one area of state:
+//
+//   geometrySlice — nodes/elements, imported CAD geometry, meshing pipeline
+//   materialSlice — material definitions + CRUD
+//   boundarySlice — BC / load groups and the solver-facing flat arrays
+//   resultsSlice  — solver output, solve settings, stage transitions
+//   viewSlice     — transient viewport presentation settings
+//   momentLoad    — pure math (moment → equivalent nodal forces), no Zustand
+//
+// Whole-model lifecycle actions that cut across every slice (loadAnalysis,
+// reset) live here. All public types and helpers are re-exported so consumers
+// keep importing from "store/modelStore".
+
 import { create } from "zustand";
+import type { StateCreator } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import type { AnalysisState } from "../lib/analysisFile";
+import { createGeometrySlice, type GeometrySlice } from "./geometrySlice";
+import {
+  createMaterialSlice,
+  DEFAULT_MATERIAL,
+  type MaterialSlice,
+} from "./materialSlice";
+import {
+  createBoundarySlice,
+  rebuildConstraints,
+  rebuildLoads,
+  rebuildSurfaceLoads,
+  type BoundarySlice,
+} from "./boundarySlice";
+import { createResultsSlice, type ResultsSlice } from "./resultsSlice";
+import { createViewSlice, type ViewSlice } from "./viewSlice";
 
-export interface Node {
-  id: number;
-  x: number;
-  y: number;
-  z: number;
-}
+export type {
+  Node,
+  ElementType,
+  Property,
+  Element,
+  GeometryFormat,
+  StepTessellation,
+  VolMesh,
+} from "./geometrySlice";
+export type { Material } from "./materialSlice";
+export type {
+  Constraint,
+  Load,
+  FaceSelection,
+  BcFaceEntry,
+  NamedBcGroup,
+  LoadKind,
+  NamedLoadGroup,
+  SurfaceLoad,
+} from "./boundarySlice";
+export { loadKind, loadComponents } from "./boundarySlice";
+export type { SolverResult, ResultType, AppMode } from "./resultsSlice";
+export { RESULT_TYPES } from "./resultsSlice";
+export type { LoadDisplay, ViewRepr } from "./viewSlice";
 
-// The live OCCT → Netgen → MFEM pipeline only ever produces solid elements:
-// tetrahedra (CTETRA) and hexahedra (CHEXA). 1D (beam) and 2D (shell/plane)
-// element types are not modelled — restore the relevant variants here when
-// such support is actually added.
-export type ElementType = "CTETRA" | "CHEXA";
-
-// Reserved seam for #317 (multibody: per-body materials). Currently
-// write-only — the solver reads `materials[0]` directly (solver.worker.ts)
-// and does not consult `propertyId`/`materialId` to resolve an element's
-// material. Every model still carries exactly one auto-created Property
-// referencing the model's sole material; do not treat this as the current
-// material-assignment mechanism until #317 wires per-element regions
-// through it (see #320).
-export interface Property {
-  id: number;
-  materialId: number;
-}
-
-export interface Element {
-  id: number;
-  type: ElementType;
-  nodeIds: number[];
-  propertyId: number;
-}
-
-export interface Material {
-  id: number;
-  name: string;
-  young: number;
-  poisson: number;
-  density: number;
-}
-
-export interface Constraint {
-  nodeId: number;
-  dof: number; // 0=Ux 1=Uy 2=Uz 3=Rx 4=Ry 5=Rz
-  prescribedValue?: number;
-}
-
-export interface Load {
-  nodeId: number;
-  dof: number;
-  value: number;
-}
-
-export interface SolverResult {
-  displacements: Float64Array;
-  vonMises?: Float64Array;
-}
-
-export const RESULT_TYPES = [
-  "Displacement (magnitude)",
-  "Ux",
-  "Uy",
-  "Uz",
-  "Von Mises stress",
-] as const;
-export type ResultType = (typeof RESULT_TYPES)[number];
-
-// CAD geometry source format. The import pipeline reads STEP and IGES into the
-// same OCCT shape, but a re-mesh reloads the file (the worker is torn down after
-// each mesh), so the reader needs to know which format the retained bytes are.
-export type GeometryFormat = "step" | "iges";
-
-export interface StepTessellation {
-  points: [number, number, number][];
-  triangles: [number, number, number][];
-}
-
-export interface VolMesh {
-  points: [number, number, number][];
-  edges: [number, number][];
-}
-
-export interface FaceSelection {
-  nodeIds: number[];
-  label: string; // e.g. "Min X face (9 nodes)"
-  axis: "X" | "Y" | "Z";
-  isMax: boolean;
-}
-
-// ── Named BC / Load groups ────────────────────────────────────────────────────
-
-export interface BcFaceEntry {
-  id: number;
-  label: string; // e.g. "Face 1"
-  nodeIds: number[];
-}
-
-export interface NamedBcGroup {
-  id: number;
-  name: string; // e.g. "BC1"
-  dofs: number[];
-  value: number;
-  faces: BcFaceEntry[];
-}
-
-// A load group's physical kind. "force" and "pressure" are applied to the solver
-// as work-equivalent surface tractions (SurfaceLoad); "moment" is still lumped to
-// equivalent nodal forces (rebuildLoads). For backward-compat with saved analyses
-// that predate this field, `kind` is optional and inferred from `dof` via
-// loadKind().
-export type LoadKind = "force" | "moment" | "pressure";
-
-// How load glyphs are drawn in the viewport. "resultant" shows one arrow per
-// force/pressure group at the centroid of its loaded nodes (the statically
-// equivalent load the user specifies). "nodal" shows the work-equivalent load
-// each individual node carries — the per-node tributary share of the group total
-// — which is what actually reaches the solver as a surface traction (issue #196).
-export type LoadDisplay = "resultant" | "nodal";
-
-export interface NamedLoadGroup {
-  id: number;
-  name: string; // e.g. "Load1"
-  dof: number; // force: 0=Fx,1=Fy,2=Fz · moment: 3=Mx,4=My,5=Mz · pressure: unused
-  totalForce: number; // force/moment magnitude (N, N·mm), or pressure magnitude (MPa)
-  // Componentwise force [Fx,Fy,Fz] (N) or moment [Mx,My,Mz] (N·mm) vector
-  // (issues #219, #190). Present on force/moment groups created via the
-  // componentwise UI, where it is the source of truth and supersedes
-  // dof/totalForce. Absent on pressure groups and on payloads saved before
-  // componentwise input existed — those reconstruct the vector from dof +
-  // totalForce via loadComponents().
-  components?: [number, number, number];
-  faces: BcFaceEntry[];
-  kind?: LoadKind;
-}
-
-// Physical kind of a load group, defaulting from `dof` for older payloads that
-// have no explicit `kind` (dof ≤ 2 ⇒ force, dof ≥ 3 ⇒ moment).
-export function loadKind(g: NamedLoadGroup): LoadKind {
-  return g.kind ?? (g.dof <= 2 ? "force" : "moment");
-}
-
-// The force [Fx,Fy,Fz] (N) or moment [Mx,My,Mz] (N·mm) vector of a load group.
-// Uses the explicit componentwise vector when present, else reconstructs the
-// single-axis vector from the legacy dof + totalForce (force: axis 0–2; moment:
-// axis dof−3). Pressure groups have no vector and return zeros.
-export function loadComponents(g: NamedLoadGroup): [number, number, number] {
-  if (g.components) return g.components;
-  const vec: [number, number, number] = [0, 0, 0];
-  const kind = loadKind(g);
-  if (kind === "force" && g.dof >= 0 && g.dof <= 2) vec[g.dof] = g.totalForce;
-  else if (kind === "moment" && g.dof >= 3 && g.dof <= 5)
-    vec[g.dof - 3] = g.totalForce;
-  return vec;
-}
-
-// Legacy single-axis summary (primary axis + signed magnitude) of a componentwise
-// vector, stored alongside `components` so older readers and the pre-flight
-// fallback still see a sensible dof/totalForce. For a single non-zero component
-// this reproduces the vector exactly; for a general vector it names the first
-// non-zero axis. `components` remains the source of truth.
-function summarizeComponents(
-  components: [number, number, number],
-  kind: LoadKind,
-): { dof: number; totalForce: number } {
-  const found = components.findIndex((value) => value !== 0);
-  const axis = found < 0 ? 0 : found;
-  return {
-    dof: kind === "moment" ? axis + 3 : axis,
-    totalForce: components[axis],
-  };
-}
-
-// A work-equivalent surface load handed to the engine's boundary integrator.
-// `faces` are the element boundary faces of one loaded face — triangles (tets) or
-// quads (hexes) — each a list of node indices the engine matches to its generated
-// boundary elements by vertex set.
-//   force    — total force vector, spread by the engine as a uniform traction
-//   pressure — scalar magnitude, applied as -p·n̂ (outward normal; + pushes in)
-//   traction — traction vector applied directly (not surfaced in the UI yet)
-export interface SurfaceLoad {
-  type: "force" | "pressure" | "traction";
-  faces: number[][];
-  force?: [number, number, number];
-  pressure?: number;
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function rebuildConstraints(bcGroups: NamedBcGroup[]): Constraint[] {
-  const result: Constraint[] = [];
-  for (const g of bcGroups)
-    for (const f of g.faces)
-      for (const nodeId of f.nodeIds)
-        for (const dof of g.dofs)
-          result.push({ nodeId, dof, prescribedValue: g.value });
-  return result;
-}
-
-// Local vertex indices of each boundary face of a solid element, in the node
-// ordering used by both the .inp/fixture meshes and MFEM's AddTet/AddHex (and so
-// by the boundary elements the engine generates). Matching is by vertex set, so
-// only the grouping matters, not the winding.
-const TET_FACE_INDICES = [
-  [0, 1, 2],
-  [0, 1, 3],
-  [0, 2, 3],
-  [1, 2, 3],
-];
-const HEX_FACE_INDICES = [
-  [0, 1, 2, 3],
-  [4, 5, 6, 7],
-  [0, 1, 5, 4],
-  [1, 2, 6, 5],
-  [2, 3, 7, 6],
-  [3, 0, 4, 7],
-];
-
-// The element boundary faces lying on one loaded face: every solid-element face
-// whose nodes all belong to the face's node set — triangles for tets, quads for
-// hexes. The engine matches these to its generated boundary elements by vertex
-// set (and ignores any interior faces that aren't boundaries), so the load is
-// integrated over the real surface, mesh type regardless.
-function loadedFaces(
-  face: { nodeIds: number[] },
-  elements: Element[],
-): number[][] {
-  const nodeSet = new Set(face.nodeIds);
-  const seen = new Set<string>();
-  const faces: number[][] = [];
-  for (const el of elements) {
-    const local =
-      el.type === "CTETRA"
-        ? TET_FACE_INDICES
-        : el.type === "CHEXA"
-          ? HEX_FACE_INDICES
-          : null;
-    if (!local) continue;
-    for (const lf of local) {
-      const verts = lf.map((i) => el.nodeIds[i]);
-      if (!verts.every((v) => nodeSet.has(v))) continue;
-      const key = [...verts].sort((a, b) => a - b).join(",");
-      if (seen.has(key)) continue; // a boundary face is owned by one element
-      seen.add(key);
-      faces.push(verts);
-    }
-  }
-  return faces;
-}
-
-function rebuildLoads(loadGroups: NamedLoadGroup[], nodes: Node[]): Load[] {
-  const nodeById = new Map<number, Node>();
-  for (const n of nodes) nodeById.set(n.id, n);
-
-  const result: Load[] = [];
-  for (const g of loadGroups) {
-    // Force and pressure loads are applied as work-equivalent surface tractions
-    // (rebuildSurfaceLoads), not lumped nodal forces — they are skipped here.
-    if (loadKind(g) !== "moment") continue;
-    // A moment may be specified componentwise [Mx,My,Mz]; each non-zero axis is
-    // converted independently and its nodal forces summed (superposition).
-    const moment = loadComponents(g);
-    for (let momentAxis = 0; momentAxis < 3; momentAxis++) {
-      const momentMag = moment[momentAxis]; // about x (0), y (1) or z (2)
-      if (momentMag === 0) continue;
-      // Moment about one axis — convert to equivalent nodal forces. For each
-      // face, find the centroid, then apply tangential forces F_i = M/S·(n̂×r_i)
-      // where S = Σ|r_i⊥|² (perpendicular distance squared from moment axis).
-      // This satisfies Σ(r_i × F_i) = M exactly with zero net force.
-      let skippedFaces = 0;
-      for (const f of g.faces) {
-        let cx = 0,
-          cy = 0,
-          cz = 0,
-          count = 0;
-        for (const nodeId of f.nodeIds) {
-          const n = nodeById.get(nodeId);
-          if (n) {
-            cx += n.x;
-            cy += n.y;
-            cz += n.z;
-            count++;
-          }
-        }
-        if (count === 0) continue;
-        cx /= count;
-        cy /= count;
-        cz /= count;
-
-        let S = 0;
-        for (const nodeId of f.nodeIds) {
-          const n = nodeById.get(nodeId);
-          if (!n) continue;
-          const rx = n.x - cx,
-            ry = n.y - cy,
-            rz = n.z - cz;
-          if (momentAxis === 0) S += ry * ry + rz * rz;
-          else if (momentAxis === 1) S += rx * rx + rz * rz;
-          else S += rx * rx + ry * ry;
-        }
-        if (S === 0) {
-          // All face nodes lie on the moment axis — the tangential force
-          // direction is undefined, so this face contributes no moment.
-          skippedFaces++;
-          continue;
-        }
-
-        const scale = momentMag / S;
-        for (const nodeId of f.nodeIds) {
-          const n = nodeById.get(nodeId);
-          if (!n) continue;
-          const rx = n.x - cx,
-            ry = n.y - cy,
-            rz = n.z - cz;
-          if (momentAxis === 0) {
-            // Mx → F = scale·(0, −rz, ry)
-            result.push({ nodeId, dof: 1, value: -scale * rz });
-            result.push({ nodeId, dof: 2, value: scale * ry });
-          } else if (momentAxis === 1) {
-            // My → F = scale·(rz, 0, −rx)
-            result.push({ nodeId, dof: 0, value: scale * rz });
-            result.push({ nodeId, dof: 2, value: -scale * rx });
-          } else {
-            // Mz → F = scale·(−ry, rx, 0)
-            result.push({ nodeId, dof: 0, value: -scale * ry });
-            result.push({ nodeId, dof: 1, value: scale * rx });
-          }
-        }
-      }
-      if (skippedFaces > 0) {
-        const axisName = ["Mx", "My", "Mz"][momentAxis];
-        console.warn(
-          `[moment load] "${g.name}" (${axisName}): ${skippedFaces} of ` +
-            `${g.faces.length} face(s) skipped — all of their nodes lie on the ` +
-            "moment axis, so the applied moment is incomplete. Choose a " +
-            "different moment axis or face selection.",
-        );
-      }
-    }
-  }
-  return result;
-}
-
-// Build the work-equivalent surface loads (one per loaded face) for force and
-// pressure groups. The engine integrates these over the face's boundary elements
-// (f_i = ∫ N_i·t dS), which is both shape-function-correct and immune to the
-// spurious moment that equal nodal splitting introduces on a non-uniform mesh.
-//
-// The loaded faces are derived from the element connectivity (loadedFaces), so a
-// load works on tet meshes (triangle faces) and hex meshes (quad faces) alike,
-// with no dependency on a separately-stored surface triangulation.
-function rebuildSurfaceLoads(
-  loadGroups: NamedLoadGroup[],
-  elements: Element[],
-): SurfaceLoad[] {
-  const result: SurfaceLoad[] = [];
-  for (const g of loadGroups) {
-    const kind = loadKind(g);
-    if (kind === "moment") continue; // moments stay as equivalent point loads
-    for (const f of g.faces) {
-      const faces = loadedFaces(f, elements);
-      if (faces.length === 0) continue;
-      if (kind === "pressure") {
-        result.push({ type: "pressure", pressure: g.totalForce, faces });
-      } else {
-        result.push({ type: "force", force: loadComponents(g), faces });
-      }
-    }
-  }
-  return result;
-}
-
-// ── Store types ───────────────────────────────────────────────────────────────
-
-export type AppMode = "geometry" | "constraints" | "solve" | "results";
-
-interface ModelState {
-  nodes: Node[];
-  elements: Element[];
-  materials: Material[];
-  properties: Property[];
-  // flat arrays derived from bcGroups / loadGroups — used by solver and visualization
-  constraints: Constraint[];
-  loads: Load[];
-  // work-equivalent surface tractions (force/pressure groups) handed to the solver
-  surfaceLoads: SurfaceLoad[];
-
-  modelName: string;
-  hasStarted: boolean;
-  mode: AppMode;
-  result: SolverResult | null;
-  resultType: ResultType;
-  stepSurface: StepTessellation | null;
-  // Raw bytes of the imported STEP file, retained so the geometry can be
-  // reloaded into the mesher for a re-mesh. The worker is torn down after every
-  // mesh (resetWorker), discarding the OCCT shape it held, so re-meshing must
-  // re-supply the original file. Not persisted in saved analyses (no STEP there).
-  stepBytes: Uint8Array | null;
-  // Format of the retained stepBytes — selects the OCCT reader on re-mesh.
-  geometryFormat: GeometryFormat;
-  isRunning: boolean;
-  isMeshing: boolean;
-  // FE polynomial order for the solve: 1 = linear, 2 = quadratic (second-order).
-  // Quadratic elements resolve bending and stress gradients far better at the
-  // cost of more DOFs and a slower solve (issue #215).
-  elementOrder: number;
-  nextMatId: number;
-  pickMode: "bc" | "load" | null;
-  pickTargetGroupId: number | null; // null = creating new group; id = adding to existing
-  selectedFace: FaceSelection | null;
-  pendingFaces: FaceSelection[]; // faces accumulated via shift-click within a pick session
-
-  // Named BC / Load groups (primary source of truth for constraints & loads)
-  bcGroups: NamedBcGroup[];
-  loadGroups: NamedLoadGroup[];
-  nextBcGroupId: number;
-  nextLoadGroupId: number;
-  nextFaceEntryId: number;
-
-  volMesh: VolMesh | null;
-  // Netgen surface element vertex indices (0-based, same node IDs as the volume
-  // mesh) and their OCC face indices (1-based).  Both arrays have one entry per
-  // surface triangle and are in Netgen surface-element order — NOT in the order
-  // produced by the frontend's tet boundary extraction.  MeshScene builds a
-  // sorted-vertex-key lookup to match them to tet boundary triangles correctly.
-  surfaceTriangles: [number, number, number][] | null;
-  surfaceFaceIds: number[] | null;
-  viewRepr: "geometry" | "surface" | "volume" | "wireframe";
-  showUndeformedOverlay: boolean;
-  // Whether load glyphs are drawn as a single resultant per group or as one
-  // arrow per loaded node (issue #196). A transient view setting, not persisted.
-  loadDisplay: LoadDisplay;
-  // Deformation magnification applied to the result on top of the automatic
-  // fit-to-view scale. 1 = the default visible deformation, 0 = undeformed.
-  deformScale: number;
-  stepImportError: string | null;
-  setStepSurface(tessellation: StepTessellation | null): void;
-  setStepBytes(bytes: Uint8Array | null): void;
-  setGeometryFormat(format: GeometryFormat): void;
-  setVolMesh(mesh: VolMesh | null): void;
-  setSurfaceFaceIds(ids: number[] | null): void;
-  setViewRepr(v: "geometry" | "surface" | "volume" | "wireframe"): void;
-  setShowUndeformedOverlay(v: boolean): void;
-  setLoadDisplay(v: LoadDisplay): void;
-  setDeformScale(v: number): void;
-  setStepImportError(msg: string | null): void;
-
-  // Mode navigation
-  setMode(mode: AppMode): void;
-
-  // Solver
-  addNode(node: Node): void;
-  addElement(el: Element): void;
-  addMaterial(mat: Material): void;
-  addProperty(prop: Property): void;
-  setResult(result: SolverResult): void;
-  setResultType(t: ResultType): void;
-  setElementOrder(order: number): void;
-  setRunning(v: boolean): void;
-  setMeshing(v: boolean): void;
-  applyMeshResult(
-    nodes: Node[],
-    elements: Element[],
-    modelName: string,
-    surfaceTriangles?: [number, number, number][] | null,
-    surfaceFaceIds?: number[] | null,
-  ): void;
+// Whole-model lifecycle actions — they touch every slice, so they live in the
+// combiner rather than in any single slice.
+interface AnalysisActions {
   loadAnalysis(analysis: AnalysisState): void;
   reset(): void;
-
-  // Material CRUD
-  createMaterial(mat: Omit<Material, "id">): void;
-  updateMaterial(id: number, patch: Partial<Omit<Material, "id">>): void;
-  deleteMaterial(id: number): void;
-
-  // Pick mode / face selection
-  setPickMode(mode: "bc" | "load" | null, targetGroupId?: number | null): void;
-  setSelectedFace(face: FaceSelection | null): void;
-  setPendingFaces(faces: FaceSelection[]): void;
-
-  // BC group actions
-  createBcGroup(
-    faces: Omit<BcFaceEntry, "id">[],
-    dofs: number[],
-    value: number,
-  ): void;
-  addFaceToBcGroup(groupId: number, face: Omit<BcFaceEntry, "id">): void;
-  updateBcGroup(id: number, dofs: number[], value: number): void;
-  removeFaceFromBcGroup(groupId: number, faceId: number): void;
-  deleteBcGroup(id: number): void;
-  clearConstraints(): void;
-
-  // Load group actions
-  createLoadGroup(
-    faces: Omit<BcFaceEntry, "id">[],
-    dof: number,
-    totalForce: number,
-    kind?: LoadKind,
-    components?: [number, number, number],
-  ): void;
-  addFaceToLoadGroup(groupId: number, face: Omit<BcFaceEntry, "id">): void;
-  updateLoadGroup(
-    id: number,
-    kind: LoadKind,
-    totalForce: number,
-    components?: [number, number, number],
-  ): void;
-  removeFaceFromLoadGroup(groupId: number, faceId: number): void;
-  deleteLoadGroup(id: number): void;
-  clearLoads(): void;
-
-  // Viewport
-  fitViewTrigger: number;
-  triggerFitView(): void;
 }
 
-// ── Store ─────────────────────────────────────────────────────────────────────
+export type ModelState = GeometrySlice &
+  MaterialSlice &
+  BoundarySlice &
+  ResultsSlice &
+  ViewSlice &
+  AnalysisActions;
 
-const EMPTY_MODEL = {
-  nodes: [] as Node[],
-  elements: [] as Element[],
-  materials: [
-    // Canonical unit system: N · mm · MPa · tonne. Steel: E = 210 GPa = 210000 MPa,
-    // ρ = 7850 kg/m³ = 7.85e-9 t/mm³. STEP geometry imports in mm, so materials,
-    // loads (N), and results (mm, MPa) must share this system to stay consistent.
-    { id: 1, name: "Steel", young: 210000, poisson: 0.3, density: 7.85e-9 },
-  ] as Material[],
-  properties: [{ id: 1, materialId: 1 }] as Property[],
-  constraints: [] as Constraint[],
-  loads: [] as Load[],
-  surfaceLoads: [] as SurfaceLoad[],
-  bcGroups: [] as NamedBcGroup[],
-  loadGroups: [] as NamedLoadGroup[],
-  nextBcGroupId: 1,
-  nextLoadGroupId: 1,
-  nextFaceEntryId: 1,
-};
+// Common shape of a slice creator: `set` drafts the full combined state, so
+// cross-slice transitions (e.g. a new mesh clearing BC groups and results)
+// stay type-checked against the whole store.
+export type SliceCreator<T> = StateCreator<
+  ModelState,
+  [["zustand/immer", never]],
+  [],
+  T
+>;
+
+const createAnalysisActions: SliceCreator<AnalysisActions> = (set) => ({
+  // Restore a complete analysis parsed from a saved .vtu file — the inverse
+  // of serializeAnalysis. Keeps the saved named groups, results, and
+  // view/mode state instead of rebuilding.
+  loadAnalysis: (a) =>
+    set((s) => {
+      s.nodes = a.nodes;
+      s.elements = a.elements;
+      s.materials = a.materials;
+      s.properties = a.properties;
+      s.bcGroups = a.bcGroups;
+      s.loadGroups = a.loadGroups;
+      s.constraints = rebuildConstraints(a.bcGroups);
+      s.loads = rebuildLoads(a.loadGroups, s.nodes);
+      s.surfaceLoads = rebuildSurfaceLoads(a.loadGroups, a.elements);
+      s.nextBcGroupId = a.nextBcGroupId;
+      s.nextLoadGroupId = a.nextLoadGroupId;
+      s.nextFaceEntryId = a.nextFaceEntryId;
+      s.nextMatId = a.nextMatId;
+      s.stepSurface = a.stepSurface;
+      // Saved analyses carry the tessellated surface but not the original STEP
+      // file, so re-meshing a loaded analysis requires re-importing the STEP.
+      s.stepBytes = null;
+      s.geometryFormat = "step";
+      s.volMesh = a.volMesh;
+      s.surfaceTriangles = a.surfaceTriangles;
+      s.surfaceFaceIds = a.surfaceFaceIds;
+      s.modelName = a.modelName;
+      s.result = a.result;
+      s.resultType = a.resultType;
+      s.viewRepr = a.viewRepr;
+      s.deformScale = 1;
+      s.mode = a.mode;
+      s.stepImportError = null;
+      s.isRunning = false;
+      s.isMeshing = false;
+      s.selectedFace = null;
+      s.pendingFaces = [];
+      s.pickMode = null;
+      s.pickTargetGroupId = null;
+      s.hasStarted = true;
+      s.fitViewTrigger++;
+    }),
+
+  reset: () =>
+    set((s) => {
+      s.nodes = [];
+      s.elements = [];
+      s.materials = [DEFAULT_MATERIAL];
+      s.properties = [{ id: 1, materialId: 1 }];
+      s.bcGroups = [];
+      s.loadGroups = [];
+      s.constraints = [];
+      s.loads = [];
+      s.surfaceLoads = [];
+      s.nextBcGroupId = 1;
+      s.nextLoadGroupId = 1;
+      s.nextFaceEntryId = 1;
+      s.modelName = "";
+      s.result = null;
+      s.resultType = "Displacement (magnitude)";
+      s.stepSurface = null;
+      s.stepBytes = null;
+      s.geometryFormat = "step";
+      s.volMesh = null;
+      s.surfaceTriangles = null;
+      s.surfaceFaceIds = null;
+      s.viewRepr = "surface";
+      s.deformScale = 1;
+      s.elementOrder = 1;
+      s.nextMatId = 2;
+      s.selectedFace = null;
+      s.pendingFaces = [];
+      s.pickMode = null;
+      s.pickTargetGroupId = null;
+      s.mode = "geometry";
+      s.stepImportError = null;
+      s.isRunning = false;
+      s.isMeshing = false;
+      s.hasStarted = false;
+    }),
+});
 
 export const useModelStore = create<ModelState>()(
-  immer((set) => ({
-    ...EMPTY_MODEL,
-    modelName: "",
-    hasStarted: false,
-    mode: "geometry" as AppMode,
-    result: null,
-    resultType: "Displacement (magnitude)" as ResultType,
-    stepSurface: null,
-    stepBytes: null,
-    geometryFormat: "step" as GeometryFormat,
-    isRunning: false,
-    isMeshing: false,
-    // Default to linear: it's fast and reliable for every mesh size. Quadratic is
-    // an opt-in upgrade (Solver settings) — far more accurate but ~8× the DOFs.
-    elementOrder: 1,
-    volMesh: null,
-    surfaceTriangles: null,
-    surfaceFaceIds: null,
-    viewRepr: "surface" as const,
-    showUndeformedOverlay: true,
-    loadDisplay: "resultant" as LoadDisplay,
-    deformScale: 1,
-    stepImportError: null,
-    nextMatId: 2,
-    pickMode: null,
-    pickTargetGroupId: null,
-    selectedFace: null,
-    pendingFaces: [] as FaceSelection[],
-    fitViewTrigger: 0,
-
-    setStepImportError: (msg) =>
-      set((s) => {
-        s.stepImportError = msg;
-      }),
-    setViewRepr: (v) =>
-      set((s) => {
-        s.viewRepr = v;
-      }),
-    setShowUndeformedOverlay: (v) =>
-      set((s) => {
-        s.showUndeformedOverlay = v;
-      }),
-    setLoadDisplay: (v) =>
-      set((s) => {
-        s.loadDisplay = v;
-      }),
-    setDeformScale: (v) =>
-      set((s) => {
-        s.deformScale = v;
-      }),
-    setVolMesh: (mesh) =>
-      set((s) => {
-        s.volMesh = mesh;
-        if (mesh) s.viewRepr = "volume";
-      }),
-    setSurfaceFaceIds: (ids) =>
-      set((s) => {
-        s.surfaceFaceIds = ids;
-      }),
-    setStepBytes: (bytes) =>
-      set((s) => {
-        s.stepBytes = bytes;
-      }),
-    setGeometryFormat: (format) =>
-      set((s) => {
-        s.geometryFormat = format;
-      }),
-    setStepSurface: (tessellation) =>
-      set((s) => {
-        s.stepSurface = tessellation;
-        // Clearing the geometry also drops the retained STEP bytes — keeping the
-        // invariant "no surface ⇒ nothing left to re-mesh from".
-        if (!tessellation) {
-          s.stepBytes = null;
-          s.geometryFormat = "step";
-        }
-        s.volMesh = null;
-        s.viewRepr = "geometry";
-        s.stepImportError = null;
-        s.nodes = [];
-        s.elements = [];
-        s.bcGroups = [];
-        s.loadGroups = [];
-        s.constraints = [];
-        s.loads = [];
-        s.surfaceLoads = [];
-        s.nextBcGroupId = 1;
-        s.nextLoadGroupId = 1;
-        s.nextFaceEntryId = 1;
-        s.result = null;
-        if (tessellation) {
-          s.fitViewTrigger++;
-          s.hasStarted = true;
-          s.mode = "geometry";
-        }
-      }),
-    triggerFitView: () =>
-      set((s) => {
-        s.fitViewTrigger++;
-      }),
-
-    setMode: (mode) =>
-      set((s) => {
-        s.mode = mode;
-      }),
-
-    addNode: (node) =>
-      set((s) => {
-        s.nodes.push(node);
-      }),
-    addElement: (el) =>
-      set((s) => {
-        s.elements.push(el);
-      }),
-    addMaterial: (mat) =>
-      set((s) => {
-        s.materials.push(mat);
-      }),
-    addProperty: (prop) =>
-      set((s) => {
-        s.properties.push(prop);
-      }),
-    setResult: (result) =>
-      set((s) => {
-        s.result = result;
-        s.resultType = "Displacement (magnitude)";
-      }),
-    setResultType: (t) =>
-      set((s) => {
-        s.resultType = t;
-      }),
-    setElementOrder: (order) =>
-      set((s) => {
-        s.elementOrder = order;
-      }),
-    setRunning: (v) =>
-      set((s) => {
-        s.isRunning = v;
-      }),
-    setMeshing: (v) =>
-      set((s) => {
-        s.isMeshing = v;
-      }),
-
-    applyMeshResult: (
-      nodes,
-      elements,
-      name,
-      surfaceTriangles,
-      surfaceFaceIds,
-    ) =>
-      set((s) => {
-        s.nodes = nodes;
-        s.elements = elements;
-        s.surfaceTriangles = surfaceTriangles ?? null;
-        s.surfaceFaceIds = surfaceFaceIds ?? null;
-        s.bcGroups = [];
-        s.loadGroups = [];
-        s.constraints = [];
-        s.loads = [];
-        s.surfaceLoads = [];
-        s.nextBcGroupId = 1;
-        s.nextLoadGroupId = 1;
-        s.nextFaceEntryId = 1;
-        s.result = null;
-        s.selectedFace = null;
-        s.pendingFaces = [];
-        s.pickMode = null;
-        s.pickTargetGroupId = null;
-        s.modelName = name;
-        s.viewRepr = "surface";
-        s.fitViewTrigger++;
-        if (s.properties.length === 0) {
-          const mat = s.materials[0];
-          if (!mat)
-            throw new Error(
-              "Cannot create a default property: the model has no materials",
-            );
-          s.properties = [{ id: 1, materialId: mat.id }];
-        }
-      }),
-
-    // Restore a complete analysis parsed from a saved .vtu file — the inverse
-    // of serializeAnalysis. Keeps the saved named groups, results, and
-    // view/mode state instead of rebuilding.
-    loadAnalysis: (a) =>
-      set((s) => {
-        s.nodes = a.nodes;
-        s.elements = a.elements;
-        s.materials = a.materials;
-        s.properties = a.properties;
-        s.bcGroups = a.bcGroups;
-        s.loadGroups = a.loadGroups;
-        s.constraints = rebuildConstraints(a.bcGroups);
-        s.loads = rebuildLoads(a.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(a.loadGroups, a.elements);
-        s.nextBcGroupId = a.nextBcGroupId;
-        s.nextLoadGroupId = a.nextLoadGroupId;
-        s.nextFaceEntryId = a.nextFaceEntryId;
-        s.nextMatId = a.nextMatId;
-        s.stepSurface = a.stepSurface;
-        // Saved analyses carry the tessellated surface but not the original STEP
-        // file, so re-meshing a loaded analysis requires re-importing the STEP.
-        s.stepBytes = null;
-        s.geometryFormat = "step";
-        s.volMesh = a.volMesh;
-        s.surfaceTriangles = a.surfaceTriangles;
-        s.surfaceFaceIds = a.surfaceFaceIds;
-        s.modelName = a.modelName;
-        s.result = a.result;
-        s.resultType = a.resultType;
-        s.viewRepr = a.viewRepr;
-        s.deformScale = 1;
-        s.mode = a.mode;
-        s.stepImportError = null;
-        s.isRunning = false;
-        s.isMeshing = false;
-        s.selectedFace = null;
-        s.pendingFaces = [];
-        s.pickMode = null;
-        s.pickTargetGroupId = null;
-        s.hasStarted = true;
-        s.fitViewTrigger++;
-      }),
-
-    reset: () =>
-      set((s) => {
-        s.nodes = [];
-        s.elements = [];
-        s.materials = [
-          {
-            id: 1,
-            name: "Steel",
-            young: 210000,
-            poisson: 0.3,
-            density: 7.85e-9,
-          },
-        ];
-        s.properties = [{ id: 1, materialId: 1 }];
-        s.bcGroups = [];
-        s.loadGroups = [];
-        s.constraints = [];
-        s.loads = [];
-        s.surfaceLoads = [];
-        s.nextBcGroupId = 1;
-        s.nextLoadGroupId = 1;
-        s.nextFaceEntryId = 1;
-        s.modelName = "";
-        s.result = null;
-        s.resultType = "Displacement (magnitude)";
-        s.stepSurface = null;
-        s.stepBytes = null;
-        s.geometryFormat = "step";
-        s.volMesh = null;
-        s.surfaceTriangles = null;
-        s.surfaceFaceIds = null;
-        s.viewRepr = "surface";
-        s.deformScale = 1;
-        s.elementOrder = 1;
-        s.nextMatId = 2;
-        s.selectedFace = null;
-        s.pendingFaces = [];
-        s.pickMode = null;
-        s.pickTargetGroupId = null;
-        s.mode = "geometry";
-        s.stepImportError = null;
-        s.isRunning = false;
-        s.isMeshing = false;
-        s.hasStarted = false;
-      }),
-
-    // Material CRUD
-    createMaterial: (mat) =>
-      set((s) => {
-        s.materials.push({ ...mat, id: s.nextMatId++ });
-      }),
-
-    updateMaterial: (id, patch) =>
-      set((s) => {
-        const idx = s.materials.findIndex((m) => m.id === id);
-        if (idx >= 0) Object.assign(s.materials[idx], patch);
-      }),
-
-    deleteMaterial: (id) =>
-      set((s) => {
-        s.materials = s.materials.filter((m) => m.id !== id);
-      }),
-
-    // Pick mode / face selection
-    setPickMode: (
-      mode: "bc" | "load" | null,
-      targetGroupId: number | null = null,
-    ) =>
-      set((s) => {
-        s.pickMode = mode;
-        s.pickTargetGroupId = mode !== null ? (targetGroupId ?? null) : null;
-        if (mode === null) {
-          s.selectedFace = null;
-          s.pendingFaces = [];
-        }
-      }),
-
-    setSelectedFace: (face: FaceSelection | null) =>
-      set((s) => {
-        s.selectedFace = face;
-      }),
-
-    setPendingFaces: (faces: FaceSelection[]) =>
-      set((s) => {
-        s.pendingFaces = faces;
-      }),
-
-    // BC group actions
-    createBcGroup: (
-      faces: Omit<BcFaceEntry, "id">[],
-      dofs: number[],
-      value: number,
-    ) =>
-      set((s) => {
-        const faceEntries = faces.map((f) => ({
-          id: s.nextFaceEntryId++,
-          label: f.label,
-          nodeIds: f.nodeIds,
-        }));
-        s.bcGroups.push({
-          id: s.nextBcGroupId,
-          name: `BC${s.nextBcGroupId}`,
-          dofs,
-          value,
-          faces: faceEntries,
-        });
-        s.nextBcGroupId++;
-        s.constraints = rebuildConstraints(s.bcGroups);
-        s.result = null;
-      }),
-
-    addFaceToBcGroup: (groupId: number, face: Omit<BcFaceEntry, "id">) =>
-      set((s) => {
-        const g = s.bcGroups.find((g) => g.id === groupId);
-        if (!g) return;
-        const faceId = s.nextFaceEntryId++;
-        g.faces.push({ id: faceId, label: face.label, nodeIds: face.nodeIds });
-        s.constraints = rebuildConstraints(s.bcGroups);
-        s.result = null;
-      }),
-
-    updateBcGroup: (id: number, dofs: number[], value: number) =>
-      set((s) => {
-        const group = s.bcGroups.find((g) => g.id === id);
-        if (!group) return;
-        group.dofs = dofs;
-        group.value = value;
-        s.constraints = rebuildConstraints(s.bcGroups);
-        s.result = null;
-      }),
-
-    removeFaceFromBcGroup: (groupId: number, faceId: number) =>
-      set((s) => {
-        const g = s.bcGroups.find((g) => g.id === groupId);
-        if (!g) return;
-        g.faces = g.faces.filter((f) => f.id !== faceId);
-        if (g.faces.length === 0)
-          s.bcGroups = s.bcGroups.filter((g) => g.id !== groupId);
-        s.constraints = rebuildConstraints(s.bcGroups);
-        s.result = null;
-      }),
-
-    deleteBcGroup: (id: number) =>
-      set((s) => {
-        s.bcGroups = s.bcGroups.filter((g) => g.id !== id);
-        s.constraints = rebuildConstraints(s.bcGroups);
-        s.result = null;
-      }),
-
-    clearConstraints: () =>
-      set((s) => {
-        s.bcGroups = [];
-        s.constraints = [];
-        s.result = null;
-      }),
-
-    // Load group actions
-    createLoadGroup: (
-      faces: Omit<BcFaceEntry, "id">[],
-      dofArg: number,
-      totalForceArg: number,
-      kind: LoadKind = dofArg <= 2 ? "force" : "moment",
-      components?: [number, number, number],
-    ) =>
-      set((s) => {
-        const faceEntries = faces.map((f) => ({
-          id: s.nextFaceEntryId++,
-          label: f.label,
-          nodeIds: f.nodeIds,
-        }));
-        // A componentwise force/moment carries its vector in `components` (the
-        // source of truth); dof/totalForce are derived as a legacy summary.
-        const { dof, totalForce } = components
-          ? summarizeComponents(components, kind)
-          : { dof: dofArg, totalForce: totalForceArg };
-        s.loadGroups.push({
-          id: s.nextLoadGroupId,
-          name: `Load${s.nextLoadGroupId}`,
-          dof,
-          totalForce,
-          ...(components ? { components } : {}),
-          faces: faceEntries,
-          kind,
-        });
-        s.nextLoadGroupId++;
-        s.loads = rebuildLoads(s.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
-        s.result = null;
-      }),
-
-    addFaceToLoadGroup: (groupId: number, face: Omit<BcFaceEntry, "id">) =>
-      set((s) => {
-        const g = s.loadGroups.find((g) => g.id === groupId);
-        if (!g) return;
-        const faceId = s.nextFaceEntryId++;
-        g.faces.push({ id: faceId, label: face.label, nodeIds: face.nodeIds });
-        s.loads = rebuildLoads(s.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
-        s.result = null;
-      }),
-
-    // Replace a load group's values in place, keeping its faces. Mirrors
-    // createLoadGroup: force/moment carry their vector in `components` (the
-    // source of truth, with dof/totalForce derived as the legacy summary);
-    // pressure carries its magnitude in totalForce and has no vector.
-    updateLoadGroup: (
-      id: number,
-      kind: LoadKind,
-      totalForceArg: number,
-      components?: [number, number, number],
-    ) =>
-      set((s) => {
-        const group = s.loadGroups.find((g) => g.id === id);
-        if (!group) return;
-        const { dof, totalForce } = components
-          ? summarizeComponents(components, kind)
-          : { dof: 0, totalForce: totalForceArg };
-        group.kind = kind;
-        group.dof = dof;
-        group.totalForce = totalForce;
-        if (components) group.components = components;
-        else delete group.components;
-        s.loads = rebuildLoads(s.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
-        s.result = null;
-      }),
-
-    removeFaceFromLoadGroup: (groupId: number, faceId: number) =>
-      set((s) => {
-        const g = s.loadGroups.find((g) => g.id === groupId);
-        if (!g) return;
-        g.faces = g.faces.filter((f) => f.id !== faceId);
-        if (g.faces.length === 0)
-          s.loadGroups = s.loadGroups.filter((g) => g.id !== groupId);
-        s.loads = rebuildLoads(s.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
-        s.result = null;
-      }),
-
-    deleteLoadGroup: (id: number) =>
-      set((s) => {
-        s.loadGroups = s.loadGroups.filter((g) => g.id !== id);
-        s.loads = rebuildLoads(s.loadGroups, s.nodes);
-        s.surfaceLoads = rebuildSurfaceLoads(s.loadGroups, s.elements);
-        s.result = null;
-      }),
-
-    clearLoads: () =>
-      set((s) => {
-        s.loadGroups = [];
-        s.loads = [];
-        s.surfaceLoads = [];
-        s.result = null;
-      }),
+  immer((...args) => ({
+    ...createGeometrySlice(...args),
+    ...createMaterialSlice(...args),
+    ...createBoundarySlice(...args),
+    ...createResultsSlice(...args),
+    ...createViewSlice(...args),
+    ...createAnalysisActions(...args),
   })),
 );
 

--- a/web/src/store/momentLoad.ts
+++ b/web/src/store/momentLoad.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Pure math: convert a moment applied over faces into equivalent nodal forces.
+// No Zustand dependency — unit-testable without any store setup (issue #202).
+
+import type { Node } from "./geometrySlice";
+import type { Load } from "./boundarySlice";
+
+export interface MomentFace {
+  nodeIds: number[];
+}
+
+// Equivalent nodal forces of a moment vector [Mx, My, Mz] (N·mm) applied over
+// the given faces. Each non-zero axis is converted independently and its nodal
+// forces summed (superposition). For each face, find the centroid, then apply
+// tangential forces F_i = M/S·(n̂×r_i) where S = Σ|r_i⊥|² (perpendicular
+// distance squared from the moment axis). This satisfies Σ(r_i × F_i) = M
+// exactly with zero net force.
+export function momentToNodalForces(
+  moment: [number, number, number],
+  faces: MomentFace[],
+  nodeById: Map<number, Node>,
+  groupName: string,
+): Load[] {
+  const result: Load[] = [];
+  for (let momentAxis = 0; momentAxis < 3; momentAxis++) {
+    const momentMag = moment[momentAxis]; // about x (0), y (1) or z (2)
+    if (momentMag === 0) continue;
+    let skippedFaces = 0;
+    for (const f of faces) {
+      let cx = 0,
+        cy = 0,
+        cz = 0,
+        count = 0;
+      for (const nodeId of f.nodeIds) {
+        const n = nodeById.get(nodeId);
+        if (n) {
+          cx += n.x;
+          cy += n.y;
+          cz += n.z;
+          count++;
+        }
+      }
+      if (count === 0) continue;
+      cx /= count;
+      cy /= count;
+      cz /= count;
+
+      let S = 0;
+      for (const nodeId of f.nodeIds) {
+        const n = nodeById.get(nodeId);
+        if (!n) continue;
+        const rx = n.x - cx,
+          ry = n.y - cy,
+          rz = n.z - cz;
+        if (momentAxis === 0) S += ry * ry + rz * rz;
+        else if (momentAxis === 1) S += rx * rx + rz * rz;
+        else S += rx * rx + ry * ry;
+      }
+      if (S === 0) {
+        // All face nodes lie on the moment axis — the tangential force
+        // direction is undefined, so this face contributes no moment.
+        skippedFaces++;
+        continue;
+      }
+
+      const scale = momentMag / S;
+      for (const nodeId of f.nodeIds) {
+        const n = nodeById.get(nodeId);
+        if (!n) continue;
+        const rx = n.x - cx,
+          ry = n.y - cy,
+          rz = n.z - cz;
+        if (momentAxis === 0) {
+          // Mx → F = scale·(0, −rz, ry)
+          result.push({ nodeId, dof: 1, value: -scale * rz });
+          result.push({ nodeId, dof: 2, value: scale * ry });
+        } else if (momentAxis === 1) {
+          // My → F = scale·(rz, 0, −rx)
+          result.push({ nodeId, dof: 0, value: scale * rz });
+          result.push({ nodeId, dof: 2, value: -scale * rx });
+        } else {
+          // Mz → F = scale·(−ry, rx, 0)
+          result.push({ nodeId, dof: 0, value: -scale * ry });
+          result.push({ nodeId, dof: 1, value: scale * rx });
+        }
+      }
+    }
+    if (skippedFaces > 0) {
+      const axisName = ["Mx", "My", "Mz"][momentAxis];
+      console.warn(
+        `[moment load] "${groupName}" (${axisName}): ${skippedFaces} of ` +
+          `${faces.length} face(s) skipped — all of their nodes lie on the ` +
+          "moment axis, so the applied moment is incomplete. Choose a " +
+          "different moment axis or face selection.",
+      );
+    }
+  }
+  return result;
+}

--- a/web/src/store/momentLoad.ts
+++ b/web/src/store/momentLoad.ts
@@ -14,9 +14,9 @@ export interface MomentFace {
 // Equivalent nodal forces of a moment vector [Mx, My, Mz] (N·mm) applied over
 // the given faces. Each non-zero axis is converted independently and its nodal
 // forces summed (superposition). For each face, find the centroid, then apply
-// tangential forces F_i = M/S·(n̂×r_i) where S = Σ|r_i⊥|² (perpendicular
-// distance squared from the moment axis). This satisfies Σ(r_i × F_i) = M
-// exactly with zero net force.
+// tangential forces F_i = M/S·(n̂×r_i) where S = Σ|r_i⊥|² (`sumPerpSq`, the
+// summed perpendicular distance squared from the moment axis). This satisfies
+// Σ(r_i × F_i) = M exactly with zero net force.
 export function momentToNodalForces(
   moment: [number, number, number],
   faces: MomentFace[],
@@ -47,25 +47,25 @@ export function momentToNodalForces(
       cy /= count;
       cz /= count;
 
-      let S = 0;
+      let sumPerpSq = 0;
       for (const nodeId of f.nodeIds) {
         const n = nodeById.get(nodeId);
         if (!n) continue;
         const rx = n.x - cx,
           ry = n.y - cy,
           rz = n.z - cz;
-        if (momentAxis === 0) S += ry * ry + rz * rz;
-        else if (momentAxis === 1) S += rx * rx + rz * rz;
-        else S += rx * rx + ry * ry;
+        if (momentAxis === 0) sumPerpSq += ry * ry + rz * rz;
+        else if (momentAxis === 1) sumPerpSq += rx * rx + rz * rz;
+        else sumPerpSq += rx * rx + ry * ry;
       }
-      if (S === 0) {
+      if (sumPerpSq === 0) {
         // All face nodes lie on the moment axis — the tangential force
         // direction is undefined, so this face contributes no moment.
         skippedFaces++;
         continue;
       }
 
-      const scale = momentMag / S;
+      const scale = momentMag / sumPerpSq;
       for (const nodeId of f.nodeIds) {
         const n = nodeById.get(nodeId);
         if (!n) continue;

--- a/web/src/store/resultsSlice.ts
+++ b/web/src/store/resultsSlice.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Results slice: solver output, solve settings, and the app's stage
+// transitions (mode navigation).
+
+import type { SliceCreator } from "./modelStore";
+
+export interface SolverResult {
+  displacements: Float64Array;
+  vonMises?: Float64Array;
+}
+
+export const RESULT_TYPES = [
+  "Displacement (magnitude)",
+  "Ux",
+  "Uy",
+  "Uz",
+  "Von Mises stress",
+] as const;
+export type ResultType = (typeof RESULT_TYPES)[number];
+
+export type AppMode = "geometry" | "constraints" | "solve" | "results";
+
+export interface ResultsSlice {
+  result: SolverResult | null;
+  resultType: ResultType;
+  isRunning: boolean;
+  // FE polynomial order for the solve: 1 = linear, 2 = quadratic (second-order).
+  // Quadratic elements resolve bending and stress gradients far better at the
+  // cost of more DOFs and a slower solve (issue #215).
+  elementOrder: number;
+  mode: AppMode;
+  hasStarted: boolean;
+
+  setResult(result: SolverResult): void;
+  setResultType(t: ResultType): void;
+  setRunning(v: boolean): void;
+  setElementOrder(order: number): void;
+
+  // Mode navigation
+  setMode(mode: AppMode): void;
+}
+
+export const createResultsSlice: SliceCreator<ResultsSlice> = (set) => ({
+  result: null,
+  resultType: "Displacement (magnitude)",
+  isRunning: false,
+  // Default to linear: it's fast and reliable for every mesh size. Quadratic is
+  // an opt-in upgrade (Solver settings) — far more accurate but ~8× the DOFs.
+  elementOrder: 1,
+  mode: "geometry",
+  hasStarted: false,
+
+  setResult: (result) =>
+    set((s) => {
+      s.result = result;
+      s.resultType = "Displacement (magnitude)";
+    }),
+  setResultType: (t) =>
+    set((s) => {
+      s.resultType = t;
+    }),
+  setRunning: (v) =>
+    set((s) => {
+      s.isRunning = v;
+    }),
+  setElementOrder: (order) =>
+    set((s) => {
+      s.elementOrder = order;
+    }),
+
+  setMode: (mode) =>
+    set((s) => {
+      s.mode = mode;
+    }),
+});

--- a/web/src/store/viewSlice.ts
+++ b/web/src/store/viewSlice.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// View slice: transient viewport presentation settings — none of this is
+// persisted in saved analyses except viewRepr.
+
+import type { SliceCreator } from "./modelStore";
+
+// How load glyphs are drawn in the viewport. "resultant" shows one arrow per
+// force/pressure group at the centroid of its loaded nodes (the statically
+// equivalent load the user specifies). "nodal" shows the work-equivalent load
+// each individual node carries — the per-node tributary share of the group total
+// — which is what actually reaches the solver as a surface traction (issue #196).
+export type LoadDisplay = "resultant" | "nodal";
+
+export type ViewRepr = "geometry" | "surface" | "volume" | "wireframe";
+
+export interface ViewSlice {
+  viewRepr: ViewRepr;
+  showUndeformedOverlay: boolean;
+  // Whether load glyphs are drawn as a single resultant per group or as one
+  // arrow per loaded node (issue #196). A transient view setting, not persisted.
+  loadDisplay: LoadDisplay;
+  // Deformation magnification applied to the result on top of the automatic
+  // fit-to-view scale. 1 = the default visible deformation, 0 = undeformed.
+  deformScale: number;
+  fitViewTrigger: number;
+
+  setViewRepr(v: ViewRepr): void;
+  setShowUndeformedOverlay(v: boolean): void;
+  setLoadDisplay(v: LoadDisplay): void;
+  setDeformScale(v: number): void;
+  triggerFitView(): void;
+}
+
+export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
+  viewRepr: "surface",
+  showUndeformedOverlay: true,
+  loadDisplay: "resultant",
+  deformScale: 1,
+  fitViewTrigger: 0,
+
+  setViewRepr: (v) =>
+    set((s) => {
+      s.viewRepr = v;
+    }),
+  setShowUndeformedOverlay: (v) =>
+    set((s) => {
+      s.showUndeformedOverlay = v;
+    }),
+  setLoadDisplay: (v) =>
+    set((s) => {
+      s.loadDisplay = v;
+    }),
+  setDeformScale: (v) =>
+    set((s) => {
+      s.deformScale = v;
+    }),
+  triggerFitView: () =>
+    set((s) => {
+      s.fitViewTrigger++;
+    }),
+});

--- a/web/tests/test_moment_load.mjs
+++ b/web/tests/test_moment_load.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env bun
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Unit test for the pure moment → equivalent-nodal-forces conversion
+// (src/store/momentLoad.ts, extracted in issue #202).
+//
+// The conversion applies tangential forces F_i = M/S·(n̂×r_i) with
+// S = Σ|r_i⊥|², which must reproduce the applied moment exactly
+// (Σ r_i × F_i = M) with zero net force.
+//
+// Run: bun tests/test_moment_load.mjs   (from the web/ directory)
+
+import { momentToNodalForces } from "../src/store/momentLoad.ts";
+
+let passed = 0,
+  failed = 0;
+
+function assert(label, condition) {
+  if (condition) {
+    console.log(`  ✓ ${label}`);
+    passed++;
+  } else {
+    console.error(`  ✗ FAIL: ${label}`);
+    failed++;
+  }
+}
+
+function near(a, b, tol = 1e-9) {
+  return Math.abs(a - b) < tol;
+}
+
+// Sum the nodal loads into net force [Fx,Fy,Fz] and net moment [Mx,My,Mz]
+// about the centroid of the given nodes.
+function resultants(loads, nodeById) {
+  let n = 0;
+  const c = [0, 0, 0];
+  for (const node of nodeById.values()) {
+    c[0] += node.x;
+    c[1] += node.y;
+    c[2] += node.z;
+    n++;
+  }
+  c[0] /= n;
+  c[1] /= n;
+  c[2] /= n;
+
+  const force = [0, 0, 0];
+  const moment = [0, 0, 0];
+  for (const l of loads) {
+    const node = nodeById.get(l.nodeId);
+    const F = [0, 0, 0];
+    F[l.dof] = l.value;
+    const r = [node.x - c[0], node.y - c[1], node.z - c[2]];
+    force[0] += F[0];
+    force[1] += F[1];
+    force[2] += F[2];
+    moment[0] += r[1] * F[2] - r[2] * F[1];
+    moment[1] += r[2] * F[0] - r[0] * F[2];
+    moment[2] += r[0] * F[1] - r[1] * F[0];
+  }
+  return { force, moment };
+}
+
+function nodeMap(nodes) {
+  return new Map(nodes.map((n) => [n.id, n]));
+}
+
+// ── Test 1: Mz on a square face in the xy-plane ───────────────────────────────
+
+console.log("Test 1: Mz over a square face reproduces the moment exactly");
+
+const square = nodeMap([
+  { id: 1, x: 0, y: 0, z: 0 },
+  { id: 2, x: 10, y: 0, z: 0 },
+  { id: 3, x: 10, y: 10, z: 0 },
+  { id: 4, x: 0, y: 10, z: 0 },
+]);
+const squareFace = [{ nodeIds: [1, 2, 3, 4] }];
+
+{
+  const M = 500;
+  const loads = momentToNodalForces([0, 0, M], squareFace, square, "Load1");
+  const { force, moment } = resultants(loads, square);
+  assert("produces nodal loads", loads.length > 0);
+  assert(
+    "zero net force",
+    near(force[0], 0) && near(force[1], 0) && near(force[2], 0),
+  );
+  assert(
+    "net moment equals applied Mz",
+    near(moment[0], 0) && near(moment[1], 0) && near(moment[2], M),
+  );
+  assert(
+    "forces are tangential (no z components)",
+    loads.every((l) => l.dof === 0 || l.dof === 1),
+  );
+}
+
+// ── Test 2: componentwise moment is the superposition of its axes ─────────────
+
+console.log("\nTest 2: componentwise [Mx,0,Mz] superposes the per-axis loads");
+
+{
+  const combined = momentToNodalForces(
+    [300, 0, -200],
+    squareFace,
+    square,
+    "Load1",
+  );
+  const { force, moment } = resultants(combined, square);
+  assert(
+    "zero net force",
+    near(force[0], 0) && near(force[1], 0) && near(force[2], 0),
+  );
+  assert(
+    "net moment equals [300, 0, -200]",
+    near(moment[0], 300) && near(moment[1], 0) && near(moment[2], -200),
+  );
+
+  const mx = momentToNodalForces([300, 0, 0], squareFace, square, "Load1");
+  const mz = momentToNodalForces([0, 0, -200], squareFace, square, "Load1");
+  assert(
+    "combined load count = sum of per-axis counts",
+    combined.length === mx.length + mz.length,
+  );
+}
+
+// ── Test 3: zero moment produces no loads ─────────────────────────────────────
+
+console.log("\nTest 3: zero moment vector produces no loads");
+
+{
+  const loads = momentToNodalForces([0, 0, 0], squareFace, square, "Load1");
+  assert("no loads generated", loads.length === 0);
+}
+
+// ── Test 4: face collinear with the moment axis is skipped ────────────────────
+
+console.log("\nTest 4: face whose nodes all lie on the moment axis is skipped");
+
+{
+  // All nodes on the x-axis → S = 0 for Mx; the face cannot carry the moment.
+  const line = nodeMap([
+    { id: 1, x: 0, y: 0, z: 0 },
+    { id: 2, x: 5, y: 0, z: 0 },
+    { id: 3, x: 10, y: 0, z: 0 },
+  ]);
+  const warnings = [];
+  const origWarn = console.warn;
+  console.warn = (msg) => warnings.push(msg);
+  const loads = momentToNodalForces(
+    [100, 0, 0],
+    [{ nodeIds: [1, 2, 3] }],
+    line,
+    "Load7",
+  );
+  console.warn = origWarn;
+  assert("no loads generated", loads.length === 0);
+  assert(
+    "a warning names the group and axis",
+    warnings.length === 1 &&
+      warnings[0].includes('"Load7"') &&
+      warnings[0].includes("Mx"),
+  );
+}
+
+// ── Test 5: multiple faces each carry the full moment ─────────────────────────
+
+console.log("\nTest 5: each face carries the full applied moment");
+
+{
+  // Two parallel square faces stacked in z; the conversion is per-face, so the
+  // total transferred moment is M per face (matching rebuildLoads semantics,
+  // where a group's faces each receive the group moment).
+  const nodes = nodeMap([
+    { id: 1, x: 0, y: 0, z: 0 },
+    { id: 2, x: 10, y: 0, z: 0 },
+    { id: 3, x: 10, y: 10, z: 0 },
+    { id: 4, x: 0, y: 10, z: 0 },
+    { id: 5, x: 0, y: 0, z: 10 },
+    { id: 6, x: 10, y: 0, z: 10 },
+    { id: 7, x: 10, y: 10, z: 10 },
+    { id: 8, x: 0, y: 10, z: 10 },
+  ]);
+  const faces = [{ nodeIds: [1, 2, 3, 4] }, { nodeIds: [5, 6, 7, 8] }];
+  const M = 240;
+  const loads = momentToNodalForces([0, 0, M], faces, nodes, "Load1");
+  const { force, moment } = resultants(loads, nodes);
+  assert(
+    "zero net force",
+    near(force[0], 0) && near(force[1], 0) && near(force[2], 0),
+  );
+  assert("net moment is M per face (2·M total)", near(moment[2], 2 * M));
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/web/tests/test_moment_load.mjs
+++ b/web/tests/test_moment_load.mjs
@@ -34,30 +34,34 @@ function near(a, b, tol = 1e-9) {
 // about the centroid of the given nodes.
 function resultants(loads, nodeById) {
   let n = 0;
-  const c = [0, 0, 0];
+  const centroid = [0, 0, 0];
   for (const node of nodeById.values()) {
-    c[0] += node.x;
-    c[1] += node.y;
-    c[2] += node.z;
+    centroid[0] += node.x;
+    centroid[1] += node.y;
+    centroid[2] += node.z;
     n++;
   }
-  c[0] /= n;
-  c[1] /= n;
-  c[2] /= n;
+  centroid[0] /= n;
+  centroid[1] /= n;
+  centroid[2] /= n;
 
   const force = [0, 0, 0];
   const moment = [0, 0, 0];
   for (const l of loads) {
     const node = nodeById.get(l.nodeId);
-    const F = [0, 0, 0];
-    F[l.dof] = l.value;
-    const r = [node.x - c[0], node.y - c[1], node.z - c[2]];
-    force[0] += F[0];
-    force[1] += F[1];
-    force[2] += F[2];
-    moment[0] += r[1] * F[2] - r[2] * F[1];
-    moment[1] += r[2] * F[0] - r[0] * F[2];
-    moment[2] += r[0] * F[1] - r[1] * F[0];
+    const nodalForce = [0, 0, 0];
+    nodalForce[l.dof] = l.value;
+    const arm = [
+      node.x - centroid[0],
+      node.y - centroid[1],
+      node.z - centroid[2],
+    ];
+    force[0] += nodalForce[0];
+    force[1] += nodalForce[1];
+    force[2] += nodalForce[2];
+    moment[0] += arm[1] * nodalForce[2] - arm[2] * nodalForce[1];
+    moment[1] += arm[2] * nodalForce[0] - arm[0] * nodalForce[2];
+    moment[2] += arm[0] * nodalForce[1] - arm[1] * nodalForce[0];
   }
   return { force, moment };
 }
@@ -79,8 +83,13 @@ const square = nodeMap([
 const squareFace = [{ nodeIds: [1, 2, 3, 4] }];
 
 {
-  const M = 500;
-  const loads = momentToNodalForces([0, 0, M], squareFace, square, "Load1");
+  const appliedMoment = 500;
+  const loads = momentToNodalForces(
+    [0, 0, appliedMoment],
+    squareFace,
+    square,
+    "Load1",
+  );
   const { force, moment } = resultants(loads, square);
   assert("produces nodal loads", loads.length > 0);
   assert(
@@ -89,7 +98,7 @@ const squareFace = [{ nodeIds: [1, 2, 3, 4] }];
   );
   assert(
     "net moment equals applied Mz",
-    near(moment[0], 0) && near(moment[1], 0) && near(moment[2], M),
+    near(moment[0], 0) && near(moment[1], 0) && near(moment[2], appliedMoment),
   );
   assert(
     "forces are tangential (no z components)",
@@ -184,14 +193,22 @@ console.log("\nTest 5: each face carries the full applied moment");
     { id: 8, x: 0, y: 10, z: 10 },
   ]);
   const faces = [{ nodeIds: [1, 2, 3, 4] }, { nodeIds: [5, 6, 7, 8] }];
-  const M = 240;
-  const loads = momentToNodalForces([0, 0, M], faces, nodes, "Load1");
+  const appliedMoment = 240;
+  const loads = momentToNodalForces(
+    [0, 0, appliedMoment],
+    faces,
+    nodes,
+    "Load1",
+  );
   const { force, moment } = resultants(loads, nodes);
   assert(
     "zero net force",
     near(force[0], 0) && near(force[1], 0) && near(force[2], 0),
   );
-  assert("net moment is M per face (2·M total)", near(moment[2], 2 * M));
+  assert(
+    "net moment is M per face (2·M total)",
+    near(moment[2], 2 * appliedMoment),
+  );
 }
 
 // ── Summary ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Refactors the monolithic `modelStore.ts` (1026 lines) into a modular architecture with focused slices, each owning one area of state. This improves maintainability, testability, and code organization without changing any public APIs or behavior.

closes #202

## Key Changes

**web/src/store/**
- **modelStore.ts** (1026 → 180 lines): Now a thin combiner that assembles slices and handles whole-model lifecycle actions (`loadAnalysis`, `reset`). Re-exports all public types and helpers so consumers keep importing from `"store/modelStore"`.
- **geometrySlice.ts** (new): Nodes, elements, properties, CAD geometry (tessellation + retained source bytes), and meshing pipeline state.
- **materialSlice.ts** (new): Material definitions and CRUD actions. Exports `DEFAULT_MATERIAL` constant.
- **boundarySlice.ts** (new): Named BC/load groups (primary source of truth), flat constraint/load arrays for the solver, and face-pick session state. Exports helper functions `rebuildConstraints`, `rebuildLoads`, `rebuildSurfaceLoads`.
- **resultsSlice.ts** (new): Solver output, solve settings, and app stage transitions (mode navigation).
- **viewSlice.ts** (new): Transient viewport presentation settings (not persisted except `viewRepr`).
- **momentLoad.ts** (new): Pure math module for converting moments to equivalent nodal forces. No Zustand dependency — unit-testable in isolation.

**web/tests/**
- **test_moment_load.mjs** (new): Comprehensive unit tests for the moment-to-forces conversion, verifying moment reproduction, superposition, zero-moment handling, and degenerate cases.

**web/package.json**
- Added `"test": "bun tests/test_moment_load.mjs"` script.

## Notable Implementation Details

- **Slice architecture**: Each slice is a `StateCreator<ModelState, [["zustand/immer", never]], [], T>` that receives the full combined state in its `set` function, ensuring type-safe cross-slice transitions (e.g., a new mesh clears BC groups and results).
- **Moment load extraction**: The moment-to-nodal-forces algorithm (previously inline in `rebuildLoads`) is extracted to `momentLoad.ts` as a pure function with no store dependency. This enables unit testing without Zustand setup and makes the math independently verifiable.
- **Public API preservation**: All types and helpers are re-exported from `modelStore.ts`, so no consumer imports change. The refactor is internal.
- **Lifecycle actions**: `loadAnalysis` and `reset` remain in the combiner because they touch every slice and orchestrate whole-model state transitions.
- **Default material**: Moved to `materialSlice.ts` as `DEFAULT_MATERIAL` for clarity and reusability.

## Checklist

- [x] **No silent fallbacks** — all error paths and edge cases (e.g., missing nodes in moment load, degenerate faces) are handled explicitly with console warnings or early returns.
- [x] Every input accepted by the UI or an API is consumed downstream — all slice state is either used by actions or persisted/restored in `loadAnalysis`.

https://claude.ai/code/session_0119gdYEHN81i892RTkiAPY9