### PR TITLE
Reject silent BC/load drops and multi-material coupled solves

### DIFF
--- a/engine/cpp/bc_validation.h
+++ b/engine/cpp/bc_validation.h
@@ -58,6 +58,19 @@ inline void require_min_dofs(int ndof, int need, int vi, const char* fn) {
             " are required");
 }
 
+// Throw if `d` is not a valid Kirchhoff shell DOF component index (0..5). Unlike
+// the solid path's 3-component vector space, a shell node carries six DOFs — three
+// translations and three rotations — so solve_shell.cpp's fixed-DOF ingestion
+// validates against 0..5 (0=Ux, 1=Uy, 2=Uz, 3=Rx, 4=Ry, 5=Rz) instead of silently
+// dropping an out-of-range component (issue #379). `vi` and `fn` build the message.
+inline void require_valid_shell_component(int d, int vi, const char* fn) {
+    if (d < 0 || d >= 6)
+        throw std::runtime_error(
+            std::string(fn) + ": vertex " + std::to_string(vi) +
+            " was given the invalid shell DOF component index " + std::to_string(d) +
+            " — expected 0..5 (0=Ux, 1=Uy, 2=Uz, 3=Rx, 4=Ry, 5=Rz)");
+}
+
 }  // namespace kofem::bc
 
 #endif  // KOFEM_BC_VALIDATION_H

--- a/engine/cpp/shell_core.cpp
+++ b/engine/cpp/shell_core.cpp
@@ -700,8 +700,25 @@ ShellResult solve_reduced_system(Sparse& K, const std::vector<double>& F,
             for (const auto& [pi, ci] : expand(i)) Fr[red[pi]] += ci * F[i];
 
     std::vector<char> fr(nIndep, 0);
-    for (int i = 0; i < nDof; ++i)
-        if (fixed[i] != 0 && C.dep[i] == 0) fr[red[i]] = 1;
+    for (int i = 0; i < nDof; ++i) {
+        if (fixed[i] == 0) continue;
+        // A fixed DOF on a dependent (RBE3 distributing-coupling reference) node
+        // has no reduced-system column of its own — its motion is a weighted
+        // average of the coupled solid nodes — so it cannot be constrained here.
+        // Silently skipping it (the old `&& C.dep[i] == 0` guard) dropped the
+        // user's constraint and still let CG converge on an under-restrained
+        // model (issue #377). Refuse loudly instead.
+        if (C.dep[i] != 0)
+            throw std::runtime_error(
+                "solve_reduced_system: fixed DOF " + std::to_string(i) + " (node " +
+                std::to_string(i / 6) + ", component " + std::to_string(i % 6) +
+                ") lies on a coupling-dependent node — its motion is governed by "
+                "the RBE3 distributing coupling to the solid, so a direct "
+                "constraint on it cannot be honoured and would otherwise be "
+                "silently dropped. Constrain the coupled solid node(s) instead of "
+                "the shell coupling reference node.");
+        fr[red[i]] = 1;
+    }
     apply_homogeneous_bc(Kr, Fr, fr);
 
     ShellResult rr = cg_solve(Kr, Fr);

--- a/engine/cpp/solve_shell.cpp
+++ b/engine/cpp/solve_shell.cpp
@@ -12,6 +12,7 @@
 
 #include "solve_shell.h"
 
+#include "bc_validation.h"
 #include "json_util.h"
 #include "shell_core.h"
 #include "wasm_util.h"
@@ -30,6 +31,9 @@ val error_result(const std::string& message) {
 }
 
 // Append every DOF listed for a vertex (component 0..5) to the fixed set.
+// An out-of-range vertex or component is a loud error, not a silent skip:
+// dropping the constraint would let the shell CG still "converge" on a model
+// missing a BC the user configured (issue #379).
 void add_fixed_dofs(const val& fdofs_js, int n_nodes, std::vector<int>& fixed) {
     if (fdofs_js.isUndefined() || fdofs_js.isNull())
         return;
@@ -39,10 +43,11 @@ void add_fixed_dofs(const val& fdofs_js, int n_nodes, std::vector<int>& fixed) {
         int v = entry["vertex"].as<int>();
         val comps = entry["dofs"];
         unsigned nc = comps["length"].as<unsigned>();
+        kofem::bc::require_valid_vertex(v, n_nodes, "add_fixed_dofs");
         for (unsigned c = 0; c < nc; ++c) {
             int d = comps[c].as<int>();
-            if (v >= 0 && v < n_nodes && d >= 0 && d < 6)
-                fixed.push_back(6 * v + d);
+            kofem::bc::require_valid_shell_component(d, v, "add_fixed_dofs");
+            fixed.push_back(6 * v + d);
         }
     }
 }
@@ -54,9 +59,9 @@ void add_fixed_vertices(const val& fv_js, int n_nodes, std::vector<int>& fixed) 
     unsigned n = fv_js["length"].as<unsigned>();
     for (unsigned i = 0; i < n; ++i) {
         int v = fv_js[i].as<int>();
-        if (v >= 0 && v < n_nodes)
-            for (int d = 0; d < 6; ++d)
-                fixed.push_back(6 * v + d);
+        kofem::bc::require_valid_vertex(v, n_nodes, "add_fixed_vertices");
+        for (int d = 0; d < 6; ++d)
+            fixed.push_back(6 * v + d);
     }
 }
 
