### PR TITLE
Replace silent node lookup fallbacks with explicit errors

### DIFF
--- a/web/src/components/viewport/FemMeshLayer.tsx
+++ b/web/src/components/viewport/FemMeshLayer.tsx
@@ -171,7 +171,7 @@ export function FemMeshLayer({
       if (!entry)
         throw new Error(
           `Boundary face references node id ${id} missing from nodeMap ` +
-            `while building the undeformed surface — mesh/topology desync`,
+            "while building the undeformed surface — mesh/topology desync",
         );
       return entry.n;
     };

--- a/web/src/components/viewport/FemMeshLayer.tsx
+++ b/web/src/components/viewport/FemMeshLayer.tsx
@@ -166,11 +166,21 @@ export function FemMeshLayer({
     const xyz = (n: { x: number; y: number; z: number }) =>
       [n.x, n.y, n.z] as [number, number, number];
 
+    const nodeById = (id: number) => {
+      const entry = nodeMap.get(id);
+      if (!entry)
+        throw new Error(
+          `Boundary face references node id ${id} missing from nodeMap ` +
+            `while building the undeformed surface — mesh/topology desync`,
+        );
+      return entry.n;
+    };
+
     for (const [a, b, c_, dd] of boundaryQuadFaceIds) {
-      const pa = nodeMap.get(a)!.n,
-        pb = nodeMap.get(b)!.n;
-      const pc = nodeMap.get(c_)!.n,
-        pd = nodeMap.get(dd)!.n;
+      const pa = nodeById(a),
+        pb = nodeById(b);
+      const pc = nodeById(c_),
+        pd = nodeById(dd);
       positions.push(
         ...xyz(pa),
         ...xyz(pb),
@@ -185,9 +195,9 @@ export function FemMeshLayer({
       for (let k = 0; k < 6; k++) normals.push(norm.x, norm.y, norm.z);
     }
     for (const [a, b, c_] of boundaryTriFaceIds) {
-      const pa = nodeMap.get(a)!.n,
-        pb = nodeMap.get(b)!.n,
-        pc = nodeMap.get(c_)!.n;
+      const pa = nodeById(a),
+        pb = nodeById(b),
+        pc = nodeById(c_);
       positions.push(...xyz(pa), ...xyz(pb), ...xyz(pc));
       const AB = new THREE.Vector3(pb.x - pa.x, pb.y - pa.y, pb.z - pa.z);
       const AC = new THREE.Vector3(pc.x - pa.x, pc.y - pa.y, pc.z - pa.z);

--- a/web/src/components/viewport/useMeshTopology.ts
+++ b/web/src/components/viewport/useMeshTopology.ts
@@ -223,7 +223,12 @@ export function useMeshTopology(): MeshTopology {
 
     const getPos = (id: number): Vec3 => {
       const n = nodeMap.get(id)?.n;
-      return n ? [n.x, n.y, n.z] : [0, 0, 0];
+      if (!n)
+        throw new Error(
+          `Boundary triangle references node id ${id} missing from nodeMap ` +
+            `while building face-picking topology — mesh/topology desync`,
+        );
+      return [n.x, n.y, n.z];
     };
 
     // Build per-boundary-triangle face IDs by matching sorted vertex triples.

--- a/web/src/components/viewport/useMeshTopology.ts
+++ b/web/src/components/viewport/useMeshTopology.ts
@@ -226,7 +226,7 @@ export function useMeshTopology(): MeshTopology {
       if (!n)
         throw new Error(
           `Boundary triangle references node id ${id} missing from nodeMap ` +
-            `while building face-picking topology — mesh/topology desync`,
+            "while building face-picking topology — mesh/topology desync",
         );
       return [n.x, n.y, n.z];
     };


### PR DESCRIPTION
## Summary

Replace non-fatal fallbacks in node lookups with explicit error throws to catch mesh/topology desynchronization bugs early. When a boundary face or triangle references a node ID that doesn't exist in the node map, the code now raises a clear error instead of silently substituting a default value or using the non-null assertion operator.

closes #369

## Key Changes

**web/src/components/viewport/FemMeshLayer.tsx**
- Extract `nodeById(id)` helper that throws if a node ID is missing from the node map
- Replace all `nodeMap.get(id)!.n` calls with `nodeById(id)` for boundary quad and triangle face processing
- Error message clearly indicates the desync condition and which operation failed

**web/src/components/viewport/useMeshTopology.ts**
- Replace silent fallback `[0, 0, 0]` in `getPos()` with an explicit error throw
- Error message identifies the missing node ID and the face-picking topology build context

## Notable Implementation Details

Both changes follow the same pattern: when a node ID referenced by a boundary element is missing from the node map, this indicates a critical mesh/topology desynchronization that should never happen in normal operation. Rather than masking the problem with defaults or non-null assertions, we now fail fast with a descriptive error message that includes:
- The missing node ID
- The operation context (undeformed surface building vs. face-picking topology)
- The root cause ("mesh/topology desync")

This makes debugging significantly easier if the mesh pipeline ever produces inconsistent data.

## Checklist

- [x] **No silent fallbacks** — replaced `nodeMap.get(id)!.n` non-null assertions and `[0, 0, 0]` default with explicit error throws that clearly describe the desync condition
- [x] Every input accepted by the UI or an API is actually consumed downstream

https://claude.ai/code/session_016Bc57K71M1A1HLTNWkLGqh