### PR TITLE
Expose auto-shell detection settings to single-body parts

### DIFF
--- a/web/src/components/panel/GeometryPanel.tsx
+++ b/web/src/components/panel/GeometryPanel.tsx
@@ -7,7 +7,7 @@ import type { Material } from "../../store/modelStore";
 import { pickMaterialColor } from "../../store/materialSlice";
 import { fmt } from "../../lib/modelDisplay";
 import { useGeometry } from "../../hooks/useGeometry";
-import { detectShellBodies, DEFAULT_THIN_RATIO } from "../../lib/thinBodies";
+import { detectShellBodies } from "../../lib/thinBodies";
 import { MeshPanel } from "./MeshPanel";
 import styles from "./LeftPanel.module.css";
 
@@ -220,6 +220,7 @@ function MaterialSection() {
       {materials.length === 1 && properties.length <= 1 && (
         <div className={styles.empty}>Applied to the whole part.</div>
       )}
+      <AutoShellSection />
       <BodiesSection />
     </>
   );
@@ -272,7 +273,7 @@ const AUTO_SHELL_TIP =
   "inward from each body's surface and compares the wall thickness it finds " +
   "against the body's own size; a body whose median wall is thinner than the " +
   "ratio below is idealised as shells. Switch it off to keep every body Solid, " +
-  "or set each body's type by hand below.";
+  "or set each body's type by hand in the Bodies list below.";
 
 const AUTO_SHELL_RATIO_TIP =
   "Wall-thickness threshold, as a fraction of the body's own bounding-box " +
@@ -286,22 +287,18 @@ const ELEMENT_TYPE_TIP =
   "walls as Kirchhoff shells coupled to the solid bodies — far more robust for " +
   "thin parts. Thin-walled bodies are preselected Shell automatically.";
 
