### PR TITLE
Add resizable/collapsible sidebar with responsive layout

### DIFF
--- a/web/src/App.module.css
+++ b/web/src/App.module.css
@@ -1,21 +1,27 @@
 .layout {
-  display: grid;
-  grid-template-columns: 340px 1fr;
-  grid-template-rows: 44px 1fr 28px;
-  grid-template-areas:
-    "topbar  topbar"
-    "panel   viewport"
-    "status  status";
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100vh;
+  height: 100dvh;
   background: #f4f5f7;
   color: #0d1117;
   font-family: "IBM Plex Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
 
+/* Middle row: sidebar + viewport. position: relative anchors the sidebar's
+   small-screen overlay mode and its collapsed expand button. */
+.main {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  position: relative;
+}
+
 .viewport {
-  grid-area: viewport;
+  flex: 1;
+  min-width: 0;
   position: relative;
   overflow: hidden;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,7 +4,7 @@
 import { useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { TopBar } from "./components/topbar/TopBar";
-import { LeftPanel } from "./components/panel/LeftPanel";
+import { Sidebar } from "./components/panel/Sidebar";
 import { Viewport } from "./components/viewport/Viewport";
 import { StatusBar } from "./components/statusbar/StatusBar";
 import { useModelStore } from "./store/modelStore";
@@ -44,10 +44,12 @@ function Workspace() {
   return (
     <div className={styles.layout}>
       <TopBar />
-      <LeftPanel />
-      <main className={styles.viewport}>
-        <Viewport />
-      </main>
+      <div className={styles.main}>
+        <Sidebar />
+        <main className={styles.viewport}>
+          <Viewport />
+        </main>
+      </div>
       <StatusBar />
     </div>
   );

--- a/web/src/components/panel/LeftPanel.module.css
+++ b/web/src/components/panel/LeftPanel.module.css
@@ -25,6 +25,7 @@
 .aside {
   flex: 1;
   min-width: 0;
+  min-height: 0;
   background: var(--surface);
   border-right: 1px solid var(--border);
   overflow-y: auto;
@@ -118,30 +119,6 @@
 .navDotDone {
   border-color: #15803d;
   color: #15803d;
-}
-
-.collapseBtn {
-  flex-shrink: 0;
-  align-self: center;
-  display: grid;
-  place-items: center;
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  margin-left: 2px;
-  border: none;
-  border-radius: 4px;
-  background: none;
-  color: var(--muted-2);
-  cursor: pointer;
-  transition:
-    color 100ms ease,
-    background 100ms ease;
-}
-
-.collapseBtn:hover {
-  color: var(--ink);
-  background: var(--hover);
 }
 
 /* ── Tabs ───────────────────────────────────────────────────── */

--- a/web/src/components/panel/LeftPanel.module.css
+++ b/web/src/components/panel/LeftPanel.module.css
@@ -23,7 +23,8 @@
 /* ── Layout ─────────────────────────────────────────────────── */
 
 .aside {
-  grid-area: panel;
+  flex: 1;
+  min-width: 0;
   background: var(--surface);
   border-right: 1px solid var(--border);
   overflow-y: auto;
@@ -117,6 +118,30 @@
 .navDotDone {
   border-color: #15803d;
   color: #15803d;
+}
+
+.collapseBtn {
+  flex-shrink: 0;
+  align-self: center;
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  margin-left: 2px;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  color: var(--muted-2);
+  cursor: pointer;
+  transition:
+    color 100ms ease,
+    background 100ms ease;
+}
+
+.collapseBtn:hover {
+  color: var(--ink);
+  background: var(--hover);
 }
 
 /* ── Tabs ───────────────────────────────────────────────────── */

--- a/web/src/components/panel/PanelNav.tsx
+++ b/web/src/components/panel/PanelNav.tsx
@@ -19,6 +19,7 @@ export function PanelNav() {
   const constraints = useModelStore((s) => s.constraints);
   const loads = useModelStore((s) => s.loads);
   const result = useModelStore((s) => s.result);
+  const setSidebarOpen = useModelStore((s) => s.setSidebarOpen);
 
   function isValid(m: AppMode): boolean {
     if (m === "geometry") return nodes.length > 0;
@@ -57,6 +58,22 @@ export function PanelNav() {
           </button>
         );
       })}
+      <button
+        className={styles.collapseBtn}
+        title="Hide panel"
+        aria-label="Hide panel"
+        onClick={() => setSidebarOpen(false)}
+      >
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M10 3L5.5 8 10 13"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
     </nav>
   );
 }

--- a/web/src/components/panel/PanelNav.tsx
+++ b/web/src/components/panel/PanelNav.tsx
@@ -19,7 +19,6 @@ export function PanelNav() {
   const constraints = useModelStore((s) => s.constraints);
   const loads = useModelStore((s) => s.loads);
   const result = useModelStore((s) => s.result);
-  const setSidebarOpen = useModelStore((s) => s.setSidebarOpen);
 
   function isValid(m: AppMode): boolean {
     if (m === "geometry") return nodes.length > 0;
@@ -58,22 +57,6 @@ export function PanelNav() {
           </button>
         );
       })}
-      <button
-        className={styles.collapseBtn}
-        title="Hide panel"
-        aria-label="Hide panel"
-        onClick={() => setSidebarOpen(false)}
-      >
-        <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
-          <path
-            d="M10 3L5.5 8 10 13"
-            stroke="currentColor"
-            strokeWidth="1.6"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </button>
     </nav>
   );
 }

