### PR TITLE
Add privacy policy page and GDPR-compliant Google Analytics

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,8 @@
+# Copy to `.env` (or set in the deploy environment) to configure the web build.
+# Vite exposes VITE_* vars to the bundle/HTML at build time via import.meta.env.
+
+# Google Analytics (GA4) measurement ID, e.g. G-XXXXXXXXXX.
+# Leave empty/unset to disable analytics entirely — no gtag.js is loaded and no
+# cookie-consent banner is shown. When set, GA4 is loaded only after the visitor
+# accepts the cookie-consent banner.
+VITE_GA_ID=

--- a/web/.env.example
+++ b/web/.env.example
@@ -2,7 +2,16 @@
 # Vite exposes VITE_* vars to the bundle/HTML at build time via import.meta.env.
 
 # Google Analytics (GA4) measurement ID, e.g. G-XXXXXXXXXX.
-# Leave empty/unset to disable analytics entirely — no gtag.js is loaded and no
-# cookie-consent banner is shown. When set, GA4 is loaded only after the visitor
-# accepts the cookie-consent banner.
+#
+# Build time (local dev / static hosts): set here or export VITE_GA_ID before
+#   `bun run dev` / `bun run build` and the ID is baked into the HTML.
+#
+# Run time (Docker): leave this UNSET when building the image. The image then
+#   ships a placeholder and reads VITE_GA_ID at container start instead, so one
+#   prebuilt image can be configured without a rebuild:
+#     docker run -e VITE_GA_ID=G-XXXXXXXXXX ...
+#
+# Unset in both places => analytics fully disabled (no gtag.js, no consent
+# banner, no cookies). When set, GA4 loads only after the visitor accepts the
+# cookie-consent banner.
 VITE_GA_ID=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -51,7 +51,17 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # template is rendered with envsubst at container start.
 ENV PORT=10000
 
+# Google Analytics measurement ID, applied to the served HTML at container start
+# (see docker-entrypoint.d/40-kofem-ga-config.sh). Set at `docker run` time, e.g.
+# `-e VITE_GA_ID=G-XXXXXXXXXX`. Empty (the default) leaves analytics disabled, so
+# the same image works with or without analytics — no rebuild required.
+ENV VITE_GA_ID=""
+
 COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+
+# Runs before nginx starts (the base image executes /docker-entrypoint.d/*.sh).
+COPY docker-entrypoint.d/40-kofem-ga-config.sh /docker-entrypoint.d/40-kofem-ga-config.sh
+RUN chmod +x /docker-entrypoint.d/40-kofem-ga-config.sh
 
 EXPOSE 10000
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -30,6 +30,12 @@ COPY . .
 ARG VITE_GIT_VERSION=local
 ENV VITE_GIT_VERSION=$VITE_GIT_VERSION
 
+# Optional Google Analytics (GA4) measurement ID, e.g. G-XXXXXXXXXX. When empty
+# (the default) analytics and the cookie-consent banner are omitted from the
+# build. When set, GA4 loads only after the visitor accepts the consent banner.
+ARG VITE_GA_ID=
+ENV VITE_GA_ID=$VITE_GA_ID
+
 RUN bun run build
 
 # Defensive: production images must never contain source maps.

