### PR TITLE
Add edge picking for shell mesh rims (#386)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "examples:generate": "bun ../examples/web-examples/generate.mjs",
     "examples:generate-crane-shell": "bun ../examples/web-examples/generate-crane-shell.mjs",
     "examples:generate-plate-hole-shell": "bun ../examples/web-examples/generate-plate-hole-shell.mjs",
-    "test": "bun ../examples/validation/run.mjs && bun ../examples/validation/dof-constraint.test.mjs && bun ../examples/validation/prescribed-displacement.test.mjs && bun tests/test_wall_bracket.mjs 20.0 && bun tests/test_multibody.mjs && bun tests/test_tie.mjs && bun tests/test_face_pick.mjs && bun tests/test_moment_load.mjs && playwright test",
+    "test": "bun ../examples/validation/run.mjs && bun ../examples/validation/dof-constraint.test.mjs && bun ../examples/validation/prescribed-displacement.test.mjs && bun tests/test_wall_bracket.mjs 20.0 && bun tests/test_multibody.mjs && bun tests/test_tie.mjs && bun tests/test_face_pick.mjs && bun tests/test_edge_pick.mjs && bun tests/test_moment_load.mjs && playwright test",
     "test:coverage": "rm -rf .nyc_output coverage && COVERAGE=1 playwright test && bun run coverage:report",
     "coverage:report": "nyc report && bun scripts/coverage-dead-code.ts",
     "test:ui": "playwright test --ui",

--- a/web/src/components/panel/BcLoadFormControls.tsx
+++ b/web/src/components/panel/BcLoadFormControls.tsx
@@ -10,16 +10,49 @@ import {
 } from "./bcFormUtils";
 import styles from "./LeftPanel.module.css";
 
+// Face / Edge picker for shell models: a flat shell sheet is one face-pick
+// region, so grabbing its rim (an edge load or supported-edge BC) needs edge
+// picking (#386). Offered only when the model has CTRIA3 elements.
+export function PickGeometryToggle({
+  value,
+  onChange,
+}: {
+  value: "face" | "edge";
+  onChange(geometry: "face" | "edge"): void;
+}) {
+  return (
+    <div className={styles.segToggle} role="group" aria-label="Pick geometry">
+      {(["face", "edge"] as const).map((geometry) => (
+        <button
+          key={geometry}
+          type="button"
+          className={`${styles.segBtn} ${value === geometry ? styles.segBtnActive : ""}`}
+          aria-pressed={value === geometry}
+          onClick={() => onChange(geometry)}
+        >
+          {geometry === "face" ? "Face" : "Edge"}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export function PickedFaceList({
   faces,
   onRemove,
+  geometry = "face",
 }: {
   faces: FaceSelection[];
   onRemove(index: number): void;
+  geometry?: "face" | "edge";
 }) {
   if (faces.length === 0) {
     return (
-      <div className={styles.pickHint}>Click a face in the 3D viewport</div>
+      <div className={styles.pickHint}>
+        {geometry === "edge"
+          ? "Click near a mesh edge in the 3D viewport"
+          : "Click a face in the 3D viewport"}
+      </div>
     );
   }
   return (

--- a/web/src/components/panel/BcSection.tsx
+++ b/web/src/components/panel/BcSection.tsx
@@ -5,7 +5,11 @@ import { useState } from "react";
 import { useModelStore } from "../../store/modelStore";
 import { usePickedFaces } from "../../hooks/usePickedFaces";
 import { DOF_LABELS, toFaceEntries } from "./bcFormUtils";
-import { DofCheckboxes, PickedFaceList } from "./BcLoadFormControls";
+import {
+  DofCheckboxes,
+  PickedFaceList,
+  PickGeometryToggle,
+} from "./BcLoadFormControls";
 import { BcValueForm } from "./GroupValueForms";
 import { GroupCard } from "./GroupCard";
 import styles from "./LeftPanel.module.css";
@@ -15,7 +19,10 @@ import styles from "./LeftPanel.module.css";
 export function BcSection({ onError }: { onError(msg: string | null): void }) {
   const bcGroups = useModelStore((s) => s.bcGroups);
   const pickMode = useModelStore((s) => s.pickMode);
-  // Shell nodes carry rotational DOFs, so shell models expose Rx/Ry/Rz too.
+  const pickGeometry = useModelStore((s) => s.pickGeometry);
+  const setPickGeometry = useModelStore((s) => s.setPickGeometry);
+  // Shell nodes carry rotational DOFs, so shell models expose Rx/Ry/Rz too, and
+  // edge picking (grabbing the rim of the flat sheet) is only offered for them.
   const hasShells = useModelStore((s) =>
     s.elements.some((el) => el.type === "CTRIA3"),
   );
@@ -55,6 +62,7 @@ export function BcSection({ onError }: { onError(msg: string | null): void }) {
     const faceEntries = toFaceEntries(
       allPickedFaces,
       targetBcGroup?.faces.length ?? 0,
+      pickGeometry === "edge" ? "Edge" : "Face",
     );
     if (targetBcGroup) {
       for (const faceEntry of faceEntries) {
@@ -100,7 +108,18 @@ export function BcSection({ onError }: { onError(msg: string | null): void }) {
             </button>
           </div>
 
-          <PickedFaceList faces={allPickedFaces} onRemove={removePickedFace} />
+          {hasShells && (
+            <PickGeometryToggle
+              value={pickGeometry}
+              onChange={setPickGeometry}
+            />
+          )}
+
+          <PickedFaceList
+            faces={allPickedFaces}
+            onRemove={removePickedFace}
+            geometry={pickGeometry}
+          />
 
           {allPickedFaces.length > 0 && !targetBcGroup && (
             <>

--- a/web/src/components/panel/LeftPanel.module.css
+++ b/web/src/components/panel/LeftPanel.module.css
@@ -670,6 +670,46 @@
   gap: 8px;
 }
 
+/* Face / Edge picker — a shell sheet's flat face is one face-pick region, so
+   edge picking is the only way to grab its rim (#386). Offered for shell models. */
+.segToggle {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.segBtn {
+  flex: 1;
+  padding: 5px 0;
+  background: none;
+  border: none;
+  border-left: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    background 100ms,
+    color 100ms;
+}
+
+.segBtn:first-child {
+  border-left: none;
+}
+
+.segBtn:hover:not(.segBtnActive) {
+  background: var(--hover);
+  color: var(--ink);
+}
+
+.segBtnActive {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+
 .pickHint {
   font-size: 12px;
   color: var(--muted);

--- a/web/src/components/panel/LoadSection.tsx
+++ b/web/src/components/panel/LoadSection.tsx
@@ -15,6 +15,7 @@ import {
   LoadKindSelect,
   LoadVectorInputs,
   PickedFaceList,
+  PickGeometryToggle,
   PressureInput,
 } from "./BcLoadFormControls";
 import { LoadValueForm } from "./GroupValueForms";
@@ -31,6 +32,13 @@ export function LoadSection({
 }) {
   const loadGroups = useModelStore((s) => s.loadGroups);
   const pickMode = useModelStore((s) => s.pickMode);
+  const pickGeometry = useModelStore((s) => s.pickGeometry);
+  const setPickGeometry = useModelStore((s) => s.setPickGeometry);
+  // Edge picking (grabbing the rim of the flat sheet for a line load) is only
+  // offered for shell models — a flat shell is a single face-pick region.
+  const hasShells = useModelStore((s) =>
+    s.elements.some((el) => el.type === "CTRIA3"),
+  );
   const createLoadGroup = useModelStore((s) => s.createLoadGroup);
   const addFaceToLoadGroup = useModelStore((s) => s.addFaceToLoadGroup);
   const removeFaceFromLoadGroup = useModelStore(
@@ -75,6 +83,7 @@ export function LoadSection({
     const faceEntries = toFaceEntries(
       allPickedFaces,
       targetLoadGroup?.faces.length ?? 0,
+      pickGeometry === "edge" ? "Edge" : "Face",
     );
     if (targetLoadGroup) {
       for (const faceEntry of faceEntries) {
@@ -133,7 +142,18 @@ export function LoadSection({
             </button>
           </div>
 
-          <PickedFaceList faces={allPickedFaces} onRemove={removePickedFace} />
+          {hasShells && (
+            <PickGeometryToggle
+              value={pickGeometry}
+              onChange={setPickGeometry}
+            />
+          )}
+
+          <PickedFaceList
+            faces={allPickedFaces}
+            onRemove={removePickedFace}
+            geometry={pickGeometry}
+          />
 
           {allPickedFaces.length > 0 && !targetLoadGroup && (
             <>
@@ -153,7 +173,9 @@ export function LoadSection({
                 {loadKindSel === "pressure"
                   ? "applied as p·n̂ over each face (work-equivalent)"
                   : loadKindSel === "force"
-                    ? "applied as a work-equivalent surface traction"
+                    ? pickGeometry === "edge"
+                      ? "applied as a work-equivalent line load along the edge"
+                      : "applied as a work-equivalent surface traction"
                     : "distributed as equivalent nodal forces"}
               </div>
               <button className={styles.loadBtn} onClick={applyLoad}>

--- a/web/src/components/panel/bcFormUtils.ts
+++ b/web/src/components/panel/bcFormUtils.ts
@@ -32,9 +32,13 @@ export function faceKey(face: FaceSelection): string {
   return `${face.nodeIds.length}-${face.nodeIds[0]}-${face.nodeIds[face.nodeIds.length - 1]}`;
 }
 
-export function toFaceEntries(faces: FaceSelection[], existingCount: number) {
+export function toFaceEntries(
+  faces: FaceSelection[],
+  existingCount: number,
+  noun: "Face" | "Edge" = "Face",
+) {
   return faces.map((face, i) => ({
-    label: `Face ${existingCount + i + 1}`,
+    label: `${noun} ${existingCount + i + 1}`,
     nodeIds: face.nodeIds,
   }));
 }

--- a/web/src/components/statusbar/StatusBar.tsx
+++ b/web/src/components/statusbar/StatusBar.tsx
@@ -115,6 +115,7 @@ export function StatusBar() {
   const mode = useModelStore((s) => s.mode);
   const selectedFace = useModelStore((s) => s.selectedFace);
   const pickMode = useModelStore((s) => s.pickMode);
+  const pickGeometry = useModelStore((s) => s.pickGeometry);
   const viewRepr = useModelStore((s) => s.viewRepr);
   const setViewRepr = useModelStore((s) => s.setViewRepr);
   const showUndeformedOverlay = useModelStore((s) => s.showUndeformedOverlay);
@@ -164,9 +165,9 @@ export function StatusBar() {
         {pickMode && (
           <span className={styles.pickChip}>
             <span className={styles.pickDot} />
-            {pickMode === "bc"
-              ? "Pick face — fixed displacement"
-              : "Pick face — apply load"}
+            {`Pick ${pickGeometry} — ${
+              pickMode === "bc" ? "fixed displacement" : "apply load"
+            }`}
           </span>
         )}
 

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -29,8 +29,22 @@ export function MeshScene() {
   const viewRepr = useModelStore((s) => s.viewRepr);
 
   const topology = useMeshTopology();
-  const onFacePick = useFacePick(topology.boundaryMeshTopo);
-  const { modelSize } = topology;
+  const { modelSize, nodeMap } = topology;
+
+  // Node position lookup for edge picking (nearest-edge + polyline directions).
+  const getPos = useMemo(
+    () =>
+      (id: number): [number, number, number] => {
+        const n = nodeMap.get(id)?.n;
+        if (!n)
+          throw new Error(
+            `Pick referenced node id ${id} missing from nodeMap — mesh/topology desync`,
+          );
+        return [n.x, n.y, n.z];
+      },
+    [nodeMap],
+  );
+  const onFacePick = useFacePick(topology.boundaryMeshTopo, getPos);
 
   // Automatic fit-to-view scale (max displacement → TARGET_DEFORM_FRACTION of the
   // model size) multiplied by the user-controlled deformScaleFactor. A factor of

--- a/web/src/components/viewport/useFacePick.ts
+++ b/web/src/components/viewport/useFacePick.ts
@@ -4,21 +4,28 @@
 import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useModelStore } from "../../store/modelStore";
-import { pickFaceNodeIds, toggleFaceSelection } from "../../lib/facePick";
-import type { BoundaryMeshTopo } from "../../lib/facePick";
+import {
+  pickFaceNodeIds,
+  pickEdgeNodeIds,
+  toggleFaceSelection,
+} from "../../lib/facePick";
+import type { BoundaryMeshTopo, Vec3 } from "../../lib/facePick";
 
-// Face picking handler for the pickable boundary surfaces (undeformed solid
-// and deformed result surface). Returns undefined outside pick mode so the
-// meshes carry no onClick at all.
+// Picking handler for the pickable boundary surfaces (undeformed solid and
+// deformed result surface). Returns undefined outside pick mode so the meshes
+// carry no onClick at all.
 //
-// When OCC face IDs are available (STEP mesh via Netgen), uses instant face ID
-// lookup — topologically exact, works on any curved or flat CAD face.
-// Falls back to BFS flood-fill with normal-angle thresholds when no face IDs
-// are present (parametric box mesh or .inp import).
+// Face mode selects a surface region: when OCC face IDs are available (STEP mesh
+// via Netgen) an instant face-ID lookup (topologically exact on any CAD face),
+// otherwise a BFS flood-fill with normal-angle thresholds (parametric box mesh
+// or .inp import). Edge mode selects the boundary polyline near the click — the
+// only way to grab the rim of a flat shell, whose whole sheet is one region.
 export function useFacePick(
   boundaryMeshTopo: BoundaryMeshTopo | null,
+  getPos: (id: number) => Vec3,
 ): ((e: ThreeEvent<MouseEvent>) => void) | undefined {
   const pickMode = useModelStore((s) => s.pickMode);
+  const pickGeometry = useModelStore((s) => s.pickGeometry);
   const selectedFace = useModelStore((s) => s.selectedFace);
   const pendingFaces = useModelStore((s) => s.pendingFaces);
   const setSelectedFace = useModelStore((s) => s.setSelectedFace);
@@ -31,7 +38,18 @@ export function useFacePick(
     const startIdx = e.faceIndex;
     if (startIdx >= boundaryMeshTopo.triangles.length) return;
 
-    const faceNodeIds = [...pickFaceNodeIds(startIdx, boundaryMeshTopo)];
+    const faceNodeIds =
+      pickGeometry === "edge"
+        ? [
+            ...pickEdgeNodeIds(
+              [e.point.x, e.point.y, e.point.z],
+              startIdx,
+              boundaryMeshTopo,
+              getPos,
+            ),
+          ]
+        : [...pickFaceNodeIds(startIdx, boundaryMeshTopo)];
+    if (faceNodeIds.length === 0) return;
     const normal =
       e.face?.normal.clone().normalize() ?? new THREE.Vector3(0, 1, 0);
     const ax = Math.abs(normal.x),
@@ -56,12 +74,16 @@ export function useFacePick(
     const current = selectedFace
       ? [...pendingFaces, selectedFace]
       : pendingFaces;
-    const next = toggleFaceSelection(current, {
-      nodeIds: faceNodeIds,
-      axis,
-      isMax,
-      label: "",
-    });
+    const next = toggleFaceSelection(
+      current,
+      {
+        nodeIds: faceNodeIds,
+        axis,
+        isMax,
+        label: "",
+      },
+      pickGeometry === "edge" ? "Edge" : "Face",
+    );
 
     // Re-split into pending faces + the active (last) selection.
     setPendingFaces(next.slice(0, -1));

--- a/web/src/lib/facePick.ts
+++ b/web/src/lib/facePick.ts
@@ -9,6 +9,12 @@ export const CURVE_ANGLE = (89 * Math.PI) / 180; // curved: stop only at near-pe
 export const COS_FLAT = Math.cos(FLAT_ANGLE);
 export const COS_CURVE = Math.cos(CURVE_ANGLE);
 
+// Edge-pick polyline walk: stop when the turn between consecutive boundary
+// segments exceeds this. Straight runs (turn ≈ 0) traverse up to sharp corners;
+// a smoothly-tessellated hole/fillet loop (small per-segment turns) is walked
+// whole. 50° stops at 90° corners while continuing round circles of ≥8 segments.
+export const EDGE_TURN_LIMIT = (50 * Math.PI) / 180;
+
 export type Vec3 = [number, number, number];
 export type Tri = [number, number, number];
 
@@ -54,16 +60,18 @@ export function sameFaceNodes(a: number[], b: number[]): boolean {
 }
 
 /**
- * Fold a freshly picked face into the current selection.
+ * Fold a freshly picked selection into the current one.
  *
- * Re-selecting a face that is already in the selection removes it instead of
- * adding a duplicate (#264); otherwise the face is appended. Faces are
- * identified by their node-id set (see `sameFaceNodes`). The result is
- * relabeled "Face 1..N" by position so labels stay contiguous after a toggle.
+ * Re-selecting an item that is already in the selection removes it instead of
+ * adding a duplicate (#264); otherwise it is appended. Items are identified by
+ * their node-id set (see `sameFaceNodes`). The result is relabeled
+ * "<noun> 1..N" by position so labels stay contiguous after a toggle. `noun`
+ * is "Face" for region picks and "Edge" for polyline picks.
  */
 export function toggleFaceSelection(
   current: PickedFace[],
   picked: PickedFace,
+  noun: "Face" | "Edge" = "Face",
 ): PickedFace[] {
   const existingIdx = current.findIndex((f) =>
     sameFaceNodes(f.nodeIds, picked.nodeIds),
@@ -74,7 +82,7 @@ export function toggleFaceSelection(
       : [...current, picked];
   return next.map((f, i) => ({
     ...f,
-    label: `Face ${i + 1} (${f.nodeIds.length} nodes)`,
+    label: `${noun} ${i + 1} (${f.nodeIds.length} nodes)`,
   }));
 }
 
@@ -217,5 +225,155 @@ export function pickFaceNodeIds(
     }
   }
 
+  return nodeIds;
+}
+
+// ── Edge picking ──────────────────────────────────────────────────────────────
+//
+// A shell mesh is a 2D sheet, so its whole flat face is one face-pick region —
+// there is no way to grab just its boundary polyline (the pulled edge of a plate,
+// a supported rim) for an edge load or a supported-edge BC. Edge picking fills
+// that gap: it selects the connected boundary polyline near the click.
+
+function edgeKey(a: number, b: number): string {
+  return a < b ? `${a},${b}` : `${b},${a}`;
+}
+
+/**
+ * Boundary edges of a surface mesh: the triangle edges used by exactly one
+ * facet. This is the used-once extraction of `extractBoundaryTriFaceIds` one
+ * dimension down — for a shell sheet it yields the outer rim and any hole rims;
+ * for a closed solid boundary (every edge shared by two facets) it is empty.
+ * Returned as `[min, max]` node-id pairs (matching `edgeToTris` keys).
+ */
+export function extractBoundaryEdges(
+  topo: BoundaryMeshTopo,
+): [number, number][] {
+  const edges: [number, number][] = [];
+  for (const [key, tris] of topo.edgeToTris) {
+    if (tris.length !== 1) continue;
+    const [a, b] = key.split(",").map(Number);
+    edges.push([a, b]);
+  }
+  return edges;
+}
+
+function pointSegmentDistSq(p: Vec3, a: Vec3, b: Vec3): number {
+  const ab: Vec3 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+  const ap: Vec3 = [p[0] - a[0], p[1] - a[1], p[2] - a[2]];
+  const abLenSq = dot(ab, ab);
+  const proj =
+    abLenSq < 1e-30 ? 0 : Math.max(0, Math.min(1, dot(ap, ab) / abLenSq));
+  const perp: Vec3 = [
+    ap[0] - proj * ab[0],
+    ap[1] - proj * ab[1],
+    ap[2] - proj * ab[2],
+  ];
+  return dot(perp, perp);
+}
+
+/**
+ * Pick the connected boundary polyline of a shell mesh near a click.
+ *
+ * The seed is the boundary edge nearest the click point — preferring the edges
+ * of the clicked triangle (`startTriIdx`) so a click on the rim grabs the rim it
+ * is on, falling back to the globally nearest boundary edge when the clicked
+ * triangle is interior. From the seed the walk extends along both directions,
+ * stepping to the next boundary edge whenever the turn between consecutive
+ * segment directions stays within `EDGE_TURN_LIMIT` (see face-pick's analogous
+ * feature-angle walk). It stops at sharp corners and closes round smooth loops.
+ *
+ * Returns the set of node IDs on the picked polyline — the same node-id-set
+ * shape `pickFaceNodeIds` returns, so group creation, storage and the solve
+ * path (the shell edge fallback in `loadedFaces`) need no changes.
+ */
+export function pickEdgeNodeIds(
+  clickPoint: Vec3,
+  startTriIdx: number,
+  topo: BoundaryMeshTopo,
+  getPos: (id: number) => Vec3,
+): Set<number> {
+  const boundaryEdges = extractBoundaryEdges(topo);
+  if (boundaryEdges.length === 0) return new Set();
+
+  const keyToIdx = new Map<string, number>();
+  boundaryEdges.forEach((e, i) => keyToIdx.set(edgeKey(e[0], e[1]), i));
+
+  // Seed candidates: the boundary edges of the clicked triangle, else all edges.
+  const [ta, tb, tc] = topo.triangles[startTriIdx];
+  const triEdges = [
+    keyToIdx.get(edgeKey(ta, tb)),
+    keyToIdx.get(edgeKey(tb, tc)),
+    keyToIdx.get(edgeKey(tc, ta)),
+  ].filter((i): i is number => i !== undefined);
+  const candidates =
+    triEdges.length > 0 ? triEdges : boundaryEdges.map((_, i) => i);
+
+  let seed = candidates[0];
+  let best = Infinity;
+  for (const i of candidates) {
+    const dist = pointSegmentDistSq(
+      clickPoint,
+      getPos(boundaryEdges[i][0]),
+      getPos(boundaryEdges[i][1]),
+    );
+    if (dist < best) {
+      best = dist;
+      seed = i;
+    }
+  }
+
+  const vertexToEdges = new Map<number, number[]>();
+  for (let i = 0; i < boundaryEdges.length; i++) {
+    for (const v of boundaryEdges[i]) {
+      const list = vertexToEdges.get(v);
+      if (list) list.push(i);
+      else vertexToEdges.set(v, [i]);
+    }
+  }
+
+  const other = (edge: number, v: number): number =>
+    boundaryEdges[edge][0] === v
+      ? boundaryEdges[edge][1]
+      : boundaryEdges[edge][0];
+  const dir = (from: number, to: number): Vec3 => {
+    const pa = getPos(from),
+      pb = getPos(to);
+    return normalize([pb[0] - pa[0], pb[1] - pa[1], pb[2] - pa[2]]);
+  };
+
+  const selected = new Set<number>([seed]);
+  for (const startVertex of boundaryEdges[seed]) {
+    let currentEdge = seed;
+    let tip = startVertex; // growing end of the polyline
+    let travelDir = dir(other(currentEdge, tip), tip);
+    for (;;) {
+      let nextEdge = -1;
+      let bestTurn = EDGE_TURN_LIMIT;
+      for (const e of vertexToEdges.get(tip) ?? []) {
+        if (e === currentEdge || selected.has(e)) continue;
+        const nextDir = dir(tip, other(e, tip));
+        const turn = Math.acos(
+          Math.max(-1, Math.min(1, dot(travelDir, nextDir))),
+        );
+        if (turn < bestTurn) {
+          bestTurn = turn;
+          nextEdge = e;
+        }
+      }
+      if (nextEdge < 0) break;
+      selected.add(nextEdge);
+      const nextTip = other(nextEdge, tip);
+      travelDir = dir(tip, nextTip);
+      currentEdge = nextEdge;
+      tip = nextTip;
+    }
+  }
+
+  const nodeIds = new Set<number>();
+  for (const e of selected) {
+    nodeIds.add(boundaryEdges[e][0]);
+    nodeIds.add(boundaryEdges[e][1]);
+  }
   return nodeIds;
 }

--- a/web/src/store/boundarySlice.ts
+++ b/web/src/store/boundarySlice.ts
@@ -281,11 +281,16 @@ export interface BoundarySlice {
 
   pickMode: "bc" | "load" | null;
   pickTargetGroupId: number | null; // null = creating new group; id = adding to existing
+  // Whether a click selects a surface region ("face") or a boundary polyline
+  // ("edge"). Edge picking is the only way to grab the rim of a flat shell,
+  // whose whole sheet is a single face-pick region. Reset to "face" on exit.
+  pickGeometry: "face" | "edge";
   selectedFace: FaceSelection | null;
   pendingFaces: FaceSelection[]; // faces accumulated via shift-click within a pick session
 
   // Pick mode / face selection
   setPickMode(mode: "bc" | "load" | null, targetGroupId?: number | null): void;
+  setPickGeometry(geometry: "face" | "edge"): void;
   setSelectedFace(face: FaceSelection | null): void;
   setPendingFaces(faces: FaceSelection[]): void;
 
@@ -332,6 +337,7 @@ export const createBoundarySlice: SliceCreator<BoundarySlice> = (set) => ({
   nextFaceEntryId: 1,
   pickMode: null,
   pickTargetGroupId: null,
+  pickGeometry: "face",
   selectedFace: null,
   pendingFaces: [],
 
@@ -346,7 +352,13 @@ export const createBoundarySlice: SliceCreator<BoundarySlice> = (set) => ({
       if (mode === null) {
         s.selectedFace = null;
         s.pendingFaces = [];
+        s.pickGeometry = "face";
       }
+    }),
+
+  setPickGeometry: (geometry: "face" | "edge") =>
+    set((s) => {
+      s.pickGeometry = geometry;
     }),
 
   setSelectedFace: (face: FaceSelection | null) =>

--- a/web/tests/edge-pick.spec.ts
+++ b/web/tests/edge-pick.spec.ts
@@ -92,8 +92,8 @@ test("edge picking a shell rim creates an edge BC and an edge load", async ({
 
   await page.goto("/app/?example=plate-with-hole-shell");
   await expect(page.locator("nav")).toBeVisible();
-  await page.waitForFunction(
-    () => !!(window as unknown as { __kofem?: unknown }).__kofem,
+  await page.waitForFunction(() =>
+    Boolean((window as unknown as { __kofem?: unknown }).__kofem),
   );
   await expect
     .poll(async () => (await readPickState(page)).nodeCount, {
@@ -119,11 +119,12 @@ test("edge picking a shell rim creates an edge BC and an edge load", async ({
 
   const afterBcPick = await readPickState(page);
   expect(afterBcPick.pickGeometry).toBe("edge");
-  expect(afterBcPick.selected).not.toBeNull();
-  expect(afterBcPick.selected!.label.startsWith("Edge")).toBe(true);
+  const bcSelection = afterBcPick.selected;
+  if (!bcSelection) throw new Error("edge pick did not set a selection");
+  expect(bcSelection.label.startsWith("Edge")).toBe(true);
   // A rim is a small polyline — never the whole flat plate (the motivating bug).
-  expect(afterBcPick.selected!.nodeIds.length).toBeGreaterThan(2);
-  expect(afterBcPick.selected!.nodeIds.length).toBeLessThan(totalNodes * 0.5);
+  expect(bcSelection.nodeIds.length).toBeGreaterThan(2);
+  expect(bcSelection.nodeIds.length).toBeLessThan(totalNodes * 0.5);
 
   await page.getByRole("button", { name: "Apply BC" }).click();
   const afterBc = await readPickState(page);

--- a/web/tests/edge-pick.spec.ts
+++ b/web/tests/edge-pick.spec.ts
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from "./coverage";
+import type { Page } from "@playwright/test";
+
+// End-to-end coverage for edge picking (#386): a flat shell sheet is one
+// face-pick region, so grabbing its rim (an edge load or a supported-edge BC)
+// needs the edge-pick mode. This drives the real UI on the shipped
+// plate-with-hole shell example — the Face/Edge toggle, a real viewport click
+// that routes through useFacePick → pickEdgeNodeIds → extractBoundaryEdges, and
+// applying the resulting edge selection as both a BC and a load.
+
+type PickState = {
+  selectedFace: { nodeIds: number[]; label: string } | null;
+  pickGeometry: "face" | "edge";
+  bcGroups: { name: string; faces: { label: string; nodeIds: number[] }[] }[];
+  loadGroups: { name: string; faces: { label: string }[] }[];
+  nodes: unknown[];
+};
+
+function readPickState(page: Page) {
+  return page.evaluate(() => {
+    const state = (
+      window as unknown as { __kofemStore: { getState(): PickState } }
+    ).__kofemStore.getState();
+    return {
+      selected: state.selectedFace
+        ? {
+            nodeIds: state.selectedFace.nodeIds,
+            label: state.selectedFace.label,
+          }
+        : null,
+      pickGeometry: state.pickGeometry,
+      bcGroups: state.bcGroups.map((g) => ({
+        name: g.name,
+        faces: g.faces.map((f) => ({
+          label: f.label,
+          count: f.nodeIds.length,
+        })),
+      })),
+      loadGroups: state.loadGroups.map((g) => ({
+        name: g.name,
+        faces: g.faces.map((f) => ({ label: f.label })),
+      })),
+      nodeCount: state.nodes.length,
+    };
+  });
+}
+
+// Click across the viewport until a boundary polyline is picked. Any hit on the
+// flat plate resolves to the boundary edge nearest the hit point, so a handful
+// of spread-out spots reliably lands one without depending on camera framing.
+async function edgePickOnViewport(page: Page): Promise<void> {
+  const canvas = page.locator("canvas").first();
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("viewport canvas has no bounding box");
+  const spots: [number, number][] = [
+    [0.3, 0.5],
+    [0.7, 0.5],
+    [0.5, 0.3],
+    [0.5, 0.7],
+    [0.35, 0.4],
+    [0.65, 0.6],
+  ];
+  for (const [fx, fy] of spots) {
+    await page.mouse.click(box.x + box.width * fx, box.y + box.height * fy);
+    const picked = await page
+      .evaluate(
+        () =>
+          ((
+            window as unknown as {
+              __kofemStore: {
+                getState(): { selectedFace: { nodeIds: number[] } | null };
+              };
+            }
+          ).__kofemStore.getState().selectedFace?.nodeIds.length ?? 0) > 0,
+      )
+      .catch(() => false);
+    if (picked) return;
+    await page.waitForTimeout(150);
+  }
+  throw new Error(
+    "no boundary edge was picked after trying every viewport spot",
+  );
+}
+
+test("edge picking a shell rim creates an edge BC and an edge load", async ({
+  page,
+}) => {
+  test.setTimeout(90_000);
+
+  await page.goto("/app/?example=plate-with-hole-shell");
+  await expect(page.locator("nav")).toBeVisible();
+  await page.waitForFunction(
+    () => !!(window as unknown as { __kofem?: unknown }).__kofem,
+  );
+  await expect
+    .poll(async () => (await readPickState(page)).nodeCount, {
+      timeout: 15_000,
+    })
+    .toBeGreaterThan(0);
+  const totalNodes = (await readPickState(page)).nodeCount;
+
+  // The example opens in Results; move to Constraints where the BC/Load pickers
+  // live (the nav tab drives setMode).
+  await page.getByRole("button", { name: "Constraints" }).click();
+
+  // ── Edge BC ──────────────────────────────────────────────────────────────
+  await page.getByRole("button", { name: "Add BC" }).click();
+
+  // The Face/Edge toggle is offered because the model has shell elements.
+  const edgeToggle = page.getByRole("button", { name: "Edge", exact: true });
+  await expect(edgeToggle).toBeVisible();
+  await edgeToggle.click();
+  await expect(page.getByText("Pick edge — fixed displacement")).toBeVisible();
+
+  await edgePickOnViewport(page);
+
+  const afterBcPick = await readPickState(page);
+  expect(afterBcPick.pickGeometry).toBe("edge");
+  expect(afterBcPick.selected).not.toBeNull();
+  expect(afterBcPick.selected!.label.startsWith("Edge")).toBe(true);
+  // A rim is a small polyline — never the whole flat plate (the motivating bug).
+  expect(afterBcPick.selected!.nodeIds.length).toBeGreaterThan(2);
+  expect(afterBcPick.selected!.nodeIds.length).toBeLessThan(totalNodes * 0.5);
+
+  await page.getByRole("button", { name: "Apply BC" }).click();
+  const afterBc = await readPickState(page);
+  expect(afterBc.bcGroups.length).toBeGreaterThan(0);
+  const bcFace = afterBc.bcGroups[afterBc.bcGroups.length - 1].faces[0];
+  expect(bcFace.label.startsWith("Edge")).toBe(true);
+  expect(bcFace.count).toBeGreaterThan(2);
+
+  // ── Edge load ────────────────────────────────────────────────────────────
+  await page.getByRole("button", { name: "Add Load" }).click();
+  await page.getByRole("button", { name: "Edge", exact: true }).click();
+
+  await edgePickOnViewport(page);
+
+  // A force on an edge is applied as a work-equivalent line load.
+  await expect(page.getByText(/line load along the edge/)).toBeVisible();
+
+  await page.getByRole("button", { name: "Apply Load" }).click();
+  const afterLoad = await readPickState(page);
+  expect(afterLoad.loadGroups.length).toBeGreaterThan(0);
+  const loadFace =
+    afterLoad.loadGroups[afterLoad.loadGroups.length - 1].faces[0];
+  expect(loadFace.label.startsWith("Edge")).toBe(true);
+});

--- a/web/tests/test_edge_pick.mjs
+++ b/web/tests/test_edge_pick.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env bun
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Unit test for the edge-picking algorithm (#386).
+//
+// A flat shell sheet is one face-pick region, so grabbing its rim needs edge
+// picking. These tests verify:
+//   - boundary edges are the mesh edges used by exactly one facet
+//   - clicking near a straight rim selects that whole side and stops at corners
+//   - clicking an interior triangle falls back to the nearest rim edge
+//   - clicking a smoothly-tessellated closed loop selects the whole loop
+//
+// Run: bun tests/test_edge_pick.mjs   (from the web/ directory)
+
+import {
+  buildBoundaryMeshTopo,
+  extractBoundaryEdges,
+  pickEdgeNodeIds,
+  pickFaceNodeIds,
+} from "../src/lib/facePick.ts";
+import {
+  plateWithHoleShellMesh,
+  nodesWhere,
+} from "../../examples/validation/lib/mesh.mjs";
+
+// ── Test runner ───────────────────────────────────────────────────────────────
+
+let passed = 0,
+  failed = 0;
+
+function assert(label, condition) {
+  if (condition) {
+    console.log(`  ✓ ${label}`);
+    passed++;
+  } else {
+    console.error(`  ✗ FAIL: ${label}`);
+    failed++;
+  }
+}
+
+function setsEqual(a, b) {
+  if (a.size !== b.size) return false;
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}
+
+// ── Grid-plate mesh ─────────────────────────────────────────────────────────
+//
+// NX×NY quad grid split into two triangles per cell, lying flat in z = 0.
+// Node id = j*(NX+1) + i at position (i, j, 0). The boundary is the outer
+// rectangle: bottom (j=0), top (j=NY), left (i=0), right (i=NX).
+
+const NX = 4;
+const NY = 3;
+const nid = (i, j) => j * (NX + 1) + i;
+
+const gridPos = [];
+for (let j = 0; j <= NY; j++) {
+  for (let i = 0; i <= NX; i++) gridPos[nid(i, j)] = [i, j, 0];
+}
+
+// Triangle order: cells in (j outer, i inner), triangle A then B per cell.
+// triIdx(cell A) = 2*(j*NX + i), triIdx(cell B) = 2*(j*NX + i) + 1.
+const gridTris = [];
+for (let j = 0; j < NY; j++) {
+  for (let i = 0; i < NX; i++) {
+    const v00 = nid(i, j),
+      v10 = nid(i + 1, j),
+      v01 = nid(i, j + 1),
+      v11 = nid(i + 1, j + 1);
+    gridTris.push([v00, v10, v11]); // A
+    gridTris.push([v00, v11, v01]); // B
+  }
+}
+const triA = (i, j) => 2 * (j * NX + i);
+const gridGetPos = (id) => gridPos[id];
+const gridTopo = buildBoundaryMeshTopo(gridTris, gridGetPos);
+
+// ── Test 1: boundary-edge extraction (used-once) ─────────────────────────────
+
+console.log("\nTest 1: boundary edges = edges used by exactly one facet");
+
+const gridBoundary = extractBoundaryEdges(gridTopo);
+// Rectangle perimeter: NX bottom + NX top + NY left + NY right segments.
+assert(
+  "boundary-edge count matches the rectangle perimeter",
+  gridBoundary.length === 2 * NX + 2 * NY,
+);
+const gridBoundaryNodes = new Set(gridBoundary.flat());
+// Interior nodes (not on any rim) must not appear in any boundary edge.
+assert(
+  "interior node is not on any boundary edge",
+  !gridBoundaryNodes.has(nid(2, 1)),
+);
+
+// ── Test 2: straight rim pick stops at corners ───────────────────────────────
+
+console.log("\nTest 2: clicking a straight rim selects that side only");
+
+// Click the midpoint of the bottom edge of cell (2,0) — triangle A.
+const bottomExpected = new Set([
+  nid(0, 0),
+  nid(1, 0),
+  nid(2, 0),
+  nid(3, 0),
+  nid(4, 0),
+]);
+const bottomPick = pickEdgeNodeIds(
+  [2.5, 0, 0],
+  triA(2, 0),
+  gridTopo,
+  gridGetPos,
+);
+assert(
+  "bottom rim: exactly the bottom row selected",
+  setsEqual(bottomPick, bottomExpected),
+);
+assert(
+  "bottom rim: does not turn up a side (no left/right-only node)",
+  !bottomPick.has(nid(0, 1)) && !bottomPick.has(nid(4, 1)),
+);
+
+// Click the left edge (cell (0,1) triangle B carries the left rim segment).
+const leftExpected = new Set([nid(0, 0), nid(0, 1), nid(0, 2), nid(0, 3)]);
+const leftPick = pickEdgeNodeIds(
+  [0, 1.5, 0],
+  triA(0, 1) + 1, // triangle B of cell (0,1)
+  gridTopo,
+  gridGetPos,
+);
+assert(
+  "left rim: exactly the left column selected",
+  setsEqual(leftPick, leftExpected),
+);
+
+// ── Test 3: interior click falls back to the nearest rim ─────────────────────
+
+console.log("\nTest 3: interior-triangle click falls back to nearest rim edge");
+
+// Cell (2,1) is fully interior (no boundary edge); a click near the bottom rim
+// should still grab the bottom row via the global nearest-edge fallback.
+const fallbackPick = pickEdgeNodeIds(
+  [2.5, 0, 0],
+  triA(2, 1),
+  gridTopo,
+  gridGetPos,
+);
+assert(
+  "interior click near bottom selects the bottom row",
+  setsEqual(fallbackPick, bottomExpected),
+);
+
+// ── Fan mesh (closed smooth loop) ────────────────────────────────────────────
+//
+// A center node fanned out to N rim nodes on a circle. Every rim edge is used
+// by one triangle (boundary); every spoke is shared by two (interior). The rim
+// is a regular N-gon whose per-vertex turn (360/N) is below EDGE_TURN_LIMIT for
+// N = 16, so one click should walk the whole loop.
+
+console.log("\nTest 4: smooth closed loop selects the whole rim");
+
+const SEGS = 16;
+const RADIUS = 10;
+const fanPos = [[0, 0, 0]];
+for (let i = 0; i < SEGS; i++) {
+  const theta = (2 * Math.PI * i) / SEGS;
+  fanPos.push([RADIUS * Math.cos(theta), RADIUS * Math.sin(theta), 0]);
+}
+const fanTris = [];
+for (let i = 0; i < SEGS; i++) {
+  fanTris.push([0, 1 + i, 1 + ((i + 1) % SEGS)]);
+}
+const fanGetPos = (id) => fanPos[id];
+const fanTopo = buildBoundaryMeshTopo(fanTris, fanGetPos);
+
+const fanBoundary = extractBoundaryEdges(fanTopo);
+assert(
+  "fan: boundary edge count equals rim segment count",
+  fanBoundary.length === SEGS,
+);
+
+const rimExpected = new Set();
+for (let i = 1; i <= SEGS; i++) rimExpected.add(i);
+// Click the rim segment carried by triangle 0 ([0, 1, 2]) — midpoint of nodes 1,2.
+const mid = [
+  (fanPos[1][0] + fanPos[2][0]) / 2,
+  (fanPos[1][1] + fanPos[2][1]) / 2,
+  0,
+];
+const rimPick = pickEdgeNodeIds(mid, 0, fanTopo, fanGetPos);
+assert("fan: all rim nodes selected", setsEqual(rimPick, rimExpected));
+assert("fan: center node not selected", !rimPick.has(0));
+
+// ── Test 5: closed solid boundary has no pickable edges ──────────────────────
+
+console.log("\nTest 5: closed manifold surface yields no boundary edges");
+
+// A tetrahedron's surface is closed — every edge is shared by two facets.
+const tetPos = [
+  [0, 0, 0],
+  [1, 0, 0],
+  [0, 1, 0],
+  [0, 0, 1],
+];
+const tetTris = [
+  [0, 1, 2],
+  [0, 1, 3],
+  [0, 2, 3],
+  [1, 2, 3],
+];
+const tetTopo = buildBoundaryMeshTopo(tetTris, (id) => tetPos[id]);
+assert(
+  "closed surface: no boundary edges",
+  extractBoundaryEdges(tetTopo).length === 0,
+);
+assert(
+  "closed surface: edge pick returns empty",
+  pickEdgeNodeIds([0.5, 0.5, 0], 0, tetTopo, (id) => tetPos[id]).size === 0,
+);
+
+// ── Test 6: the real plate-with-hole shell mesh (#386 target case) ───────────
+//
+// The exact mesh the plate-with-hole-shell gallery card ships (same generator
+// call as generate-plate-hole-shell.mjs): an annulus from the hole rim out to a
+// square outer boundary. It reproduces the motivating problem — a flat shell is
+// one face-pick region — and proves edge picking grabs the rim the saved
+// analysis loads (the pulled right edge) instead of the whole plate.
+
+console.log("\nTest 6: real plate-with-hole shell mesh");
+
+const HOLE_R = 1000;
+const HALF_W = 10000;
+const NTH = 64;
+const shell = plateWithHoleShellMesh(HOLE_R, HALF_W, 12, NTH, 2);
+const shellGetPos = (id) => shell.vertices[id];
+const shellTopo = buildBoundaryMeshTopo(shell.triangles, shellGetPos);
+const shellBoundary = extractBoundaryEdges(shellTopo);
+
+// Boundary = inner hole rim + outer square, NTH segments each.
+assert(
+  "shell: boundary loops are the hole rim + outer square",
+  shellBoundary.length === 2 * NTH,
+);
+
+// Face picking a flat plate flood-fills the whole sheet — the exact problem
+// edge picking exists to work around.
+const wholePlate = pickFaceNodeIds(0, shellTopo);
+assert(
+  "shell: face pick selects the whole flat plate",
+  wholePlate.size === shell.vertices.length,
+);
+
+const midOf = (edge) => [
+  (shellGetPos(edge[0])[0] + shellGetPos(edge[1])[0]) / 2,
+  (shellGetPos(edge[0])[1] + shellGetPos(edge[1])[1]) / 2,
+  0,
+];
+const ownerTri = (edge) =>
+  shellTopo.edgeToTris.get(
+    edge[0] < edge[1] ? `${edge[0]},${edge[1]}` : `${edge[1]},${edge[0]}`,
+  )[0];
+
+// Click the outer right edge near y = 0 — the pulled edge of the saved analysis.
+const rightEdges = shellBoundary.filter(
+  (e) =>
+    shellGetPos(e[0])[0] >= HALF_W - 1e-6 &&
+    shellGetPos(e[1])[0] >= HALF_W - 1e-6,
+);
+const rightSeed = rightEdges.reduce((best, e) =>
+  Math.abs(midOf(e)[1]) < Math.abs(midOf(best)[1]) ? e : best,
+);
+const rightPick = pickEdgeNodeIds(
+  midOf(rightSeed),
+  ownerTri(rightSeed),
+  shellTopo,
+  shellGetPos,
+);
+// The generator defines the pulled edge as exactly the nodes at x = +b.
+const pulledEdge = new Set(
+  nodesWhere(shell.vertices, (x) => x >= HALF_W - 1e-6),
+);
+assert(
+  "shell: edge pick reproduces the generator's pulled right edge",
+  setsEqual(rightPick, pulledEdge),
+);
+assert(
+  "shell: the pulled edge is a small fraction of the plate",
+  rightPick.size > 2 && rightPick.size < shell.vertices.length * 0.1,
+);
+
+// Click a hole-rim segment — the smooth loop is walked whole.
+const rimEdges = shellBoundary.filter((e) => {
+  const r0 = Math.hypot(shellGetPos(e[0])[0], shellGetPos(e[0])[1]);
+  const r1 = Math.hypot(shellGetPos(e[1])[0], shellGetPos(e[1])[1]);
+  return Math.abs(r0 - HOLE_R) < 1e-6 && Math.abs(r1 - HOLE_R) < 1e-6;
+});
+const holeRimPick = pickEdgeNodeIds(
+  midOf(rimEdges[0]),
+  ownerTri(rimEdges[0]),
+  shellTopo,
+  shellGetPos,
+);
+const holeRim = new Set(
+  nodesWhere(
+    shell.vertices,
+    (x, y) => Math.abs(Math.hypot(x, y) - HOLE_R) < 1e-6,
+  ),
+);
+assert(
+  "shell: edge pick walks the whole hole rim",
+  setsEqual(holeRimPick, holeRim),
+);
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Implements edge picking for shell meshes, enabling users to select boundary polylines (rims, holes, fillets) instead of entire flat sheets. A flat shell is a single face-pick region, so edge picking is the only way to grab its rim for edge loads or supported-edge boundary conditions.

closes #386

## Key Changes

**Core edge-picking algorithm** (`web/src/lib/facePick.ts`):
- `extractBoundaryEdges()`: Identifies mesh edges used by exactly one facet (the boundary of a surface)
- `pickEdgeNodeIds()`: Selects a connected boundary polyline by walking from a seed edge, stopping at sharp corners (>50°) but continuing through smooth curves (e.g., tessellated circles)
- `EDGE_TURN_LIMIT` constant: 50° threshold for polyline walk continuation, tuned to stop at 90° corners while traversing smooth loops of ≥8 segments

**UI integration** (`web/src/components/panel/`):
- `PickGeometryToggle`: New Face/Edge toggle button, shown only for shell models (CTRIA3 elements)
- Updated `PickedFaceList` and `toFaceEntries()` to label picks as "Edge" or "Face" depending on mode
- Integrated toggle into `LoadSection` and `BcSection` panels

**Viewport picking** (`web/src/components/viewport/`):
- `useFacePick()` now accepts `getPos` callback for node position lookup (required for edge-picking distance calculations)
- Routes clicks to `pickEdgeNodeIds()` when `pickGeometry === "edge"`
- `MeshScene` provides node position lookup via `nodeMap`

**State management** (`web/src/store/boundarySlice.ts`):
- Added `pickGeometry: "face" | "edge"` state with `setPickGeometry()` action
- Resets to "face" on pick-mode exit

**Comprehensive test suite** (`web/tests/test_edge_pick.mjs`):
- 6 test groups covering boundary extraction, straight rim selection, interior fallback, smooth closed loops, closed manifolds, and the real plate-with-hole shell mesh
- Validates that edge picking reproduces the generator's pulled edge and walks hole rims correctly

## Notable Implementation Details

- **Boundary edge definition**: An edge is on the boundary iff it appears in exactly one triangle's edge list. This works for any topology: open sheets (outer rim), annuli (hole + outer), closed solids (empty set).
- **Polyline walk**: Bidirectional walk from the seed edge, extending along both directions independently. Stops when the turn angle between consecutive segment directions exceeds `EDGE_TURN_LIMIT`, allowing sharp corners to act as natural stops while smooth tessellations (e.g., 16-segment circles) are traversed whole.
- **Fallback to global nearest edge**: If the clicked triangle has no boundary edges (interior), the walk seeds from the globally nearest boundary edge. This handles clicks on interior triangles of a flat sheet.
- **Node position lookup**: Edge picking requires computing distances and directions, so `useFacePick` now takes a `getPos` callback. This is provided by `MeshScene` via the existing `nodeMap`.
- **Label consistency**: Both face and edge picks use the same `PickedFace` structure and selection toggle logic; only the label noun changes ("Face" vs. "Edge").

## Checklist

- [x] **No silent fallbacks** — `pickEdgeNodeIds` returns an empty set (not a fallback region) if no boundary edges exist; `getPos` throws a clear error if a node is missing from `nodeMap`
- [x] Every input accepted by the UI (Face/Edge toggle, click point, triangle index) is consumed downstream in the picking algorithm

https://claude.ai/code/session_01NzLUCEJ3wRGep92fj1VPgb