### PR TITLE
Add diagnostic logging for dropped worker responses

### DIFF
--- a/web/src/workers/sharedWorker.ts
+++ b/web/src/workers/sharedWorker.ts
@@ -37,7 +37,14 @@ function createWorker(): Worker {
       return;
     }
     const pending = _pending.get(id);
-    if (!pending) return;
+    if (!pending) {
+      console.warn(
+        `[worker] dropped response for unknown id ${id} — no pending request` +
+          ` (pending ids: [${[..._pending.keys()].join(", ")}]).` +
+          " Likely a response that arrived after resetWorker() or a duplicate resolution.",
+      );
+      return;
+    }
     _pending.delete(id);
     if (ok) {
       pending.resolve(rest);


### PR DESCRIPTION
## Summary

Improves observability when the shared worker drops a response due to a missing pending request. This can occur when a response arrives after `resetWorker()` is called or when a duplicate resolution is attempted. The new warning log includes the response ID and a list of currently pending request IDs to aid debugging.

## Key Changes

**web**
- Enhanced the worker response handler to log a detailed warning when a response is received for an unknown request ID, including the problematic ID and all currently pending IDs

## Notable Implementation Details

This change follows the project convention of preferring clear, information-rich error messages over silent fall-throughs. Rather than silently dropping the response, we now emit a diagnostic warning that includes:
- The unknown response ID
- The list of pending request IDs at the time of the dropped response
- A hint about likely causes (response after `resetWorker()` or duplicate resolution)

This makes it easier to diagnose worker lifecycle issues during development and debugging.

## Checklist

- [x] **No silent fallbacks** — replaced a silent `return` with an informative `console.warn()` that explains why the response was dropped and provides context for debugging
- [x] Every input accepted by the UI or an API is actually consumed downstream — the response ID and pending keys are only used for logging

https://claude.ai/code/session_01Q3t7JpTMgtiLPZwuBaxSCK