-function BodiesSection() {
-  const materials = useModelStore((s) => s.materials);
-  const properties = useModelStore((s) => s.properties);
-  const assignBodyMaterial = useModelStore((s) => s.assignBodyMaterial);
-  const setBodyDiscretization = useModelStore((s) => s.setBodyDiscretization);
-  const setHighlightBodyId = useModelStore((s) => s.setHighlightBodyId);
-  const hiddenBodyIds = useModelStore((s) => s.hiddenBodyIds);
-  const toggleBodyVisibility = useModelStore((s) => s.toggleBodyVisibility);
-  const tieDistance = useModelStore((s) => s.tieDistance);
-  const setTieDistance = useModelStore((s) => s.setTieDistance);
-  const viewRepr = useModelStore((s) => s.viewRepr);
-  const setViewRepr = useModelStore((s) => s.setViewRepr);
+// Automatic shell idealisation: the on/off switch for thin-wall detection and,
+// while it is on, the ratio that decides how thin a wall must be. Shown for
+// every imported model — including single-body parts, where it is the only way
+// to choose between a shell and a solid idealisation (the per-body Element type
+// dropdown below appears for assemblies only).
+function AutoShellSection() {
   const stepSurface = useModelStore((s) => s.stepSurface);
   const applyShellDetection = useModelStore((s) => s.applyShellDetection);
-  const [autoShell, setAutoShell] = useState(true);
-  const [thinRatio, setThinRatio] = useState(DEFAULT_THIN_RATIO);
+  const autoShell = useModelStore((s) => s.autoShell);
+  const setAutoShell = useModelStore((s) => s.setAutoShell);
+  const thinRatio = useModelStore((s) => s.thinRatio);
+  const setThinRatio = useModelStore((s) => s.setThinRatio);
 
   // Re-run thin-wall detection over the imported tessellation and re-apply the
   // Shell/Solid choice. Detection is pure geometry (no mesh needed), so changing
@@ -330,25 +327,12 @@ function BodiesSection() {
     );
   };
 
-  if (properties.length <= 1) return null;
-
-  const matColor = (materialId: number) =>
-    materials.find((mat) => mat.id === materialId)?.color ?? "#7a9bbf";
-
-  // Highlighting a body dims the others in the geometry (coloured-tessellation)
-  // view; the FEM mesh views are a single neutral colour and can't show it. So
-  // when the user reaches for a body, switch to the geometry view where the
-  // highlight is visible. (The FEM surface is suppressed there, so no overlap.)
-  const highlight = (id: number) => {
-    setHighlightBodyId(id);
-    if (viewRepr !== "geometry" && viewRepr !== "wireframe")
-      setViewRepr("geometry");
-  };
+  if (!stepSurface) return null;
 
   return (
     <>
-      <div className={styles.sectionLabel} title={BODIES_TIP}>
-        Bodies
+      <div className={styles.sectionLabel} title={AUTO_SHELL_TIP}>
+        Shell idealisation
       </div>
       <label className={styles.formRow} title={AUTO_SHELL_TIP}>
         <input
@@ -382,6 +366,43 @@ function BodiesSection() {
           />
         </div>
       )}
+    </>
+  );
+}
+
+function BodiesSection() {
+  const materials = useModelStore((s) => s.materials);
+  const properties = useModelStore((s) => s.properties);
+  const assignBodyMaterial = useModelStore((s) => s.assignBodyMaterial);
+  const setBodyDiscretization = useModelStore((s) => s.setBodyDiscretization);
+  const setHighlightBodyId = useModelStore((s) => s.setHighlightBodyId);
+  const hiddenBodyIds = useModelStore((s) => s.hiddenBodyIds);
+  const toggleBodyVisibility = useModelStore((s) => s.toggleBodyVisibility);
+  const tieDistance = useModelStore((s) => s.tieDistance);
+  const setTieDistance = useModelStore((s) => s.setTieDistance);
+  const viewRepr = useModelStore((s) => s.viewRepr);
+  const setViewRepr = useModelStore((s) => s.setViewRepr);
+
+  if (properties.length <= 1) return null;
+
+  const matColor = (materialId: number) =>
+    materials.find((mat) => mat.id === materialId)?.color ?? "#7a9bbf";
+
+  // Highlighting a body dims the others in the geometry (coloured-tessellation)
+  // view; the FEM mesh views are a single neutral colour and can't show it. So
+  // when the user reaches for a body, switch to the geometry view where the
+  // highlight is visible. (The FEM surface is suppressed there, so no overlap.)
+  const highlight = (id: number) => {
+    setHighlightBodyId(id);
+    if (viewRepr !== "geometry" && viewRepr !== "wireframe")
+      setViewRepr("geometry");
+  };
+
+  return (
+    <>
+      <div className={styles.sectionLabel} title={BODIES_TIP}>
+        Bodies
+      </div>
       {properties.map((prop) => {
         const hidden = hiddenBodyIds.includes(prop.id);
         return (

--- a/web/src/hooks/useGeometry.ts
+++ b/web/src/hooks/useGeometry.ts
@@ -17,6 +17,8 @@ export function useGeometry() {
   const setStepBytes = useModelStore((s) => s.setStepBytes);
   const setGeometryFormat = useModelStore((s) => s.setGeometryFormat);
   const setBodies = useModelStore((s) => s.setBodies);
+  const autoShell = useModelStore((s) => s.autoShell);
+  const thinRatio = useModelStore((s) => s.thinRatio);
 
   const [isImporting, setIsImporting] = useState(false);
 
@@ -30,13 +32,16 @@ export function useGeometry() {
     setIsImporting(true);
     setRunning(true);
     const bytes = new Uint8Array(await file.arrayBuffer());
+    // The worker preselects thin-walled bodies as shells at the user's current
+    // threshold (thinRatio); with automatic detection switched off the result is
+    // ignored and every body starts out solid.
     sendToWorker<{
       points: [number, number, number][];
       triangles: [number, number, number][];
       bodyIds: number[];
       bodyCount: number;
       shellBodyIds: number[];
-    }>("parse_step", { bytes, format })
+    }>("parse_step", { bytes, format, thinRatio })
       .then(({ points, triangles, bodyIds, bodyCount, shellBodyIds }) => {
         if (points.length === 0) setStepImportError("No geometry found.");
         else {
@@ -46,7 +51,7 @@ export function useGeometry() {
           setGeometryFormat(format);
           setStepSurface({ points, triangles, bodyIds });
           // One property per body (#353); thin-walled bodies preselected as shells.
-          setBodies(bodyCount, shellBodyIds);
+          setBodies(bodyCount, autoShell ? shellBodyIds : []);
         }
       })
       .catch((err) =>

--- a/web/src/store/geometrySlice.ts
+++ b/web/src/store/geometrySlice.ts
@@ -5,6 +5,7 @@
 // + retained source bytes), and the meshing pipeline state.
 
 import type { SliceCreator } from "./modelStore";
+import { DEFAULT_THIN_RATIO } from "../lib/thinBodies";
 
 export interface Node {
   id: number;
@@ -93,6 +94,12 @@ export interface GeometrySlice {
   surfaceTriangles: [number, number, number][] | null;
   surfaceFaceIds: number[] | null;
   stepImportError: string | null;
+  // Automatic thin-wall detection (auto-shell): when on, every CAD import — and
+  // every change of `thinRatio` — preselects the bodies whose median wall is
+  // thinner than `thinRatio` times their own bounding-box diagonal as Shell.
+  // When off no body is preselected; the element type is the user's alone.
+  autoShell: boolean;
+  thinRatio: number;
 
   addNode(node: Node): void;
   addElement(el: Element): void;
@@ -109,6 +116,8 @@ export interface GeometrySlice {
   // table, so per-body material assignments survive. Pass an empty list to make
   // every body Solid (automatic detection switched off).
   applyShellDetection(shellBodyIds: number[]): void;
+  setAutoShell(enabled: boolean): void;
+  setThinRatio(ratio: number): void;
   setStepSurface(tessellation: StepTessellation | null): void;
   setStepBytes(bytes: Uint8Array | null): void;
   setGeometryFormat(format: GeometryFormat): void;
@@ -142,6 +151,8 @@ export const createGeometrySlice: SliceCreator<GeometrySlice> = (set) => ({
   surfaceTriangles: null,
   surfaceFaceIds: null,
   stepImportError: null,
+  autoShell: true,
+  thinRatio: DEFAULT_THIN_RATIO,
 
   addNode: (node) =>
     set((s) => {
@@ -179,6 +190,18 @@ export const createGeometrySlice: SliceCreator<GeometrySlice> = (set) => ({
         prop.discretization = shell.has(prop.id)
           ? ("shell" as BodyDiscretization)
           : ("solid" as BodyDiscretization);
+    }),
+  setAutoShell: (enabled) =>
+    set((s) => {
+      s.autoShell = enabled;
+    }),
+  setThinRatio: (ratio) =>
+    set((s) => {
+      if (!Number.isFinite(ratio) || ratio <= 0)
+        throw new Error(
+          `Thin ratio must be a positive number, got ${String(ratio)}`,
+        );
+      s.thinRatio = ratio;
     }),
   setBodyDiscretization: (propertyId, disc) =>
     set((s) => {

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -19,6 +19,7 @@ import { create } from "zustand";
 import type { StateCreator } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import type { AnalysisState } from "../lib/analysisFile";
+import { DEFAULT_THIN_RATIO } from "../lib/thinBodies";
 import { createGeometrySlice, type GeometrySlice } from "./geometrySlice";
 import {
   createMaterialSlice,
@@ -161,6 +162,8 @@ const createAnalysisActions: SliceCreator<AnalysisActions> = (set) => ({
       s.deformScale = 1;
       s.elementOrder = 1;
       s.tieDistance = 0;
+      s.autoShell = true;
+      s.thinRatio = DEFAULT_THIN_RATIO;
       s.nextMatId = 2;
       s.selectedFace = null;
       s.pendingFaces = [];

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -154,6 +154,10 @@ interface SurfaceLoad {
 interface ParseStepPayload {
   bytes: Uint8Array;
   format?: string;
+  // Wall-thickness threshold of the thin-body (auto-shell) preselection, as a
+  // fraction of each body's own bounding-box diagonal. Absent ⇒ the detector's
+  // own default (DEFAULT_THIN_RATIO).
+  thinRatio?: number;
 }
 interface VolumeMeshPayload {
   bytes?: Uint8Array;
@@ -205,11 +209,10 @@ function handleParseStep(id: number, payload: ParseStepPayload) {
   // Thin-walled bodies (a ray cast inward from the surface finds an opposite wall
   // close by, relative to the body's size) are preselected as shells — before any
   // volume mesh exists, purely from the tessellation.
-  const shellBodyIds = detectShellBodies({
-    vertices,
-    triangles,
-    triangleBodyIds,
-  });
+  const shellBodyIds = detectShellBodies(
+    { vertices, triangles, triangleBodyIds },
+    { thinRatio: payload.thinRatio },
+  );
   // Return as {points, triangles} to match the StepTessellation type used by
   // the store; tessellate_step returns flat Float32/Uint32 typed arrays.
   // bodyCount (#353) drives the per-body material assignment UI; bodyIds

--- a/web/tests/auto-shell-toggle-single-body.spec.ts
+++ b/web/tests/auto-shell-toggle-single-body.spec.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Single-body parts get the same "Automatic shell detection" control as
+// assemblies. The per-body Element type dropdown is offered for assemblies only,
+// so for a one-body part the switch and its ratio are the ONLY way to choose
+// between a shell and a solid idealisation — they must be reachable there too.
+// Both settings are model state, so a re-import honours them instead of falling
+// back to detection at the default ratio.
+//
+// I_beam.step is a 300 mm long 80x80 mm I-section: its ~5 mm flanges are thin
+// walls, but not thin enough for the default 2 % of the body diagonal, so it
+// imports Solid and turns Shell once the ratio is raised.
+
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { test, expect } from "./coverage";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const STEP_PATH = join(here, "../../test_files/I_beam.step");
+
+type Disc = { id: number; discretization?: string }[];
+
+async function bodies(page: import("@playwright/test").Page): Promise<Disc> {
+  return (await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __kofemStore: { getState(): { properties: Disc } };
+        }
+      ).__kofemStore.getState().properties,
+  )) as Disc;
+}
+
+test("automatic shell detection and its ratio are offered for single-body parts", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+
+  await page.goto("/app/");
+  await expect(page.locator("nav")).toBeVisible();
+  await page.waitForFunction(() =>
+    Boolean((window as unknown as { __kofem?: unknown }).__kofem),
+  );
+
+  await page.setInputFiles('input[accept=".stp,.step"]', STEP_PATH);
+  const toggle = page.getByTestId("auto-shell-detection");
+  await expect(toggle).toBeVisible({ timeout: 60_000 });
+  await expect(toggle).toBeChecked();
+
+  const initial = await bodies(page);
+  expect(initial).toHaveLength(1);
+  expect(initial[0].discretization).toBe("solid");
+
+  // The ratio decides which bodies auto-shell: the I-beam's flanges qualify at
+  // 5 % of the body diagonal, so the sole body flips to Shell.
+  await page.getByTestId("auto-shell-ratio").fill("0.05");
+  await expect
+    .poll(async () => (await bodies(page))[0].discretization)
+    .toBe("shell");
+
+  // Switching detection off is the single-body part's way back to a solid mesh.
+  await toggle.uncheck();
+  await expect
+    .poll(async () => (await bodies(page))[0].discretization)
+    .toBe("solid");
+  await expect(page.getByTestId("auto-shell-ratio")).toHaveCount(0);
+
+  // Re-importing must not silently switch detection back on.
+  await page.setInputFiles('input[accept=".stp,.step"]', STEP_PATH);
+  await expect(toggle).not.toBeChecked();
+  await expect
+    .poll(async () => (await bodies(page))[0].discretization, {
+      timeout: 60_000,
+    })
+    .toBe("solid");
+
+  // Switching it back on re-runs detection at the retained 5 % ratio.
+  await toggle.check();
+  await expect(page.getByTestId("auto-shell-ratio")).toHaveValue("0.05");
+  await expect
+    .poll(async () => (await bodies(page))[0].discretization)
+    .toBe("shell");
+});


### PR DESCRIPTION
## Summary

Refactors the shell idealisation UI to make automatic thin-wall detection available for single-body parts, not just assemblies. Previously, only multi-body models showed the auto-shell toggle and ratio controls; single-body parts had no way to choose between shell and solid idealisation except through the per-body Element type dropdown (which only appeared for assemblies). Now both settings are model state, persisted across re-imports, and shown for every imported model.

Part of #404 (the "autoconvert" half — per-subpart shell selection within one body is still open, so this does not close it).

## Key Changes

**web/src/components/panel/GeometryPanel.tsx**
- Split shell idealisation UI into a new `AutoShellSection()` component shown for all models (when `stepSurface` exists)
- Moved auto-shell toggle and ratio controls from `BodiesSection()` to `AutoShellSection()`
- `BodiesSection()` now only renders for multi-body models (`properties.length &gt; 1`)
- Updated tooltip text to clarify that per-body Element type is for assemblies only

**web/src/store/geometrySlice.ts**
- Added `autoShell: boolean` and `thinRatio: number` to `GeometrySlice` state
- Added `setAutoShell()` and `setThinRatio()` actions with validation
- Initialize `autoShell = true` and `thinRatio = DEFAULT_THIN_RATIO` on slice creation

**web/src/store/modelStore.ts**
- Reset `autoShell` and `thinRatio` to defaults in the whole-model `reset()` action, alongside the other meshing settings (`elementOrder`, `tieDistance`). A **re-import deliberately keeps** them — only a full model reset restores the defaults.

**web/src/hooks/useGeometry.ts**
- Pass `thinRatio` to the worker&#39;s `parse_step` message
- Respect the `autoShell` flag: only apply detected shell bodies if detection is enabled; otherwise all bodies start solid

**web/src/workers/solver.worker.ts**
- Accept optional `thinRatio` in `ParseStepPayload`
- Pass `thinRatio` to `detectShellBodies()` so the worker uses the user&#39;s threshold instead of the detector&#39;s default

**web/tests/auto-shell-toggle-single-body.spec.ts** (new)
- End-to-end test over `I_beam.step`, which imports Solid at the default 2 % ratio and turns Shell at 5 % — so it exercises both directions
- Confirms that single-body parts expose the toggle and ratio, and that both change the body&#39;s discretization
- Verifies that re-importing respects the user&#39;s previous settings instead of resetting to defaults

## Notable Implementation Details

- `AutoShellSection()` is now the only place where shell detection is configured; it appears for all models with a tessellation, making the feature discoverable for single-body parts.
- The `autoShell` and `thinRatio` settings are part of model state (not local component state), so they survive re-imports and are consistent across the UI.
- When `autoShell` is false, the worker still runs detection (for consistency) but the result is discarded in `useGeometry.ts`, leaving all bodies solid.
- The `BodiesSection()` now only shows the per-body Element type dropdown for assemblies, where it makes sense; single-body parts use the auto-shell controls instead.
- Validation in `setThinRatio()` ensures the ratio is a positive finite number, raising a clear error if invalid.

## Verification

- Full Playwright suite green locally: 66 passed (3.2 min), including the pre-existing multi-body `auto-shell-toggle.spec.ts` and the new single-body spec.
- `tsc --noEmit`, `eslint`, and `prettier --check` clean.

## Checklist

- [x] **No silent fallbacks** — `setThinRatio()` validates input and raises an error for invalid values; `thinRatio` is always passed explicitly to the worker.
- [x] Every input accepted by the UI is consumed downstream — the `autoShell` toggle and `thinRatio` input are both used in `useGeometry.ts` to control shell detection behavior.

https://claude.ai/code/session_01CKerAbw5uUCmMuUGHqLJbD