### PR TITLE
Enforce no-silent-fallback rule in components and hooks

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -43,7 +43,18 @@ export default [
     // displayed results. Here any `??`/`||` fabricating a plausible value
     // default is an error; genuinely optional fields carry an
     // eslint-disable comment with a justification.
-    files: ["src/workers/**", "src/store/**", "src/lib/**"],
+    //
+    // Components and hooks are in scope because result rendering and solver
+    // input now live there too, not just in workers/store/lib: the von Mises
+    // colormap zero-filled missing stress data and the rule never saw it
+    // (issue #363).
+    files: [
+      "src/workers/**",
+      "src/store/**",
+      "src/lib/**",
+      "src/components/**",
+      "src/hooks/**",
+    ],
     plugins: { kofem },
     rules: {
       "kofem/no-silent-fallback": ["error", { checkValueDefaults: true }],

--- a/web/src/components/panel/BcSection.tsx
+++ b/web/src/components/panel/BcSection.tsx
@@ -61,6 +61,7 @@ export function BcSection({ onError }: { onError(msg: string | null): void }) {
     if (allPickedFaces.length === 0) return;
     const faceEntries = toFaceEntries(
       allPickedFaces,
+      // eslint-disable-next-line kofem/no-silent-fallback -- numbering offset for the new entries; a pick with no target group starts a fresh group, which has 0 faces
       targetBcGroup?.faces.length ?? 0,
       pickGeometry === "edge" ? "Edge" : "Face",
     );

--- a/web/src/components/panel/GeometryPanel.tsx
+++ b/web/src/components/panel/GeometryPanel.tsx
@@ -22,11 +22,16 @@ function MaterialForm({
   onSave(v: Omit<Material, "id">): void;
   onCancel(): void;
 }) {
+  // Form seeds for the "new material" dialog (`mat` undefined): structural
+  // steel, shown in the editable fields and validated in handleSave before it
+  // becomes a material. Nothing here reaches the solver unseen.
+  /* eslint-disable kofem/no-silent-fallback -- prefilled form values the user sees and edits, not a substitute for missing solver data */
   const [name, setName] = useState(mat?.name ?? "Material");
   const [young, setYoung] = useState(String(mat?.young ?? 210000));
   const [poisson, setPoisson] = useState(String(mat?.poisson ?? 0.3));
   const [density, setDensity] = useState(String(mat?.density ?? 7.85e-9));
   const [color, setColor] = useState(mat?.color ?? defaultColor ?? "#4e79a7");
+  /* eslint-enable kofem/no-silent-fallback */
   const [error, setError] = useState<string | null>(null);
 
   function handleSave() {
@@ -49,6 +54,7 @@ function MaterialForm({
       return;
     }
     onSave({
+      // eslint-disable-next-line kofem/no-silent-fallback -- label for a material the user left unnamed; cosmetic, the physical constants above are all validated
       name: name || "Material",
       young: youngModulus,
       poisson: poissonRatio,
@@ -386,6 +392,7 @@ function BodiesSection() {
   if (properties.length <= 1) return null;
 
   const matColor = (materialId: number) =>
+    // eslint-disable-next-line kofem/no-silent-fallback -- swatch colour for a body whose material carries none; display only, never reaches the solver
     materials.find((mat) => mat.id === materialId)?.color ?? "#7a9bbf";
 
   // Highlighting a body dims the others in the geometry (coloured-tessellation)
@@ -446,6 +453,7 @@ function BodiesSection() {
               className={styles.formSelect}
               data-testid={`body-type-${prop.id}`}
               title={ELEMENT_TYPE_TIP}
+              // eslint-disable-next-line kofem/no-silent-fallback -- selected option for a body left at the default discretization; absent means solid, matching how geometrySlice assigns it
               value={prop.discretization ?? "solid"}
               onFocus={() => highlight(prop.id)}
               onBlur={() => setHighlightBodyId(null)}

--- a/web/src/components/panel/LoadSection.tsx
+++ b/web/src/components/panel/LoadSection.tsx
@@ -82,6 +82,7 @@ export function LoadSection({
     if (allPickedFaces.length === 0) return;
     const faceEntries = toFaceEntries(
       allPickedFaces,
+      // eslint-disable-next-line kofem/no-silent-fallback -- numbering offset for the new entries; a pick with no target group starts a fresh group, which has 0 faces
       targetLoadGroup?.faces.length ?? 0,
       pickGeometry === "edge" ? "Edge" : "Face",
     );

--- a/web/src/components/topbar/TopBar.tsx
+++ b/web/src/components/topbar/TopBar.tsx
@@ -70,6 +70,7 @@ export function TopBar() {
         <span className={styles.crumb}>
           <span className={styles.crumbMuted}>Workspace</span>
           <span className={styles.crumbSep}>/</span>
+          {/* eslint-disable-next-line kofem/no-silent-fallback -- breadcrumb label for an unnamed model; cosmetic, never fed back into the analysis */}
           <span className={styles.crumbPage}>{modelName || "Untitled"}</span>
         </span>
       </div>

--- a/web/src/components/viewport/BoundaryConditionLayer.tsx
+++ b/web/src/components/viewport/BoundaryConditionLayer.tsx
@@ -159,6 +159,7 @@ export function BoundaryConditionLayer({
         normal.negate();
 
       for (const id of faceIds) {
+        // eslint-disable-next-line kofem/no-silent-fallback -- accumulating face normals; the zero vector is the identity for a node seen for the first time
         const acc = outward.get(id) ?? new THREE.Vector3();
         outward.set(id, acc.add(normal));
       }
@@ -348,8 +349,10 @@ export function BoundaryConditionLayer({
 
         const share = area / corners.length;
         for (const id of ids) {
+          // eslint-disable-next-line kofem/no-silent-fallback -- accumulating tributary area; 0 is the identity for a node seen for the first time
           tribArea.set(id, (tribArea.get(id) ?? 0) + share);
           if (kind === "pressure") {
+            // eslint-disable-next-line kofem/no-silent-fallback -- accumulating area-weighted normals; the zero vector is the identity for a node seen for the first time
             const acc = inward.get(id) ?? new THREE.Vector3();
             inward.set(id, acc.addScaledVector(normal, area));
           }

--- a/web/src/components/viewport/GeometryLayer.tsx
+++ b/web/src/components/viewport/GeometryLayer.tsx
@@ -44,6 +44,7 @@ export function GeometryLayer({ wireframe }: GeometryLayerProps) {
 
     const triIndicesByBody = new Map<number, number[]>();
     for (let t = 0; t < triangles.length; t++) {
+      // eslint-disable-next-line kofem/no-silent-fallback -- bodyIds is absent on analyses saved before per-body colours; StepTessellation documents body 1 for the whole tessellation in that case
       const body = bodyIds?.[t] ?? 1;
       let list = triIndicesByBody.get(body);
       if (!list) {
@@ -81,6 +82,7 @@ export function GeometryLayer({ wireframe }: GeometryLayerProps) {
         let nx = ay * bz - az * by,
           ny = az * bx - ax * bz,
           nz = ax * by - ay * bx;
+        // eslint-disable-next-line kofem/no-silent-fallback -- div-by-zero guard: a degenerate (zero-area) triangle has no defined normal
         const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
         nx /= len;
         ny /= len;
@@ -103,6 +105,7 @@ export function GeometryLayer({ wireframe }: GeometryLayerProps) {
     return (bodyId: number): string => {
       const prop = properties.find((p) => p.id === bodyId);
       const mat = prop ? matById.get(prop.materialId) : undefined;
+      // eslint-disable-next-line kofem/no-silent-fallback -- display colour only: a body with no material assigned yet is drawn in the neutral default and never reaches the solver
       return mat?.color ?? DEFAULT_BODY_COLOR;
     };
   }, [properties, materials]);

--- a/web/src/components/viewport/ResultsColormap.tsx
+++ b/web/src/components/viewport/ResultsColormap.tsx
@@ -51,6 +51,14 @@ export function ResultsColormap({
     // plausible-looking but wrong colormap/deformed shape — bail instead.
     if (disp.length !== nodeMap.size * 3) return null;
 
+    // `SolverResult.vonMises` is optional, so an analysis file written before
+    // the field existed (or produced elsewhere) legitimately lacks it. Filling
+    // the missing field with zeros paints every node the same colour, which
+    // reads as a valid uniform-stress result — the same silent zero-fill the
+    // guard above rejects. Bail instead; ResultsPanel already reports
+    // "Von Mises data not available — re-run the solver".
+    if (resultType === "Von Mises stress" && !nodeVonMises) return null;
+
     // Compute per-node scalar value for the selected result type
     const nodeValue = (i: number, rt: ResultType): number => {
       switch (rt) {
@@ -61,7 +69,11 @@ export function ResultsColormap({
         case "Uz":
           return disp[i * 3 + 2];
         case "Von Mises stress":
-          return nodeVonMises?.[i] ?? 0;
+          if (!nodeVonMises)
+            throw new Error(
+              "von Mises node field is unavailable although it was requested",
+            );
+          return nodeVonMises[i];
         default: {
           const ux = disp[i * 3],
             uy = disp[i * 3 + 1],
@@ -78,6 +90,7 @@ export function ResultsColormap({
       if (val < minVal) minVal = val;
       if (val > maxVal) maxVal = val;
     }
+    // eslint-disable-next-line kofem/no-silent-fallback -- div-by-zero guard: a uniform field has zero range and every node then maps to frac 0
     const range = maxVal - minVal || 1;
 
     const positions: number[] = [];

--- a/web/src/components/viewport/useFacePick.ts
+++ b/web/src/components/viewport/useFacePick.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Michael Kofler
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useModelStore } from "../../store/modelStore";
 import {
@@ -50,8 +49,11 @@ export function useFacePick(
           ]
         : [...pickFaceNodeIds(startIdx, boundaryMeshTopo)];
     if (faceNodeIds.length === 0) return;
-    const normal =
-      e.face?.normal.clone().normalize() ?? new THREE.Vector3(0, 1, 0);
+    // The normal decides which axis/extreme the picked face is snapped to, and
+    // that selection becomes solver input. Substituting +Y for a missing normal
+    // would silently snap the pick to the wrong face — drop the pick instead.
+    if (!e.face) return;
+    const normal = e.face.normal.clone().normalize();
     const ax = Math.abs(normal.x),
       ay = Math.abs(normal.y),
       az = Math.abs(normal.z);

--- a/web/src/hooks/useGeometry.ts
+++ b/web/src/hooks/useGeometry.ts
@@ -55,6 +55,7 @@ export function useGeometry() {
         }
       })
       .catch((err) =>
+        // eslint-disable-next-line kofem/no-silent-fallback -- fallback text for a rejection that arrived without a message; this is the error path itself, not solver data
         setStepImportError(err.message ?? `${label} import failed`),
       )
       .finally(() => {

--- a/web/src/hooks/useSolver.ts
+++ b/web/src/hooks/useSolver.ts
@@ -45,6 +45,7 @@ export function useSolver() {
   // A non-zero prescribed displacement drives the deformation on its own, so the
   // model is solvable without an applied load. Without either, the solve returns
   // the trivial zero field, so at least one driving action is still required.
+  // eslint-disable-next-line kofem/no-silent-fallback -- a constraint without prescribedValue is a homogeneous fixed BC, i.e. u = 0 by definition
   const prescribedOk = constraints.some((c) => (c.prescribedValue ?? 0) !== 0);
   const drivingOk = loadOk || prescribedOk;
   const allOk = meshOk && matOk && bcOk && drivingOk;


### PR DESCRIPTION
## Summary

Extends the `kofem/no-silent-fallback` ESLint rule to `src/components/**` and `src/hooks/**` to catch missing-data bugs in result rendering and solver input validation. Fixes the case where the von Mises colormap silently zero-filled missing stress data instead of rejecting it.

Fixes KOF-176

## Key Changes

**ESLint rule scope expansion (web/eslint.config.js)**
- Extended `kofem/no-silent-fallback` to cover components and hooks, not just workers/store/lib
- Rationale: result rendering and solver input validation now live in components/hooks, where silent fallbacks can corrupt analysis output

**Von Mises colormap validation (web/src/components/viewport/ResultsColormap.tsx)**
- Added early return when von Mises data is missing (before attempting to render)
- Changed `nodeVonMises?.[i] ?? 0` to throw an error if the field is unexpectedly absent during rendering
- Added ESLint disable comment explaining the div-by-zero guard for uniform fields

**Boundary condition and geometry rendering (web/src/components/viewport/)**
- Added ESLint disable comments justifying legitimate fallbacks in `BoundaryConditionLayer.tsx` and `GeometryLayer.tsx`:
  - Accumulating face normals and tributary area (zero vector/0 is the identity for first-time nodes)
  - Backward compatibility for analyses saved before per-body colours
  - Degenerate triangle normal computation

**Form defaults and display-only fallbacks (web/src/components/panel/)**
- Added ESLint disable comments for form seed values in `GeometryPanel.tsx` (prefilled defaults the user sees and edits, not solver data)
- Added comments for display-only fallbacks: material colour swatches, body discretization defaults, unnamed material labels
- All validated before reaching the solver

**Face picking validation (web/src/components/viewport/useFacePick.ts)**
- Removed unused THREE.js import
- Changed silent fallback `e.face?.normal ?? new THREE.Vector3(0, 1, 0)` to explicit early return when face is missing
- Rationale: substituting +Y for a missing normal would silently snap the pick to the wrong face

**Minor additions (web/src/components/topbar/, web/src/hooks/)**
- Added ESLint disable comments for cosmetic fallbacks (unnamed model breadcrumb label, error message fallback text)
- Added comment for homogeneous BC constraint validation in `useSolver.ts`

## Notable Implementation Details

The rule extension distinguishes between **legitimate fallbacks** (form defaults, display-only colours, accumulation identities) and **silent data corruption** (missing solver inputs, wrong face picks, missing stress data). Each legitimate fallback carries a detailed ESLint disable comment explaining why it is safe.

The von Mises fix is defensive: an early return rejects missing data before rendering, and the nodeValue function throws if the field is somehow absent during iteration. This prevents the silent zero-fill that would paint every node the same colour and read as a valid uniform-stress result.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run format:check` clean
- Full suite: 66/66 passed
- Confirmed the widened rule is a real guard by reintroducing the original `?? 0` and watching it fail lint, then restoring

No Playwright regression test was added: there is no unit-test harness for React components, so covering this would mean a browser test loading a crafted analysis file, and KOF-197 already flags suite runtime growth. The lint rule is the durable guard, which is how KOF-176 frames the fix.

## Checklist

- [x] **No silent fallbacks** — all fallbacks in this PR either (1) carry an ESLint disable comment with justification, or (2) are replaced with explicit errors/early returns. Form defaults, display-only colours, and accumulation identities are justified; missing solver data is rejected.
- [x] Every input accepted by the UI or an API is actually consumed downstream — von Mises data is validated before use; face picks are rejected if the normal is missing; form values are validated before reaching the solver.

https://claude.ai/code/session_01S3eHCFAhwYgQA4NDgMFtQZ