--- a/web/docker-entrypoint.d/40-kofem-ga-config.sh
+++ b/web/docker-entrypoint.d/40-kofem-ga-config.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Runs at container start (nginx image executes /docker-entrypoint.d/*.sh before
+# starting nginx). Fills the Google Analytics measurement ID into the pre-built
+# static HTML so the image can be built ONCE — without a GA ID — and configured
+# at runtime via the VITE_GA_ID env var. No rebuild needed to set, change, or
+# disable analytics.
+#
+# The build ships a placeholder token inside the consent-gated gtag loader; this
+# replaces it with $VITE_GA_ID across every served HTML file. If VITE_GA_ID is
+# unset/empty the placeholder is left in place and the loader treats it as "not
+# configured" (no banner, no analytics, no cookies). Kept in sync with the
+# GA_PLACEHOLDER constant in web/vite-analytics.ts.
+set -eu
+
+ROOT="/usr/share/nginx/html"
+PLACEHOLDER="__KOFEM_GA_ID__"
+ID="${VITE_GA_ID:-}"
+
+if [ -z "$ID" ]; then
+  echo "[kofem] VITE_GA_ID not set — Google Analytics disabled."
+  exit 0
+fi
+
+# Only accept a well-formed GA measurement ID; refuse anything else so a stray
+# runtime value can't inject markup or script into the served pages.
+if ! printf '%s' "$ID" | grep -Eq '^[A-Za-z0-9_-]+$'; then
+  echo "[kofem] VITE_GA_ID='$ID' is not a valid measurement ID — analytics disabled." >&2
+  exit 0
+fi
+
+echo "[kofem] Enabling Google Analytics ($ID)."
+find "$ROOT" -type f -name '*.html' -exec sed -i "s/${PLACEHOLDER}/${ID}/g" {} +

--- a/web/examples/index.html
+++ b/web/examples/index.html
@@ -590,6 +590,8 @@
           <a href="/">Home</a>
           <a href="/examples/">Examples</a>
           <a href="/app/">Launch</a>
+          <a href="/privacy/">Privacy &amp; Cookies</a>
+          <a href="#" id="kofem-cookie-settings">Cookie settings</a>
         </div>
       </div>
     </footer>

--- a/web/index.html
+++ b/web/index.html
@@ -965,6 +965,8 @@
           <div class="legal">
             <a href="/">Home</a>
             <a href="/examples/">Examples</a>
+            <a href="/privacy/">Privacy &amp; Cookies</a>
+            <a href="#" id="kofem-cookie-settings">Cookie settings</a>
             <a
               href="https://github.com/mkofler96/KoFEM/blob/main/LICENSE"
               target="_blank"

--- a/web/privacy/index.html
+++ b/web/privacy/index.html
@@ -1,0 +1,364 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/svg+xml" href="/kofem_logo.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+
+    <title>Privacy &amp; Cookies | KoFEM</title>
+    <meta
+      name="description"
+      content="How KoFEM handles data and cookies. KoFEM runs your FEM analysis entirely in the browser and uses Google Analytics only with your consent."
+    />
+    <link rel="canonical" href="https://solver.example.com/privacy/" />
+    <meta name="robots" content="index, follow" />
+
+    <!-- Self-hosted fonts (SIL OFL) — see public/fonts/README.md -->
+    <link href="/fonts/geist.css" rel="stylesheet" />
+
+    <!-- Apply the saved theme before first paint to avoid a flash. -->
+    <script>
+      try {
+        if (localStorage.getItem("kofem_theme") === "light")
+          document.documentElement.setAttribute("data-theme", "light");
+      } catch (e) {}
+    </script>
+
+    <style>
+      :root {
+        --bg: #0a0b0f;
+        --bg2: #0c0e13;
+        --panel: #13151c;
+        --border: #23262f;
+        --border2: #2d313b;
+        --text: #eceef3;
+        --muted: #9aa0ad;
+        --faint: #6b7280;
+        --accent: #5b7cff;
+        --mono: "Geist Mono", ui-monospace, SFMono-Regular, monospace;
+      }
+
+      :root[data-theme="light"] {
+        --bg: #ffffff;
+        --bg2: #f7f8fa;
+        --panel: #ffffff;
+        --border: #e7e9ee;
+        --border2: #d8dbe2;
+        --text: #0d1117;
+        --muted: #5b616e;
+        --faint: #868d99;
+        --accent: #2f54eb;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family:
+          "Geist",
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.6;
+        min-height: 100vh;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+
+      .site-header {
+        border-bottom: 1px solid var(--border);
+        background: var(--bg2);
+      }
+
+      .header-inner {
+        max-width: 820px;
+        margin: 0 auto;
+        padding: 16px 24px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        color: var(--text);
+      }
+
+      .brand-mark {
+        width: 28px;
+        height: 28px;
+        border-radius: 8px;
+      }
+
+      .brand-name {
+        font-weight: 600;
+        font-size: 16px;
+        letter-spacing: -0.015em;
+      }
+
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 56px 24px 80px;
+      }
+
+      .eyebrow {
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        color: var(--accent);
+        text-transform: uppercase;
+        margin-bottom: 14px;
+      }
+
+      h1 {
+        font-size: clamp(30px, 5vw, 42px);
+        line-height: 1.1;
+        letter-spacing: -0.03em;
+        font-weight: 600;
+        margin: 0 0 6px;
+      }
+
+      .updated {
+        color: var(--faint);
+        font-size: 13.5px;
+        font-family: var(--mono);
+        margin: 0 0 38px;
+      }
+
+      h2 {
+        font-size: 21px;
+        letter-spacing: -0.02em;
+        font-weight: 600;
+        margin: 40px 0 12px;
+      }
+
+      p {
+        color: var(--muted);
+        margin: 0 0 16px;
+      }
+
+      ul {
+        color: var(--muted);
+        padding-left: 20px;
+        margin: 0 0 16px;
+      }
+
+      li {
+        margin-bottom: 8px;
+      }
+
+      code {
+        font-family: var(--mono);
+        font-size: 0.9em;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 5px;
+        padding: 1px 6px;
+      }
+
+      .note {
+        border: 1px solid var(--border);
+        background: var(--panel);
+        border-radius: 12px;
+        padding: 18px 20px;
+        margin: 24px 0;
+      }
+
+      .note p:last-child {
+        margin-bottom: 0;
+      }
+
+      .back {
+        display: inline-block;
+        margin-top: 40px;
+        font-size: 14px;
+      }
+
+      .site-footer {
+        border-top: 1px solid var(--border);
+        background: var(--bg2);
+      }
+
+      .footer-bottom-inner {
+        max-width: 820px;
+        margin: 0 auto;
+        padding: 18px 24px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+        font-size: 13px;
+        color: var(--faint);
+      }
+
+      .footer-bottom-inner .legal {
+        display: flex;
+        gap: 20px;
+        flex-wrap: wrap;
+      }
+
+      .footer-bottom-inner a {
+        color: var(--muted);
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="site-header">
+      <div class="header-inner">
+        <a class="brand" href="/">
+          <img
+            class="brand-mark"
+            src="/kofem_logo.svg"
+            alt="KoFEM logo"
+            width="28"
+            height="28"
+          />
+          <span class="brand-name">KoFEM</span>
+        </a>
+      </div>
+    </header>
+
+    <main>
+      <div class="eyebrow">Legal</div>
+      <h1>Privacy &amp; Cookies</h1>
+      <p class="updated">Last updated: July 2026</p>
+
+      <p>
+        KoFEM is a browser-based finite element solver. Your geometry, meshes,
+        and analysis all run <strong>locally in your browser</strong> — STEP
+        files, meshes, loads, and results are never uploaded to a server. This
+        page explains the limited data KoFEM does collect and the cookies it may
+        set.
+      </p>
+
+      <h2>Analytics cookies</h2>
+      <p>
+        With your consent, KoFEM uses
+        <a
+          href="https://marketingplatform.google.com/about/analytics/"
+          rel="noopener"
+          target="_blank"
+          >Google Analytics</a
+        >
+        (GA4) to understand how the site is used — for example which pages are
+        visited and roughly how many people use the solver. This helps us decide
+        what to improve.
+      </p>
+      <p>
+        Google Analytics sets first-party cookies (typically named
+        <code>_ga</code> and <code>_ga_&lt;id&gt;</code>) that store a randomly
+        generated identifier and are used to distinguish visitors and sessions.
+        These cookies are <strong>not strictly necessary</strong> for the site
+        to work.
+      </p>
+
+      <div class="note">
+        <p>
+          <strong>Consent first.</strong> The analytics script is not loaded and
+          no analytics cookies are set until you choose <em>Accept</em> in the
+          cookie banner. If you choose <em>Decline</em>, Google Analytics stays
+          disabled.
+        </p>
+        <p>
+          You can change your choice at any time using the
+          <a href="#" id="kofem-cookie-settings">Cookie settings</a> link (also
+          in the site footer). Declining opts you out via Google's documented
+          <code>ga-disable</code> flag.
+        </p>
+      </div>
+
+      <h2>What is collected</h2>
+      <p>If you accept analytics, Google Analytics may process:</p>
+      <ul>
+        <li>Pages viewed and events such as starting the solver.</li>
+        <li>
+          Approximate location (country / region), derived by Google from your
+          IP address. IP addresses are not stored by GA4.
+        </li>
+        <li>
+          Device and browser information (screen size, browser, operating
+          system).
+        </li>
+      </ul>
+      <p>
+        Data is processed by Google on our behalf. See
+        <a
+          href="https://policies.google.com/privacy"
+          rel="noopener"
+          target="_blank"
+          >Google's Privacy Policy</a
+        >
+        for details on how Google handles this data. You can also install the
+        <a
+          href="https://tools.google.com/dlpage/gaoptout"
+          rel="noopener"
+          target="_blank"
+          >Google Analytics opt-out browser add-on</a
+        >.
+      </p>
+
+      <h2>Other storage</h2>
+      <p>
+        KoFEM stores a couple of small values in your browser's
+        <code>localStorage</code> that are strictly functional and never leave
+        your device: your light/dark theme preference and your cookie-consent
+        choice. These are not tracking cookies.
+      </p>
+
+      <h2>Self-hosted assets</h2>
+      <p>
+        Fonts and the 3D engine are served from KoFEM itself, not third-party
+        CDNs. The only third-party request KoFEM makes is loading Google
+        Analytics — and only after you consent.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Questions about this notice? Reach out via the
+        <a
+          href="https://github.com/mkofler96/KoFEM"
+          rel="noopener"
+          target="_blank"
+          >project on GitHub</a
+        >.
+      </p>
+
+      <a class="back" href="/">← Back to KoFEM</a>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-bottom-inner">
+        <span>© 2026 KoFEM · AGPL-3.0</span>
+        <div class="legal">
+          <a href="/">Home</a>
+          <a href="/examples/">Examples</a>
+          <a href="/app/">Launch</a>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -2,6 +2,9 @@
 
 interface ImportMetaEnv {
   readonly VITE_GIT_VERSION?: string;
+  // Google Analytics (GA4) measurement ID, e.g. "G-XXXXXXXXXX". When unset,
+  // analytics and the cookie-consent banner are omitted from the build.
+  readonly VITE_GA_ID?: string;
 }
 
 interface ImportMeta {

--- a/web/vite-analytics.ts
+++ b/web/vite-analytics.ts
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { PluginOption } from "vite";
+
+// Google Analytics (GA4 / gtag.js), gated behind explicit opt-in consent.
+//
+// The measurement ID comes from the VITE_GA_ID build-time env var (see
+// vite.config.ts, .env.example and the Dockerfile). When it is unset the
+// snippet is empty, so nothing about analytics ships and no consent banner
+// appears — local and CI builds stay clean.
+//
+// GA4 sets first-party cookies (_ga, _ga_<id>) that are NOT strictly
+// necessary, so under GDPR / the ePrivacy directive they require prior
+// consent. We therefore never load gtag.js until the visitor clicks "Accept".
+// "Decline" (or a later opt-out via the footer "Cookie settings" link) sets
+// Google's documented window['ga-disable-<ID>'] flag. The choice is persisted
+// in localStorage under "kofem_analytics_consent".
+
+const GA_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Build the consent banner + gated gtag.js loader for a given measurement ID.
+ * Returns "" when no (valid) ID is configured, which disables analytics
+ * entirely. The returned block is injected verbatim before `</body>` on every
+ * page (see `injectAnalytics`).
+ */
+export function analyticsSnippet(gaId: string | undefined): string {
+  const id = (gaId ?? "").trim();
+  if (!id) return "";
+  if (!GA_ID_RE.test(id)) {
+    throw new Error(
+      `VITE_GA_ID="${id}" is not a valid GA measurement ID (expected characters [A-Za-z0-9_-], e.g. G-XXXXXXXXXX).`,
+    );
+  }
+
+  // The script uses string concatenation (no template literals) so it survives
+  // esbuild's HTML minifier untouched and never collides with this TS template.
+  return `
+    <!-- Google Analytics (gtag.js) — loaded only after explicit consent. -->
+    <style>
+      #kofem-cookie-consent {
+        position: fixed;
+        left: 16px;
+        right: 16px;
+        bottom: 16px;
+        z-index: 2147483000;
+        margin: 0 auto;
+        max-width: 660px;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 12px 18px;
+        padding: 16px 18px;
+        border-radius: 12px;
+        background: #13151c;
+        color: #eceef3;
+        border: 1px solid #2d313b;
+        box-shadow: 0 18px 50px -12px rgba(0, 0, 0, 0.6);
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        font-size: 13.5px;
+        line-height: 1.5;
+      }
+      #kofem-cookie-consent[hidden] { display: none; }
+      #kofem-cookie-consent p { margin: 0; flex: 1 1 260px; }
+      #kofem-cookie-consent a { color: #8ea2ff; text-decoration: underline; }
+      #kofem-cookie-consent .kofem-consent-actions {
+        display: flex;
+        gap: 10px;
+        margin-left: auto;
+      }
+      #kofem-cookie-consent button {
+        font: inherit;
+        font-weight: 600;
+        cursor: pointer;
+        padding: 8px 16px;
+        border-radius: 8px;
+        border: 1px solid #2d313b;
+        background: transparent;
+        color: #eceef3;
+      }
+      #kofem-cookie-consent button[data-consent="granted"] {
+        background: #5b7cff;
+        border-color: #5b7cff;
+        color: #fff;
+      }
+      :root[data-theme="light"] #kofem-cookie-consent {
+        background: #ffffff;
+        color: #0d1117;
+        border-color: #d8dbe2;
+      }
+      :root[data-theme="light"] #kofem-cookie-consent button[data-consent="denied"] {
+        color: #0d1117;
+        border-color: #d8dbe2;
+      }
+    </style>
+    <div
+      id="kofem-cookie-consent"
+      role="dialog"
+      aria-live="polite"
+      aria-label="Cookie consent"
+      hidden
+    >
+      <p>
+        We use Google Analytics cookies to understand how KoFEM is used. They
+        are only set if you accept. See our
+        <a href="/privacy/">Privacy &amp; Cookies</a> notice.
+      </p>
+      <div class="kofem-consent-actions">
+        <button type="button" data-consent="denied">Decline</button>
+        <button type="button" data-consent="granted">Accept</button>
+      </div>
+    </div>
+    <script>
+      (function () {
+        var GA_ID = "${id}";
+        var KEY = "kofem_analytics_consent";
+        var disableFlag = "ga-disable-" + GA_ID;
+
+        function getChoice() {
+          try { return localStorage.getItem(KEY); } catch (e) { return null; }
+        }
+        function setChoice(v) {
+          try { localStorage.setItem(KEY, v); } catch (e) {}
+        }
+
+        function loadGA() {
+          window[disableFlag] = false;
+          if (window.__kofemGALoaded) return;
+          window.__kofemGALoaded = true;
+          var s = document.createElement("script");
+          s.async = true;
+          s.src =
+            "https://www.googletagmanager.com/gtag/js?id=" +
+            encodeURIComponent(GA_ID);
+          document.head.appendChild(s);
+          window.dataLayer = window.dataLayer || [];
+          window.gtag = function () { window.dataLayer.push(arguments); };
+          window.gtag("js", new Date());
+          window.gtag("config", GA_ID);
+        }
+
+        function apply(choice) {
+          if (choice === "granted") loadGA();
+          else window[disableFlag] = true; // documented gtag.js opt-out
+        }
+
+        function init() {
+          var banner = document.getElementById("kofem-cookie-consent");
+          if (banner) {
+            var btns = banner.querySelectorAll("[data-consent]");
+            for (var i = 0; i < btns.length; i++) {
+              btns[i].addEventListener("click", function () {
+                var v = this.getAttribute("data-consent");
+                setChoice(v);
+                apply(v);
+                banner.hidden = true;
+              });
+            }
+          }
+          var settings = document.getElementById("kofem-cookie-settings");
+          if (settings && banner) {
+            settings.addEventListener("click", function (e) {
+              e.preventDefault();
+              banner.hidden = false;
+            });
+          }
+
+          var choice = getChoice();
+          if (choice === "granted") apply("granted");
+          else if (choice === "denied") apply("denied");
+          else if (banner) banner.hidden = false;
+        }
+
+        if (document.readyState === "loading") {
+          document.addEventListener("DOMContentLoaded", init);
+        } else {
+          init();
+        }
+      })();
+    </script>`;
+}
+
+/** Insert the analytics block just before `</body>` (falls back to append). */
+export function injectAnalytics(html: string, snippet: string): string {
+  if (!snippet) return html;
+  if (html.includes("</body>")) {
+    return html.replace("</body>", `${snippet}\n  </body>`);
+  }
+  return html + snippet;
+}
+
+/**
+ * Vite plugin that injects the analytics block via `transformIndexHtml`. This
+ * covers the dev server (all pages) and the production build of the app entry
+ * (app/index.html). The static marketing pages are copied outside Vite's HTML
+ * pipeline, so they are injected separately in copyStaticPages().
+ */
+export function analyticsPlugin(snippet: string): PluginOption {
+  return {
+    name: "kofem-analytics",
+    transformIndexHtml(html) {
+      return injectAnalytics(html, snippet);
+    },
+  };
+}

--- a/web/vite-analytics.ts
+++ b/web/vite-analytics.ts
@@ -5,10 +5,16 @@ import type { PluginOption } from "vite";
 
 // Google Analytics (GA4 / gtag.js), gated behind explicit opt-in consent.
 //
-// The measurement ID comes from the VITE_GA_ID build-time env var (see
-// vite.config.ts, .env.example and the Dockerfile). When it is unset the
-// snippet is empty, so nothing about analytics ships and no consent banner
-// appears — local and CI builds stay clean.
+// The measurement ID can be supplied two ways:
+//   1. Build time — the VITE_GA_ID env var is baked into the HTML by Vite
+//      (handy for local dev and fully-static hosts).
+//   2. Run time — when VITE_GA_ID is NOT set at build time, the HTML ships the
+//      GA_PLACEHOLDER token instead, and the Docker image fills it in at
+//      container start from the runtime VITE_GA_ID env var (see
+//      docker-entrypoint.d/40-kofem-ga-config.sh). This lets one prebuilt image
+//      be configured — or left disabled — without a rebuild.
+// If neither supplies an ID, the placeholder is never replaced and the loader
+// stays inert: no banner, no gtag.js, no cookies.
 //
 // GA4 sets first-party cookies (_ga, _ga_<id>) that are NOT strictly
 // necessary, so under GDPR / the ePrivacy directive they require prior
@@ -17,22 +23,26 @@ import type { PluginOption } from "vite";
 // Google's documented window['ga-disable-<ID>'] flag. The choice is persisted
 // in localStorage under "kofem_analytics_consent".
 
+// Token baked into the HTML when no build-time ID is given; replaced at runtime
+// by the Docker entrypoint. Kept in sync with docker-entrypoint.d/40-kofem-ga-config.sh.
+export const GA_PLACEHOLDER = "__KOFEM_GA_ID__";
+
 const GA_ID_RE = /^[A-Za-z0-9_-]+$/;
 
 /**
- * Build the consent banner + gated gtag.js loader for a given measurement ID.
- * Returns "" when no (valid) ID is configured, which disables analytics
- * entirely. The returned block is injected verbatim before `</body>` on every
- * page (see `injectAnalytics`).
+ * Build the consent banner + gated gtag.js loader. When `gaId` is provided it
+ * is baked in; otherwise the placeholder is emitted for runtime substitution.
+ * The block is injected verbatim before `</body>` on every page (see
+ * `injectAnalytics`) and stays inert until a real measurement ID is present.
  */
 export function analyticsSnippet(gaId: string | undefined): string {
-  const id = (gaId ?? "").trim();
-  if (!id) return "";
-  if (!GA_ID_RE.test(id)) {
+  const raw = (gaId ?? "").trim();
+  if (raw && !GA_ID_RE.test(raw)) {
     throw new Error(
-      `VITE_GA_ID="${id}" is not a valid GA measurement ID (expected characters [A-Za-z0-9_-], e.g. G-XXXXXXXXXX).`,
+      `VITE_GA_ID="${raw}" is not a valid GA measurement ID (expected characters [A-Za-z0-9_-], e.g. G-XXXXXXXXXX).`,
     );
   }
+  const id = raw || GA_PLACEHOLDER;
 
   // The script uses string concatenation (no template literals) so it survives
   // esbuild's HTML minifier untouched and never collides with this TS template.
@@ -114,6 +124,9 @@ export function analyticsSnippet(gaId: string | undefined): string {
     <script>
       (function () {
         var GA_ID = "${id}";
+        // Inert until a real measurement ID is present. An unreplaced runtime
+        // placeholder starts with "_"; real IDs (G-…, UA-…) never do.
+        if (!GA_ID || GA_ID.charAt(0) === "_") return;
         var KEY = "kofem_analytics_consent";
         var disableFlag = "ga-disable-" + GA_ID;
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,33 +1,49 @@
 // SPDX-FileCopyrightText: 2026 Michael Kofler
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { defineConfig, type PluginOption } from "vite";
+import { defineConfig, loadEnv, type PluginOption } from "vite";
 import { fileURLToPath } from "node:url";
-import { copyFileSync, mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import react from "@vitejs/plugin-react";
 import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
 import istanbul from "vite-plugin-istanbul";
+import {
+  analyticsPlugin,
+  analyticsSnippet,
+  injectAnalytics,
+} from "./vite-analytics";
 
 const htmlEntry = (p: string) => fileURLToPath(new URL(p, import.meta.url));
 
-// The marketing pages (index.html, examples/index.html) are fully static — Vite
-// emits them byte-for-byte, they import no hashed assets. Feeding them as extra
-// MPA rollup inputs is flaky (in some environments rollup crosses the landing/app
-// chunk names and drops the landing HTML entirely, leaving "/" on nginx's default
-// page). So the build has a single entry (the app) and we copy the static pages
-// into dist/ deterministically. Dev is unaffected: rollupOptions is build-only,
-// and the dev server still serves the pages from the filesystem.
-const copyStaticPages = (): PluginOption => ({
+// The marketing pages (index.html, examples/index.html, privacy/index.html) are
+// fully static — Vite emits them byte-for-byte, they import no hashed assets.
+// Feeding them as extra MPA rollup inputs is flaky (in some environments rollup
+// crosses the landing/app chunk names and drops the landing HTML entirely,
+// leaving "/" on nginx's default page). So the build has a single entry (the
+// app) and we copy the static pages into dist/ deterministically. The analytics
+// consent block is injected here because these pages bypass Vite's HTML pipeline
+// (transformIndexHtml only runs on the app entry at build time). Dev is
+// unaffected: rollupOptions is build-only, the dev server serves the pages from
+// the filesystem, and transformIndexHtml injects analytics there instead.
+const STATIC_PAGES = [
+  "index.html",
+  "examples/index.html",
+  "privacy/index.html",
+];
+
+const copyStaticPages = (snippet: string): PluginOption => ({
   name: "copy-static-pages",
   apply: "build",
   closeBundle() {
-    copyFileSync(htmlEntry("./index.html"), htmlEntry("./dist/index.html"));
-    mkdirSync(htmlEntry("./dist/examples"), { recursive: true });
-    copyFileSync(
-      htmlEntry("./examples/index.html"),
-      htmlEntry("./dist/examples/index.html"),
-    );
+    for (const page of STATIC_PAGES) {
+      const html = injectAnalytics(
+        readFileSync(htmlEntry(`./${page}`), "utf8"),
+        snippet,
+      );
+      mkdirSync(htmlEntry(`./dist/${page}/..`), { recursive: true });
+      writeFileSync(htmlEntry(`./dist/${page}`), html);
+    }
   },
 });
 
@@ -45,36 +61,45 @@ const coveragePlugins: PluginOption[] = process.env.COVERAGE
     ]
   : [];
 
-export default defineConfig(({ mode }) => ({
-  // Multi-page: "/" serves the static marketing landing (index.html); the React
-  // solver app lives at "/app/" (app/index.html). MPA mode disables the SPA
-  // history fallback so the two entries are served independently.
-  appType: "mpa",
-  plugins: [
-    react(),
-    wasm(),
-    topLevelAwait(),
-    copyStaticPages(),
-    ...coveragePlugins,
-  ],
-  worker: {
-    format: "es",
-    plugins: () => [wasm(), topLevelAwait(), ...coveragePlugins],
-  },
-  build: {
-    target: "esnext",
-    // Fail closed: source maps and unminified output are an explicit
-    // `--mode development` opt-in (see the build:dev script). Every other
-    // invocation — the default production build, CI, or any custom/empty mode
-    // a deploy host might pass — ships minified and map-free. Keying these off
-    // `mode === "production"` instead leaks readable, mapped source whenever
-    // the mode is anything but that exact string.
-    sourcemap: mode === "development",
-    minify: mode === "development" ? false : "esbuild",
-    rollupOptions: {
-      input: {
-        app: htmlEntry("./app/index.html"),
+export default defineConfig(({ mode }) => {
+  // VITE_GA_ID (empty prefix loads it from .env files and the process env, e.g.
+  // the Docker build's ENV). Empty/unset => no analytics, no consent banner.
+  const gaSnippet = analyticsSnippet(
+    loadEnv(mode, process.cwd(), "").VITE_GA_ID,
+  );
+
+  return {
+    // Multi-page: "/" serves the static marketing landing (index.html); the
+    // React solver app lives at "/app/" (app/index.html). MPA mode disables the
+    // SPA history fallback so the two entries are served independently.
+    appType: "mpa",
+    plugins: [
+      react(),
+      wasm(),
+      topLevelAwait(),
+      copyStaticPages(gaSnippet),
+      analyticsPlugin(gaSnippet),
+      ...coveragePlugins,
+    ],
+    worker: {
+      format: "es",
+      plugins: () => [wasm(), topLevelAwait(), ...coveragePlugins],
+    },
+    build: {
+      target: "esnext",
+      // Fail closed: source maps and unminified output are an explicit
+      // `--mode development` opt-in (see the build:dev script). Every other
+      // invocation — the default production build, CI, or any custom/empty mode
+      // a deploy host might pass — ships minified and map-free. Keying these off
+      // `mode === "production"` instead leaks readable, mapped source whenever
+      // the mode is anything but that exact string.
+      sourcemap: mode === "development",
+      minify: mode === "development" ? false : "esbuild",
+      rollupOptions: {
+        input: {
+          app: htmlEntry("./app/index.html"),
+        },
       },
     },
-  },
-}));
+  };
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -62,8 +62,10 @@ const coveragePlugins: PluginOption[] = process.env.COVERAGE
   : [];
 
 export default defineConfig(({ mode }) => {
-  // VITE_GA_ID (empty prefix loads it from .env files and the process env, e.g.
-  // the Docker build's ENV). Empty/unset => no analytics, no consent banner.
+  // VITE_GA_ID (empty prefix loads it from .env files and the process env). When
+  // set at build time it is baked in; when unset the snippet ships a placeholder
+  // for runtime substitution by the Docker entrypoint (or stays inert on other
+  // static hosts). See vite-analytics.ts.
   const gaSnippet = analyticsSnippet(
     loadEnv(mode, process.cwd(), "").VITE_GA_ID,
   );


### PR DESCRIPTION
## Summary

Adds a privacy policy page (`/privacy/`) and implements GDPR-compliant Google Analytics (GA4) with explicit opt-in consent. Analytics is gated behind a cookie-consent banner and never loads until the visitor accepts. The measurement ID can be supplied at build time (for local dev and static hosts) or at container runtime (for Docker deployments), allowing one prebuilt image to be configured without a rebuild.

closes #

## Key Changes

**Web**
- New `/privacy/` page documenting data handling, cookies, and analytics practices
- New `vite-analytics.ts` module that generates a consent-gated gtag.js loader with a cookie banner
- Updated `vite.config.ts` to inject the analytics block into all HTML pages (both static marketing pages and the app entry)
- New `.env.example` documenting the `VITE_GA_ID` build-time configuration
- Updated `Dockerfile` to accept `VITE_GA_ID` at build time and runtime
- New `docker-entrypoint.d/40-kofem-ga-config.sh` that substitutes the GA ID into served HTML at container start
- Updated `index.html` and `examples/index.html` footers to link to the privacy page and cookie settings
- Updated `vite-env.d.ts` to declare the `VITE_GA_ID` environment variable

## Notable Implementation Details

**Consent-first design:** The gtag.js script is never loaded and no analytics cookies are set until the visitor explicitly clicks "Accept" in the banner. Clicking "Decline" (or later using the "Cookie settings" link in the footer) sets Google's documented `ga-disable-<ID>` flag, opting the visitor out.

**Dual-mode ID configuration:**
- **Build time:** `VITE_GA_ID` env var is baked into the HTML by Vite (useful for local dev and fully-static hosts)
- **Runtime:** When `VITE_GA_ID` is unset at build time, the HTML ships a placeholder token (`__KOFEM_GA_ID__`). The Docker entrypoint script replaces it with the runtime `VITE_GA_ID` env var at container start, allowing one prebuilt image to be configured (or left disabled) without a rebuild.

**Inert when unconfigured:** If no measurement ID is present (placeholder unreplaced or empty), the consent banner never appears and the loader stays completely inert — no gtag.js, no cookies, no analytics.

**Static page injection:** Marketing pages (`index.html`, `examples/index.html`, `privacy/index.html`) bypass Vite's HTML pipeline at build time, so the analytics block is injected separately in the `copyStaticPages` plugin. The dev server still uses `transformIndexHtml` for all pages.

**Validation:** Both build time and runtime validate the GA ID format (`[A-Za-z0-9_-]+`) to prevent injection attacks or misconfiguration.

## Checklist

- [x] **No silent fallbacks** — Invalid GA IDs are rejected with clear error messages; missing IDs are handled explicitly (inert loader, no banner). The consent choice is persisted in localStorage with explicit try/catch for storage access.
- [x] Every input accepted by the UI (the consent buttons) is consumed downstream (applied to GA loading and the disable flag).

https://claude.ai/code/session_013T38QCyZbXsn2a4M9DoVEE