--- a/web/src/components/panel/Sidebar.module.css
+++ b/web/src/components/panel/Sidebar.module.css
@@ -1,0 +1,96 @@
+/* Resizable / collapsible sidebar shell (issue #339).
+   The 768px breakpoint must match SMALL_SCREEN_QUERY in store/viewSlice.ts. */
+
+.sidebar {
+  position: relative;
+  width: var(--sidebar-width);
+  height: 100%;
+  flex-shrink: 0;
+  display: flex;
+  min-width: 0;
+}
+
+/* Drag strip straddling the panel/viewport border. The visible feedback is a
+   2px accent line that appears on hover or while dragging. */
+.resizeHandle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: -4px;
+  width: 8px;
+  cursor: col-resize;
+  z-index: 25;
+  touch-action: none;
+}
+
+.resizeHandle::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 2px;
+  background: transparent;
+  transition: background 100ms ease;
+}
+
+.resizeHandle:hover::after,
+.resizeHandleActive::after {
+  background: #1f5fd0;
+}
+
+/* Floating button over the viewport when the sidebar is collapsed — styled
+   like the viewport's Fit View HUD button. */
+.expandBtn {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 25;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid #d1d5db;
+  border-radius: 5px;
+  color: #374151;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+}
+
+.expandBtn:hover {
+  background: #ffffff;
+  color: #0d1117;
+}
+
+.backdrop {
+  display: none;
+}
+
+/* Small screens: the sidebar overlays the viewport instead of squeezing it,
+   with a backdrop that closes it on tap. Drag-resize is disabled — the
+   overlay width is fixed by the screen size. */
+@media (max-width: 768px) {
+  .sidebar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    height: auto;
+    z-index: 30;
+    width: min(85vw, 360px);
+    box-shadow: 8px 0 24px rgba(13, 17, 23, 0.18);
+  }
+
+  .resizeHandle {
+    display: none;
+  }
+
+  .backdrop {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 29;
+    background: rgba(13, 17, 23, 0.25);
+  }
+}

--- a/web/src/components/panel/Sidebar.module.css
+++ b/web/src/components/panel/Sidebar.module.css
@@ -7,7 +7,41 @@
   height: 100%;
   flex-shrink: 0;
   display: flex;
+  flex-direction: column;
   min-width: 0;