@@ -69,8 +74,7 @@ void add_point_loads(const val& loads_js, int n_nodes,
     for (unsigned i = 0; i < n; ++i) {
         val entry = loads_js[i];
         int v = entry["vertex"].as<int>();
-        if (v < 0 || v >= n_nodes)
-            continue;
+        kofem::bc::require_valid_vertex(v, n_nodes, "add_point_loads");
         val force = entry["force"];
         if (!force.isUndefined() && !force.isNull())
             for (int d = 0; d < 3; ++d)

--- a/engine/tests/bc_validation.cpp
+++ b/engine/tests/bc_validation.cpp
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Native validation of the BC/load index checks (engine/cpp/bc_validation.h)
-// that solve_mfem.cpp's ingestion functions use to reject out-of-range vertex
-// and DOF-component indices instead of silently dropping the constraint/load
-// (issue #362). The header is pure C++ — no MFEM, OCCT, Netgen or Emscripten —
-// so it compiles with a plain host compiler; see scripts/test-bc-validation.sh.
-// Exits non-zero if any case behaves wrong, so it can gate CI.
+// that solve_mfem.cpp's (issue #362) and solve_shell.cpp's (issue #379) ingestion
+// functions use to reject out-of-range vertex and DOF-component indices instead of
+// silently dropping the constraint/load. The header is pure C++ — no MFEM, OCCT,
+// Netgen or Emscripten — so it compiles with a plain host compiler; see
+// scripts/test-bc-validation.sh. Exits non-zero if any case behaves wrong, so it
+// can gate CI.
 
 #include "bc_validation.h"
 
@@ -91,6 +92,21 @@ int main() {
               [&] { require_min_dofs(3, 3, 5, "apply_point_loads"); });
     expect_throws(failures, "0 DOFs (empty lookup) rejected",
                   [&] { require_min_dofs(0, 3, 5, "apply_point_loads"); }, "apply_point_loads");
+
+    // ── Shell DOF-component range check (0..5: 3 translations + 3 rotations) ───
+    // solve_shell.cpp accepts six DOFs per node, so the valid band is wider than
+    // the solid path's 0..2 — but still bounded (issue #379).
+    printf("\nShell DOF-component validation (issue #379):\n");
+    expect_ok(failures, "shell component 0 (Ux) accepted",
+              [&] { require_valid_shell_component(0, 7, "add_fixed_dofs"); });
+    expect_ok(failures, "shell component 5 (Rz, last) accepted",
+              [&] { require_valid_shell_component(5, 7, "add_fixed_dofs"); });
+    expect_throws(failures, "shell component 6 (one past end) rejected",
+                  [&] { require_valid_shell_component(6, 7, "add_fixed_dofs"); }, "6");
+    expect_throws(failures, "negative shell component rejected",
+                  [&] { require_valid_shell_component(-1, 7, "add_fixed_dofs"); }, "-1");
+    expect_throws(failures, "shell component error names the vertex",
+                  [&] { require_valid_shell_component(9, 42, "add_fixed_dofs"); }, "42");
 
     printf(failures != 0 ? "\n%d check(s) FAILED\n" : "\nall checks passed\n", failures);
     return failures != 0 ? 1 : 0;

--- a/engine/tests/shell_validation.cpp
+++ b/engine/tests/shell_validation.cpp
@@ -222,6 +222,40 @@ double coupled_moment_transfer() {
     return w / ref;
 }
 
+// A fixed-DOF constraint that lands on an RBE3 coupling reference node (a
+// dependent, shell-side DOF) must be rejected loudly, not silently dropped
+// (issue #377). Reuses the cantilever-on-anchors coupling: every root node is a
+// coupling reference node, so clamping one is exactly the offending case.
+bool coupled_fixed_dependent_throws() {
+    const double L = 2.0, b = 0.3, t = 0.01, E = 2.1e11, nu = 0.3;
+    const int nx = 4, ny = 2;
+    auto id = [&](int i, int j) { return i * (ny + 1) + j; };
+    std::vector<double> V; std::vector<int> Tr; std::vector<int> root;
+    for (int i = 0; i <= nx; ++i)
+        for (int j = 0; j <= ny; ++j) { V.push_back(L * i / nx); V.push_back(b * j / ny); V.push_back(0); }
+    for (int i = 0; i < nx; ++i)
+        for (int j = 0; j < ny; ++j) {
+            const int a = id(i,j), c = id(i+1,j), d = id(i+1,j+1), e = id(i,j+1);
+            Tr.push_back(a); Tr.push_back(c); Tr.push_back(d); Tr.push_back(a); Tr.push_back(d); Tr.push_back(e);
+        }
+    for (int j = 0; j <= ny; ++j) root.push_back(id(0, j));
+    const int aBase = (nx + 1) * (ny + 1);
+    V.insert(V.end(), {-0.1, 0.0, 0.0,  -0.1, b, 0.0,  -0.1, b / 2, 0.1});  // 3 anchors
+    CoupledInput in;
+    in.n_nodes = aBase + 3; in.vertices = V; in.triangles = Tr;
+    in.shell_young = E; in.shell_poisson = nu; in.thickness = t;
+    for (int rn : root) { Coupling cp; cp.ref_node = rn; cp.solid_nodes = {aBase, aBase + 1, aBase + 2}; in.couplings.push_back(cp); }
+    for (int aa = 0; aa < 3; ++aa) for (int c = 0; c < 3; ++c) in.fixed_dofs.push_back(6 * (aBase + aa) + c);
+    // Offending constraint: clamp a translation on a coupling reference node.
+    in.fixed_dofs.push_back(6 * root[0] + 0);
+    try {
+        solve_solid_shell_core(in);
+    } catch (const std::exception&) {
+        return true;
+    }
+    return false;
+}
+
 }  // namespace
 
 int main() {
@@ -247,6 +281,15 @@ int main() {
     printf("Coupled solid + shell (distributing coupling):\n");
     check(failures, "coupled-tet-tension", coupled_tet_tension(), 1.0, 0.2);
     check(failures, "coupled-moment-transfer", coupled_moment_transfer(), 1.0, 6.0);
+
+    printf("Constraint-on-dependent-node rejection (issue #377):\n");
+    {
+        const bool threw = coupled_fixed_dependent_throws();
+        if (!threw) ++failures;
+        printf("  [%s] %-28s %s\n", threw ? "PASS" : "FAIL",
+               "fixed-dof-on-dependent throws",
+               threw ? "rejected as expected" : "did NOT throw");
+    }
 
     printf(failures != 0 ? "\n%d check(s) FAILED\n" : "\nall checks passed\n", failures);
     return failures != 0 ? 1 : 0;

--- a/web/src/lib/shellize.ts
+++ b/web/src/lib/shellize.ts
@@ -556,13 +556,14 @@ export function shellNodeLocator(
     );
     getOrInit(grid, key, () => []).push(pi);
   }
+  const maxRings = 6;
   return (p) => {
     const cx = Math.floor(p[0] / cell),
       cy = Math.floor(p[1] / cell),
       cz = Math.floor(p[2] / cell);
-    let best = model.shellPool[0],
+    let best = -1,
       bd = Infinity;
-    for (let r = 0; r <= 6 && bd === Infinity; r++) {
+    for (let r = 0; r <= maxRings && bd === Infinity; r++) {
       for (let dx = -r; dx <= r; dx++)
         for (let dy = -r; dy <= r; dy++)
           for (let dz = -r; dz <= r; dz++) {
@@ -585,6 +586,17 @@ export function shellNodeLocator(
             }
           }
     }
+    // No candidate within the searched radius: the query point (a BC/load on the
+    // shelled body) is farther from every shell mid-surface node than the grid
+    // sweep reaches. Returning the seed node would silently map the constraint or
+    // load onto an arbitrary, unrelated node — throw instead (issue #378).
+    if (best < 0 || bd === Infinity)
+      throw new Error(
+        `shellNodeLocator: no shell mid-surface node found within ${maxRings * cell} units of ` +
+          `query point (${p[0]}, ${p[1]}, ${p[2]}) — a boundary condition or load on the shelled ` +
+          `body could not be mapped onto the shell mesh. The node may lie farther from any thin ` +
+          `wall than the search radius, or the model may be mis-scaled.`,
+      );
     return best;
   };
 }

--- a/web/src/lib/shellize.ts
+++ b/web/src/lib/shellize.ts
@@ -594,8 +594,8 @@ export function shellNodeLocator(
       throw new Error(
         `shellNodeLocator: no shell mid-surface node found within ${maxRings * cell} units of ` +
           `query point (${p[0]}, ${p[1]}, ${p[2]}) — a boundary condition or load on the shelled ` +
-          `body could not be mapped onto the shell mesh. The node may lie farther from any thin ` +
-          `wall than the search radius, or the model may be mis-scaled.`,
+          "body could not be mapped onto the shell mesh. The node may lie farther from any thin " +
+          "wall than the search radius, or the model may be mis-scaled.",
       );
     return best;
   };

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -521,21 +521,53 @@ function buildShellizeMesh(
 }
 
 // Solid and shell material for the coupled solve (single each). The shell uses
-// the thin body's material; the solid uses any other body's. Multi-material
-// solids collapse to the first solid body's material for now.
+// the thin body's material; the solid uses the single material shared by every
+// solid body. The coupled solid-shell assembler (engine/cpp/solve_coupled.cpp →
+// assemble_solid_stiffness_mfem) takes one (E, nu) pair for the whole solid
+// domain — it has no per-body material plumbing — so a solid domain that spans
+// two different materials cannot be honoured here. Rather than silently pick one
+// and solve part of the model with the wrong stiffness (issue #376), refuse
+// loudly and name the ambiguity. `solidBodyIds` are the property ids of the
+// solid bodies actually present in the coupled tet mesh (shell body excluded).
 function coupledMaterials(
   materials: Material[],
   properties: Property[],
   shellBody: number,
+  solidBodyIds: number[],
 ) {
-  const matOf = (propId: number) => {
+  const matOf = (propId: number): Material => {
     const prop = properties.find((p) => p.id === propId);
-    const mat = prop && materials.find((mm) => mm.id === prop.materialId);
-    return mat ?? materials[0];
+    if (!prop)
+      throw new Error(
+        `coupledMaterials: no property with id ${propId} in the model`,
+      );
+    const mat = materials.find((mm) => mm.id === prop.materialId);
+    if (!mat)
+      throw new Error(
+        `coupledMaterials: property ${propId} references material ${prop.materialId}, which does not exist`,
+      );
+    return mat;
   };
   const shellMat = matOf(shellBody);
-  const solidProp = properties.find((p) => p.id !== shellBody) ?? properties[0];
-  const solidMat = matOf(solidProp.id);
+  const solidMats = new Map<number, Material>();
+  for (const pid of solidBodyIds) {
+    const mat = matOf(pid);
+    solidMats.set(mat.id, mat);
+  }
+  if (solidMats.size === 0)
+    throw new Error(
+      "coupledMaterials: the coupled solve has no solid body — a shell body must be coupled to at least one solid body",
+    );
+  if (solidMats.size > 1) {
+    const names = [...solidMats.values()].map((mm) => mm.name).join(", ");
+    throw new Error(
+      `coupledMaterials: the coupled solid-shell solve supports only one solid material, but the ` +
+        `solid domain spans ${solidMats.size} distinct materials (${names}). Per-body materials are ` +
+        `not yet plumbed through the coupled shell path — assign a single material to all solid ` +
+        `bodies, or solve this model without the thin-wall shell idealisation.`,
+    );
+  }
+  const solidMat = [...solidMats.values()][0];
   return {
     solid: { young_modulus: solidMat.young, poisson_ratio: solidMat.poisson },
     shell: { young_modulus: shellMat.young, poisson_ratio: shellMat.poisson },
@@ -734,6 +766,13 @@ function tryCoupledSolve(
   const fixed_dofs = coupledFixedDofs(constraints, model, poolOf);
   const { load_dofs, load_vals } = coupledLoads(loads, surfaceLoads, poolOf);
 
+  // Solid bodies actually present in the coupled tet mesh (the shelled body is
+  // excluded — it becomes shell elements). coupledMaterials rejects the case
+  // where these span more than one distinct material (issue #376).
+  const solidBodyIds = [
+    ...new Set(tetElements.map((e) => e.propertyId)),
+  ].filter((pid) => pid !== shells.shellBody);
+
   self.postMessage({
     id: 0,
     log: `[auto-shell] body ${shells.shellBody}: ${shells.walls.length} thin walls → ${model.shellPool.length} shell nodes, ${model.tets.length / 4} solid tets, ${model.coupling.ref.length} couplings`,
@@ -756,7 +795,9 @@ function tryCoupledSolve(
       load_dofs: Int32Array.from(load_dofs),
       load_vals: Float64Array.from(load_vals),
     },
-    JSON.stringify(coupledMaterials(materials, properties, shells.shellBody)),
+    JSON.stringify(
+      coupledMaterials(materials, properties, shells.shellBody, solidBodyIds),
+    ),
   );
   if ("error" in result) throw new Error(result.error);
 

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -561,10 +561,10 @@ function coupledMaterials(
   if (solidMats.size > 1) {
     const names = [...solidMats.values()].map((mm) => mm.name).join(", ");
     throw new Error(
-      `coupledMaterials: the coupled solid-shell solve supports only one solid material, but the ` +
+      "coupledMaterials: the coupled solid-shell solve supports only one solid material, but the " +
         `solid domain spans ${solidMats.size} distinct materials (${names}). Per-body materials are ` +
-        `not yet plumbed through the coupled shell path — assign a single material to all solid ` +
-        `bodies, or solve this model without the thin-wall shell idealisation.`,
+        "not yet plumbed through the coupled shell path — assign a single material to all solid " +
+        "bodies, or solve this model without the thin-wall shell idealisation.",
     );
   }
   const solidMat = [...solidMats.values()][0];


### PR DESCRIPTION
## Summary

This PR hardens boundary condition and load ingestion across the shell and coupled solve paths to reject invalid or ambiguous inputs loudly instead of silently dropping them. It also prevents coupled solid-shell solves from proceeding when the solid domain spans multiple distinct materials, which cannot be honoured by the current C++ assembler.

closes #376 closes #377 closes #378 closes #379

## Key Changes

**Engine (C++)**
- `shell_core.cpp`: Throw when a fixed DOF lands on a coupling-dependent (RBE3 reference) node instead of silently skipping it (issue #377).
- `solve_shell.cpp`: Use `bc_validation.h` helpers to reject out-of-range vertex and DOF-component indices instead of silently dropping constraints/loads (issue #379).
- `bc_validation.h`: Add `require_valid_shell_component()` to validate shell DOF indices (0..5: three translations + three rotations) — wider than the solid path's 0..2 but still bounded.
- `shell_validation.cpp`: Add test case `coupled_fixed_dependent_throws()` to verify that fixed DOFs on coupling reference nodes are rejected (issue #377).
- `bc_validation.cpp`: Add shell DOF-component validation tests (issue #379).

**Web (TypeScript)**
- `solver.worker.ts`: 
  - Refactor `coupledMaterials()` to accept `solidBodyIds` (the property IDs of solid bodies actually in the coupled tet mesh, excluding the shelled body).
  - Throw if the solid domain has zero bodies or spans multiple distinct materials — the coupled assembler has no per-body material plumbing and cannot honour this (issue #376).
  - Improve error messages to name the conflicting materials and suggest remediation.
  - Replace silent fallbacks (`?? materials[0]`) with explicit error throws for missing properties or materials.
- `shellize.ts`: Throw when `shellNodeLocator()` cannot find a shell mid-surface node within the search radius instead of returning an arbitrary seed node (issue #378).

## Notable Implementation Details

- **Multi-material rejection (issue #376):** The coupled solid-shell assembler (`engine/cpp/solve_coupled.cpp → assemble_solid_stiffness_mfem`) takes a single `(E, nu)` pair for the entire solid domain. Rather than silently pick one material and solve part of the model with wrong stiffness, the code now collects all distinct materials spanned by the solid bodies and throws if more than one is found. The error message names the conflicting materials and suggests either assigning a single material to all solid bodies or solving without the shell idealisation.

- **Dependent-node constraint rejection (issue #377):** RBE3 distributing couplings make shell reference nodes dependent — their motion is a weighted average of coupled solid nodes. A fixed DOF on such a node has no reduced-system column and cannot be constrained directly. The old code silently skipped it (via `&& C.dep[i] == 0`), which let CG converge on an under-restrained model. Now it throws with a clear message directing the user to constrain the coupled solid nodes instead.

- **Shell DOF-component validation (issue #379):** Shell nodes carry six DOFs (three translations + three rotations), so the valid component range is 0..5, not 0..2 like the solid path. The new `require_valid_shell_component()` helper validates this and is called by `add_fixed_dofs()` and `add_point_loads()` in `solve_shell.cpp`.

- **Shell node locator robustness (issue #378):** The grid-based spatial search in `shellNodeLocator()` now throws if no candidate is found within the search radius, rather than returning the seed node (which would silently map the constraint/load onto an unrelated node). The error message suggests the query point may lie farther from any thin wall than the search radius, or the model may be mis-scaled.

- **BC validation header reuse:** The `bc_validation.h` header (previously used only by `solve_mfem.cpp` for issue #362) is now also used by `solve_shell.

https://claude.ai/code/session_01UjDtLCTTnL47wQWhmtgNaX