### PR TITLE
Refactor WASM adapter to use module instance API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ kofem_wasm_emcc.js + kofem_wasm_emcc.wasm
          ↓
 web/src/wasm/pkg/kofem_wasm.js  (thin adapter, committed)
          ↓
-solver.worker.ts  (unchanged API: init() + named exports)
+solver.worker.ts  (awaits init(), calls methods on the KofemModule instance)
 ```
 
 ### Incremental Rust migration

--- a/web/src/wasm/pkg/kofem_wasm.d.ts
+++ b/web/src/wasm/pkg/kofem_wasm.d.ts
@@ -41,34 +41,3 @@ export interface ModuleOverrides {
 
 /** Initialise the WASM module and return it. Must be awaited before using any function. */
 export default function init(overrides?: ModuleOverrides): Promise<KofemModule>
-
-/** Load a STEP or IGES file and tessellate it into a closed surface triangle mesh.
- *  @param cad_bytes Raw STEP/IGES file bytes.
- *  @param opts_json  JSON-serialised `{ deflection_relative?: number, linear_deflection?: number, angular_deflection?: number, format?: "step" | "iges" }`.
- *    `deflection_relative` is the chord tolerance as a fraction of the bounding-box
- *    diagonal (default 0.001); `linear_deflection` overrides it with an absolute mm value.
- *    `format` selects the reader (default "step").
- *  @returns Flat typed arrays — see {@link StepTessellation}.
- */
-export function tessellate_step(cad_bytes: Uint8Array, opts_json: string): StepTessellation
-
-/** Generate a quality tetrahedral volume mesh from a closed surface mesh.
- *  @param surface_json JSON-serialised `{ vertices: [number,number,number][], triangles: [number,number,number][] }`.
- *  @param opts_json    JSON-serialised `{ max_element_size: number, min_element_size: number, grading: number, second_order: boolean }`.
- *  @returns JSON-serialised `{ vertices: [number,number,number][], tetrahedra: [number,number,number,number][] }`.
- */
-export function generate_volume_mesh(surface_json: string, opts_json: string): string
-
-/** Run a linear-elastic FEM solve using MFEM.
- *  @param mesh_json JSON-serialised `{ vertices: [number,number,number][], tetrahedra: [number,number,number,number][], hexahedra: [number,number,number,number,number,number,number,number][] }`.
- *  @param mat_json  JSON-serialised `{ young_modulus: number, poisson_ratio: number, density: number }`.
- *  @param bcs_json  JSON-serialised `{ fixed_vertices: number[], point_loads: { vertex: number, force: [number,number,number] }[], surface_loads?: { type: "force"|"pressure"|"traction", faces: number[][], force?: [number,number,number], pressure?: number }[] }`.
- *  @param order     FE polynomial order (1 = linear, 2 = quadratic).
- *  @returns JSON-serialised `{ displacements: number[], von_mises: number[] }`.
- */
-export function solve_linear_elastic(
-  mesh_json: string,
-  mat_json: string,
-  bcs_json: string,
-  order: number
-): string

--- a/web/src/wasm/pkg/kofem_wasm.js
+++ b/web/src/wasm/pkg/kofem_wasm.js
@@ -1,5 +1,6 @@
-// Adapter: wraps the Emscripten/Embind module (kofem_wasm_emcc.js) to present
-// the same named-export API that solver.worker.ts expects.
+// Adapter: wraps the Emscripten/Embind module (kofem_wasm_emcc.js) behind a
+// single default `init()` export; solver.worker.ts calls methods on the
+// returned module instance (see KofemModule in kofem_wasm.d.ts).
 //
 // kofem_wasm_emcc.js and kofem_wasm_emcc.wasm are build outputs written by
 // scripts/build-wasm.sh — run that script (or scripts/docker-build-wasm.sh)
@@ -13,26 +14,12 @@ import _createModule from './kofem_wasm_emcc.js'
 // the bytes as `wasmBinary` so emcc never has to locate the file itself at runtime.
 import wasmUrl from './kofem_wasm_emcc.wasm?url'
 
-let _m = null
-
 /** Load and initialise the WASM module.  Must be awaited before any other call. */
 export default async function init(moduleOverrides = {}) {
     const res = await fetch(wasmUrl)
     const wasmBinary = await res.arrayBuffer()
-    _m = await _createModule({
+    return _createModule({
         ...moduleOverrides,
         wasmBinary,
     })
-    return _m
 }
-
-function m() {
-    if (!_m) throw new Error('kofem WASM not initialised — await init() first')
-    return _m
-}
-
-export const tessellate_step      = (...a) => m().tessellate_step(...a)
-export const generate_volume_mesh = (...a) => m().generate_volume_mesh(...a)
-export const generate_fem_mesh    = (...a) => m().generate_fem_mesh(...a)
-export const free_geometry_cache  = ()     => m().free_geometry_cache()
-export const solve_linear_elastic = (...a) => m().solve_linear_elastic(...a)

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -4,11 +4,6 @@
 
 // Runs kofem-wasm off the main thread so heavy solves don't freeze the UI.
 
-// import init, {
-//   tessellate_step,
-//   generate_volume_mesh,
-//   solve_linear_elastic,
-// } from '/wasm/pkg/kofem_wasm.js'
 import createModule from "../wasm/pkg/kofem_wasm.js";
 import type { KofemModule } from "../wasm/pkg/kofem_wasm.js";
 


### PR DESCRIPTION
## Summary

Refactor the WASM adapter layer to expose a single `init()` default export that returns a `KofemModule` instance, rather than named exports that wrap a cached module. This simplifies the API contract and makes the module lifecycle explicit.

## Key Changes

**web/src/wasm/pkg/kofem_wasm.d.ts**
- Remove TypeScript declarations for `tessellate_step`, `generate_volume_mesh`, `solve_linear_elastic` named exports
- Keep only the `init()` default export and `KofemModule` interface

**web/src/wasm/pkg/kofem_wasm.js**
- Remove module caching (`_m` variable) and the `m()` guard function
- Remove all named export wrappers (`tessellate_step`, `generate_volume_mesh`, etc.)
- Simplify `init()` to directly return the initialized module instance
- Update comment to clarify that callers invoke methods on the returned module instance

**web/src/workers/solver.worker.ts**
- Remove commented-out named import statement
- Update to import the default `init` function and `KofemModule` type

**CLAUDE.md**
- Update architecture diagram to reflect that `solver.worker.ts` awaits `init()` and calls methods on the `KofemModule` instance

## Notable Implementation Details

The refactoring shifts from a "singleton with named exports" pattern to an "instance-based" pattern. This makes the module lifecycle explicit: callers must await `init()` before use, and the returned instance is what they interact with. The change eliminates the need for a guard function and cached module state, reducing indirection and making the code flow clearer.

The `KofemModule` interface (unchanged in this diff) defines all available methods, so TypeScript provides full type safety when calling methods on the returned instance.

## Checklist

- [x] **No silent fallbacks** — the `init()` function will throw if the WASM fetch or module creation fails; no defensive fallbacks added.
- [x] Every input accepted by the API is consumed — `init()` takes optional `moduleOverrides` and passes them through to the Emscripten module.

https://claude.ai/code/session_012v7F9NXRG8zXagBwozc7gU