+}
+
+/* Slim bottom bar holding the collapse button, kept out of the mode nav so
+   it isn't mistaken for a tab. */
+.footer {
+  flex-shrink: 0;
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 8px;
+  background: #ffffff;
+  border-top: 1px solid #e2e5ea;
+  border-right: 1px solid #e2e5ea;
+}
+
+.collapseBtn {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
+  background: none;
+  color: #6b7280;
+  cursor: pointer;
+  transition:
+    color 100ms ease,
+    background 100ms ease;
+}
+
+.collapseBtn:hover {
+  color: #0d1117;
+  background: #f0f2f5;
 }
 
 /* Drag strip straddling the panel/viewport border. The visible feedback is a
@@ -40,10 +74,11 @@
 }
 
 /* Floating button over the viewport when the sidebar is collapsed — styled
-   like the viewport's Fit View HUD button. */
+   like the viewport's Fit View HUD button, at the same corner the collapse
+   button lives in when the sidebar is open. */
 .expandBtn {
   position: absolute;
-  top: 10px;
+  bottom: 10px;
   left: 10px;
   z-index: 25;
   width: 30px;

--- a/web/src/components/panel/Sidebar.tsx
+++ b/web/src/components/panel/Sidebar.tsx
@@ -10,6 +10,37 @@ import {
 import { LeftPanel } from "./LeftPanel";
 import styles from "./Sidebar.module.css";
 
+// Slim bottom bar with the collapse button — arrow pointing left, bar on the
+// right, mirroring the expand button's icon.
+function SidebarFooter({ onCollapse }: { onCollapse: () => void }) {
+  return (
+    <div className={styles.footer}>
+      <button
+        className={styles.collapseBtn}
+        title="Hide panel"
+        aria-label="Hide panel"
+        onClick={onCollapse}
+      >
+        <svg width="15" height="15" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M13 3v10"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+          <path
+            d="M9.5 8H3M6 5L3 8l3 3"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
 // Resizable / collapsible shell around LeftPanel (issue #339). On desktop the
 // right edge drags to resize (double-click resets); on small screens the
 // sidebar starts collapsed and, when opened, overlays the viewport with a
@@ -84,31 +115,7 @@ export function Sidebar() {
         style={{ "--sidebar-width": `${width}px` } as CSSProperties}
       >
         <LeftPanel />
-        <div className={styles.footer}>
-          {/* Collapse: arrow pointing left, bar on the right. */}
-          <button
-            className={styles.collapseBtn}
-            title="Hide panel"
-            aria-label="Hide panel"
-            onClick={() => setOpen(false)}
-          >
-            <svg width="15" height="15" viewBox="0 0 16 16" fill="none">
-              <path
-                d="M13 3v10"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-              />
-              <path
-                d="M9.5 8H3M6 5L3 8l3 3"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+        <SidebarFooter onCollapse={() => setOpen(false)} />
         <div
           className={`${styles.resizeHandle} ${dragging ? styles.resizeHandleActive : ""}`}
           role="separator"

--- a/web/src/components/panel/Sidebar.tsx
+++ b/web/src/components/panel/Sidebar.tsx
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useModelStore } from "../../store/modelStore";
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  SMALL_SCREEN_QUERY,
+} from "../../store/viewSlice";
+import { LeftPanel } from "./LeftPanel";
+import styles from "./Sidebar.module.css";
+
+// Resizable / collapsible shell around LeftPanel (issue #339). On desktop the
+// right edge drags to resize (double-click resets); on small screens the
+// sidebar starts collapsed and, when opened, overlays the viewport with a
+// tap-to-close backdrop instead of squeezing it.
+export function Sidebar() {
+  const open = useModelStore((s) => s.sidebarOpen);
+  const width = useModelStore((s) => s.sidebarWidth);
+  const setOpen = useModelStore((s) => s.setSidebarOpen);
+  const setWidth = useModelStore((s) => s.setSidebarWidth);
+  const drag = useRef<{ startX: number; startWidth: number } | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  // Follow breakpoint crossings: collapse when the screen becomes small,
+  // reopen when it grows back to desktop size.
+  useEffect(() => {
+    const mq = window.matchMedia(SMALL_SCREEN_QUERY);
+    const onChange = (e: MediaQueryListEvent) => setOpen(!e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, [setOpen]);
+
+  function handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
+    e.preventDefault();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    drag.current = { startX: e.clientX, startWidth: width };
+    setDragging(true);
+  }
+
+  function handlePointerMove(e: React.PointerEvent<HTMLDivElement>) {
+    if (!drag.current) return;
+    setWidth(drag.current.startWidth + e.clientX - drag.current.startX);
+  }
+
+  function handlePointerUp() {
+    drag.current = null;
+    setDragging(false);
+  }
+
+  if (!open) {
+    return (
+      <button
+        className={styles.expandBtn}
+        title="Show panel"
+        aria-label="Show panel"
+        onClick={() => setOpen(true)}
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M6 3l4.5 5L6 13"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+    );
+  }
+
+  return (
+    <>
+      <div className={styles.backdrop} onClick={() => setOpen(false)} />
+      <div
+        className={styles.sidebar}
+        style={{ "--sidebar-width": `${width}px` } as CSSProperties}
+      >
+        <LeftPanel />
+        <div
+          className={`${styles.resizeHandle} ${dragging ? styles.resizeHandleActive : ""}`}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize sidebar"
+          title="Drag to resize — double-click to reset"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onDoubleClick={() => setWidth(SIDEBAR_DEFAULT_WIDTH)}
+        />
+      </div>
+    </>
+  );
+}

--- a/web/src/components/panel/Sidebar.tsx
+++ b/web/src/components/panel/Sidebar.tsx
@@ -49,6 +49,7 @@ export function Sidebar() {
   }
 
   if (!open) {
+    // Expand: bar on the left (the collapsed panel), arrow pointing right.
     return (
       <button
         className={styles.expandBtn}
@@ -56,11 +57,17 @@ export function Sidebar() {
         aria-label="Show panel"
         onClick={() => setOpen(true)}
       >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+        <svg width="15" height="15" viewBox="0 0 16 16" fill="none">
           <path
-            d="M6 3l4.5 5L6 13"
+            d="M3 3v10"
             stroke="currentColor"
-            strokeWidth="1.6"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+          <path
+            d="M6.5 8H13M10 5l3 3-3 3"
+            stroke="currentColor"
+            strokeWidth="1.5"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
@@ -77,6 +84,31 @@ export function Sidebar() {
         style={{ "--sidebar-width": `${width}px` } as CSSProperties}
       >
         <LeftPanel />
+        <div className={styles.footer}>
+          {/* Collapse: arrow pointing left, bar on the right. */}
+          <button
+            className={styles.collapseBtn}
+            title="Hide panel"
+            aria-label="Hide panel"
+            onClick={() => setOpen(false)}
+          >
+            <svg width="15" height="15" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M13 3v10"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+              <path
+                d="M9.5 8H3M6 5L3 8l3 3"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
         <div
           className={`${styles.resizeHandle} ${dragging ? styles.resizeHandleActive : ""}`}
           role="separator"

--- a/web/src/components/statusbar/StatusBar.module.css
+++ b/web/src/components/statusbar/StatusBar.module.css
@@ -1,5 +1,6 @@
 .bar {
-  grid-area: status;
+  height: 28px;
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/web/src/components/topbar/TopBar.module.css
+++ b/web/src/components/topbar/TopBar.module.css
@@ -1,5 +1,6 @@
 .bar {
-  grid-area: topbar;
+  height: 44px;
+  flex-shrink: 0;
   display: flex;
   align-items: stretch;
   background: #ffffff;

--- a/web/src/store/viewSlice.ts
+++ b/web/src/store/viewSlice.ts
@@ -15,6 +15,28 @@ export type LoadDisplay = "resultant" | "nodal";
 
 export type ViewRepr = "geometry" | "surface" | "volume" | "wireframe";
 
+// Sidebar sizing (issue #339). Width is persisted so the user's preferred
+// split survives reloads; the open/closed state is derived from screen size
+// on startup (collapsed on small screens, expanded on desktop).
+export const SIDEBAR_DEFAULT_WIDTH = 340;
+export const SIDEBAR_MIN_WIDTH = 260;
+export const SIDEBAR_MAX_WIDTH = 560;
+// Must match the @media breakpoints in Sidebar.module.css.
+export const SMALL_SCREEN_QUERY = "(max-width: 768px)";
+
+const SIDEBAR_WIDTH_KEY = "kofem.sidebarWidth";
+
+function clampSidebarWidth(w: number): number {
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, w));
+}
+
+function initialSidebarWidth(): number {
+  const stored = Number(localStorage.getItem(SIDEBAR_WIDTH_KEY));
+  return Number.isFinite(stored) && stored > 0
+    ? clampSidebarWidth(stored)
+    : SIDEBAR_DEFAULT_WIDTH;
+}
+
 export interface ViewSlice {
   viewRepr: ViewRepr;
   showUndeformedOverlay: boolean;
@@ -25,12 +47,18 @@ export interface ViewSlice {
   // fit-to-view scale. 1 = the default visible deformation, 0 = undeformed.
   deformScale: number;
   fitViewTrigger: number;
+  // Sidebar layout (issue #339): collapsed on small screens so the viewport
+  // gets the full width, resizable on desktop.
+  sidebarOpen: boolean;
+  sidebarWidth: number;
 
   setViewRepr(v: ViewRepr): void;
   setShowUndeformedOverlay(v: boolean): void;
   setLoadDisplay(v: LoadDisplay): void;
   setDeformScale(v: number): void;
   triggerFitView(): void;
+  setSidebarOpen(v: boolean): void;
+  setSidebarWidth(v: number): void;
 }
 
 export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
@@ -39,6 +67,8 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
   loadDisplay: "resultant",
   deformScale: 1,
   fitViewTrigger: 0,
+  sidebarOpen: !window.matchMedia(SMALL_SCREEN_QUERY).matches,
+  sidebarWidth: initialSidebarWidth(),
 
   setViewRepr: (v) =>
     set((s) => {
@@ -59,5 +89,14 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
   triggerFitView: () =>
     set((s) => {
       s.fitViewTrigger++;
+    }),
+  setSidebarOpen: (v) =>
+    set((s) => {
+      s.sidebarOpen = v;
+    }),
+  setSidebarWidth: (v) =>
+    set((s) => {
+      s.sidebarWidth = clampSidebarWidth(v);
+      localStorage.setItem(SIDEBAR_WIDTH_KEY, String(s.sidebarWidth));
     }),
 });


### PR DESCRIPTION
## Summary

Implements a resizable and collapsible sidebar panel (issue #339) that adapts to screen size. On desktop, the sidebar's right edge can be dragged to resize, with double-click to reset. On small screens (≤768px), the sidebar collapses by default and overlays the viewport when opened, with a tap-to-close backdrop. The sidebar width is persisted across reloads.

closes #339

## Key Changes

**web/**
- **Sidebar.tsx** (new): Resizable/collapsible shell wrapping LeftPanel with drag-to-resize, collapse/expand buttons, and responsive overlay behavior on small screens
- **Sidebar.module.css** (new): Layout and styling for the sidebar, resize handle with visual feedback, collapse/expand buttons, and media query for small-screen overlay mode
- **App.tsx**: Replace direct LeftPanel with Sidebar component; restructure layout from CSS Grid to Flexbox to support dynamic sidebar width
- **App.module.css**: Convert from grid-based layout to flex-based layout with a new `.main` container for the sidebar + viewport row
- **LeftPanel.module.css**: Update from grid-area to flex layout properties
- **TopBar.module.css**: Update from grid-area to explicit height + flex-shrink
- **StatusBar.module.css**: Update from grid-area to explicit height + flex-shrink

**web/src/store/**
- **viewSlice.ts**: Add sidebar state management (open/closed, width) with localStorage persistence; define sizing constants (default 340px, min 260px, max 560px) and media query breakpoint (768px); initialize sidebar state based on screen size at startup

## Notable Implementation Details

- **Responsive behavior**: The sidebar automatically collapses when the screen crosses the 768px breakpoint (via `matchMedia` listener) and reopens when it grows back to desktop size. This state is independent of the persisted width.
- **Width persistence**: The sidebar width is clamped to [260px, 560px] and stored in localStorage, surviving page reloads while respecting min/max constraints.
- **Small-screen overlay**: On screens ≤768px, the sidebar uses `position: absolute` with a semi-transparent backdrop (`z-index: 29`) that closes the sidebar on tap. The resize handle is hidden and the sidebar width is fixed to `min(85vw, 360px)`.
- **Drag-to-resize**: Desktop only. The resize handle is an 8px-wide strip with a 2px visual accent line that appears on hover or while dragging. Pointer capture ensures smooth dragging even outside the sidebar bounds.
- **Layout migration**: Converted the top-level layout from CSS Grid (with named grid areas) to Flexbox to support dynamic sidebar width. The new `.main` container uses `position: relative` to anchor the sidebar's overlay mode and the collapsed expand button.
- **Accessibility**: Resize handle has `role="separator"` and `aria-orientation="vertical"`. Buttons have descriptive labels and titles.

## Checklist

- [x] **No silent fallbacks** — localStorage reads are validated with `Number.isFinite()` and fall back to the default width; all state transitions are explicit.
- [x] Every input accepted by the UI is consumed downstream — sidebar width and open state are stored and used to control rendering and layout.

https://claude.ai/code/session_01CGRme3fAPoboziBx3dBKR7