### PR TITLE
Add manual colorbar limits to clamp result field visualization

### DIFF
--- a/web/src/components/panel/LegendRangeControls.tsx
+++ b/web/src/components/panel/LegendRangeControls.tsx
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Manual colorbar limits for the displayed result field (#390). Editing either
+// limit pins both; "Auto" hands the range back to the field's own min/max.
+
+import { useEffect, useState } from "react";
+import { useModelStore } from "../../store/modelStore";
+import type { ResultRange } from "../../lib/resultField";
+import styles from "./LeftPanel.module.css";
+
+interface LegendRangeControlsProps {
+  // The field's own min/max, used both as the auto range and as the starting
+  // point when the user pins the limits.
+  fieldRange: ResultRange;
+  unit: string;
+}
+
+// Short enough to edit by hand, precise enough to not visibly move the limits.
+function format(v: number): string {
+  return String(Number(v.toPrecision(4)));
+}
+
+export function LegendRangeControls({
+  fieldRange,
+  unit,
+}: LegendRangeControlsProps) {
+  const legendRange = useModelStore((s) => s.legendRange);
+  const setLegendRange = useModelStore((s) => s.setLegendRange);
+  const active = legendRange ?? fieldRange;
+
+  const [minText, setMinText] = useState(() => format(active.min));
+  const [maxText, setMaxText] = useState(() => format(active.max));
+  const [error, setError] = useState<string | null>(null);
+
+  // The active range changes under the inputs whenever the user switches result
+  // type or a new solve lands (both clear the override) — follow it.
+  useEffect(() => {
+    setMinText(format(active.min));
+    setMaxText(format(active.max));
+    setError(null);
+  }, [active.min, active.max]);
+
+  const apply = () => {
+    const min = Number(minText);
+    const max = Number(maxText);
+    if (
+      minText.trim() === "" ||
+      maxText.trim() === "" ||
+      Number.isNaN(min) ||
+      Number.isNaN(max)
+    ) {
+      setError("Both limits must be numbers");
+      return;
+    }
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      setError("Limits must be finite");
+      return;
+    }
+    if (max <= min) {
+      setError("Max must be greater than min");
+      return;
+    }
+    setError(null);
+    setLegendRange({ min, max });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      apply();
+    }
+  };
+
+  return (
+    <>
+      <div className={styles.formRow}>
+        <span className={styles.formLabel}>Min</span>
+        <input
+          className={styles.formInput}
+          data-testid="legend-min"
+          type="number"
+          value={minText}
+          onChange={(e) => setMinText(e.target.value)}
+          onBlur={apply}
+          onKeyDown={onKeyDown}
+          aria-label="Legend minimum"
+        />
+        <span className={styles.toleranceUnit}>{unit}</span>
+      </div>
+      <div className={styles.formRow}>
+        <span className={styles.formLabel}>Max</span>
+        <input
+          className={styles.formInput}
+          data-testid="legend-max"
+          type="number"
+          value={maxText}
+          onChange={(e) => setMaxText(e.target.value)}
+          onBlur={apply}
+          onKeyDown={onKeyDown}
+          aria-label="Legend maximum"
+        />
+        <span className={styles.toleranceUnit}>{unit}</span>
+      </div>
+      {error && (
+        <div className={styles.formNote} data-testid="legend-error">
+          {error}
+        </div>
+      )}
+      <div className={styles.formNote}>
+        {legendRange
+          ? "Values outside the range take the end colours."
+          : "Auto: the field's own min/max."}
+      </div>
+      <button
+        className={styles.outlineBtn}
+        data-testid="legend-auto"
+        style={{ marginBottom: 12 }}
+        disabled={!legendRange}
+        onClick={() => {
+          setLegendRange(null);
+          setError(null);
+        }}
+      >
+        Auto
+      </button>
+    </>
+  );
+}

--- a/web/src/components/panel/ResultsPanel.tsx
+++ b/web/src/components/panel/ResultsPanel.tsx
@@ -8,6 +8,7 @@ import {
   resultFieldSymbol,
   resultUnit,
 } from "../../lib/resultField";
+import { LegendRangeControls } from "./LegendRangeControls";
 import styles from "./LeftPanel.module.css";
 
 export function ResultsPanel() {
@@ -79,6 +80,13 @@ export function ResultsPanel() {
             {deformScale.toFixed(2)}×
           </span>
         </div>
+
+        {stats && (
+          <>
+            <div className={styles.sectionLabel}>Legend range</div>
+            <LegendRangeControls fieldRange={stats} unit={unit} />
+          </>
+        )}
 
         <div className={styles.sectionLabel}>Result summary</div>
         {stats ? (

--- a/web/src/components/viewport/ColorBar.tsx
+++ b/web/src/components/viewport/ColorBar.tsx
@@ -29,21 +29,27 @@ export function ColorBar() {
   const mode = useModelStore((s) => s.mode);
   const nodes = useModelStore((s) => s.nodes);
   const elements = useModelStore((s) => s.elements);
+  const legendRange = useModelStore((s) => s.legendRange);
 
   if (mode !== "results" || !result) return null;
 
-  const range = computeResultRange(result, resultType, nodes, elements);
-  if (!range) return null;
+  const fieldRange = computeResultRange(result, resultType, nodes, elements);
+  if (!fieldRange) return null;
 
-  const { min, max } = range;
+  const { min, max } = legendRange ?? fieldRange;
   // Tick values from top (max) to bottom (min).
   const ticks = Array.from({ length: TICKS }, (_, i) => {
     const frac = 1 - i / (TICKS - 1);
     return min + frac * (max - min);
   });
+  // Manual limits clamp the colouring, so the end ticks stand for "everything
+  // at or beyond this value" rather than for the extremes of the field.
+  const clampsAbove = max < fieldRange.max;
+  const clampsBelow = min > fieldRange.min;
 
   return (
     <div
+      data-testid="colorbar"
       style={{
         position: "absolute",
         left: 12,
@@ -64,6 +70,14 @@ export function ColorBar() {
       <div style={{ marginBottom: 6, fontWeight: 600, whiteSpace: "nowrap" }}>
         {resultFieldSymbol(resultType)} [{resultUnit(resultType)}]
       </div>
+      {legendRange && (
+        <div
+          data-testid="colorbar-manual"
+          style={{ marginBottom: 6, color: "#6b7280", whiteSpace: "nowrap" }}
+        >
+          manual range
+        </div>
+      )}
       <div style={{ display: "flex", gap: 6 }}>
         <div
           style={{
@@ -84,7 +98,13 @@ export function ColorBar() {
           }}
         >
           {ticks.map((v, i) => (
-            <span key={i} style={{ whiteSpace: "nowrap", lineHeight: 1 }}>
+            <span
+              key={i}
+              data-testid={`colorbar-tick-${i}`}
+              style={{ whiteSpace: "nowrap", lineHeight: 1 }}
+            >
+              {i === 0 && clampsAbove ? "≥ " : ""}
+              {i === TICKS - 1 && clampsBelow ? "≤ " : ""}
               {v.toExponential(2)}
             </span>
           ))}

--- a/web/src/components/viewport/ColorBar.tsx
+++ b/web/src/components/viewport/ColorBar.tsx
@@ -37,10 +37,12 @@ export function ColorBar() {
   if (!fieldRange) return null;
 
   const { min, max } = legendRange ?? fieldRange;
-  // Tick values from top (max) to bottom (min).
+  // Tick values from top (max) to bottom (min). Each tick keeps its position on
+  // the bar, which is what identifies it across renders — the value changes
+  // whenever the range does.
   const ticks = Array.from({ length: TICKS }, (_, i) => {
     const frac = 1 - i / (TICKS - 1);
-    return min + frac * (max - min);
+    return { frac, value: min + frac * (max - min) };
   });
   // Manual limits clamp the colouring, so the end ticks stand for "everything
   // at or beyond this value" rather than for the extremes of the field.
@@ -97,15 +99,15 @@ export function ColorBar() {
             fontVariantNumeric: "tabular-nums",
           }}
         >
-          {ticks.map((v, i) => (
+          {ticks.map(({ frac, value }, i) => (
             <span
-              key={i}
+              key={frac}
               data-testid={`colorbar-tick-${i}`}
               style={{ whiteSpace: "nowrap", lineHeight: 1 }}
             >
-              {i === 0 && clampsAbove ? "≥ " : ""}
-              {i === TICKS - 1 && clampsBelow ? "≤ " : ""}
-              {v.toExponential(2)}
+              {frac === 1 && clampsAbove ? "≥ " : ""}
+              {frac === 0 && clampsBelow ? "≤ " : ""}
+              {value.toExponential(2)}
             </span>
           ))}
         </div>

--- a/web/src/components/viewport/ResultsColormap.tsx
+++ b/web/src/components/viewport/ResultsColormap.tsx
@@ -10,7 +10,7 @@ import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useModelStore } from "../../store/modelStore";
 import type { ResultType } from "../../store/modelStore";
-import { nodeVonMisesField } from "../../lib/resultField";
+import { nodeVonMisesField, resultFraction } from "../../lib/resultField";
 import type { MeshTopology } from "./useMeshTopology";
 
 interface ResultsColormapProps {
@@ -28,6 +28,7 @@ export function ResultsColormap({
   const elements = useModelStore((s) => s.elements);
   const result = useModelStore((s) => s.result);
   const resultType = useModelStore((s) => s.resultType);
+  const legendRange = useModelStore((s) => s.legendRange);
 
   const { nodeMap, boundaryQuadFaceIds, boundaryTriFaceIds } = topology;
 
@@ -90,8 +91,10 @@ export function ResultsColormap({
       if (val < minVal) minVal = val;
       if (val > maxVal) maxVal = val;
     }
-    // eslint-disable-next-line kofem/no-silent-fallback -- div-by-zero guard: a uniform field has zero range and every node then maps to frac 0
-    const range = maxVal - minVal || 1;
+    // Manual legend limits colour the mesh too, otherwise the colorbar would
+    // read against a different scale than the surface it annotates.
+    const colorMin = legendRange ? legendRange.min : minVal;
+    const colorMax = legendRange ? legendRange.max : maxVal;
 
     const positions: number[] = [];
     const colors: number[] = [];
@@ -106,7 +109,7 @@ export function ResultsColormap({
     };
     const nodeColor = (id: number): [number, number, number] => {
       const { i } = nodeMap.get(id)!;
-      const frac = (nodeValue(i, resultType) - minVal) / range;
+      const frac = resultFraction(nodeValue(i, resultType), colorMin, colorMax);
       const color = new THREE.Color();
       color.setHSL(0.667 * (1 - frac), 1, 0.5);
       return [color.r, color.g, color.b];
@@ -142,6 +145,7 @@ export function ResultsColormap({
   }, [
     result,
     resultType,
+    legendRange,
     nodeVonMises,
     boundaryQuadFaceIds,
     boundaryTriFaceIds,

--- a/web/src/lib/resultField.ts
+++ b/web/src/lib/resultField.ts
@@ -127,6 +127,21 @@ export interface ResultRange {
   max: number;
 }
 
+// Position of `value` inside [min, max], as the t that resultColor expects.
+// Clamped, so a value outside a manually narrowed legend range saturates at the
+// end colour instead of wrapping back through the map.
+export function resultFraction(
+  value: number,
+  min: number,
+  max: number,
+): number {
+  const span = max - min;
+  // Div-by-zero guard: a uniform field has zero span, and everything then sits
+  // at the bottom of the map.
+  if (span <= 0) return 0;
+  return Math.min(1, Math.max(0, (value - min) / span));
+}
+
 // Min/max of the selected scalar field over all nodes.  Returns null when the
 // field cannot be computed (e.g. Von Mises requested but unavailable).
 export function computeResultRange(

--- a/web/src/store/modelStore.ts
+++ b/web/src/store/modelStore.ts
@@ -58,7 +58,12 @@ export type {
   SurfaceLoad,
 } from "./boundarySlice";
 export { loadKind, loadComponents } from "./boundarySlice";
-export type { SolverResult, ResultType, AppMode } from "./resultsSlice";
+export type {
+  SolverResult,
+  ResultType,
+  AppMode,
+  LegendRange,
+} from "./resultsSlice";
 export { RESULT_TYPES } from "./resultsSlice";
 export type { LoadDisplay, ViewRepr } from "./viewSlice";
 
@@ -121,6 +126,7 @@ const createAnalysisActions: SliceCreator<AnalysisActions> = (set) => ({
       s.modelName = a.modelName;
       s.result = a.result;
       s.resultType = a.resultType;
+      s.legendRange = null;
       s.viewRepr = a.viewRepr;
       s.deformScale = 1;
       s.mode = a.mode;
@@ -152,6 +158,7 @@ const createAnalysisActions: SliceCreator<AnalysisActions> = (set) => ({
       s.modelName = "";
       s.result = null;
       s.resultType = "Displacement (magnitude)";
+      s.legendRange = null;
       s.stepSurface = null;
       s.stepBytes = null;
       s.geometryFormat = "step";

--- a/web/src/store/resultsSlice.ts
+++ b/web/src/store/resultsSlice.ts
@@ -22,6 +22,12 @@ export type ResultType = (typeof RESULT_TYPES)[number];
 
 export type AppMode = "geometry" | "constraints" | "solve" | "results";
 
+// User-chosen colorbar limits, in the units of the displayed result field.
+export interface LegendRange {
+  min: number;
+  max: number;
+}
+
 export interface ResultsSlice {
   result: SolverResult | null;
   resultType: ResultType;
@@ -35,6 +41,11 @@ export interface ResultsSlice {
   // contact) are joined by welding near-contact nodes of different bodies
   // within this distance. 0 disables the tie.
   tieDistance: number;
+  // Colorbar limits for the displayed field, or null for the field's own
+  // min/max. A single stress concentration otherwise takes the whole colour
+  // map and flattens everything else to blue, hiding the second-highest
+  // stressed region (#390); clamping to a manual range brings it back.
+  legendRange: LegendRange | null;
   mode: AppMode;
   hasStarted: boolean;
 
@@ -43,6 +54,7 @@ export interface ResultsSlice {
   setRunning(v: boolean): void;
   setElementOrder(order: number): void;
   setTieDistance(distance: number): void;
+  setLegendRange(range: LegendRange | null): void;
 
   // Mode navigation
   setMode(mode: AppMode): void;
@@ -56,6 +68,7 @@ export const createResultsSlice: SliceCreator<ResultsSlice> = (set) => ({
   // an opt-in upgrade (Solver settings) — far more accurate but ~8× the DOFs.
   elementOrder: 1,
   tieDistance: 0,
+  legendRange: null,
   mode: "geometry",
   hasStarted: false,
 
@@ -63,10 +76,14 @@ export const createResultsSlice: SliceCreator<ResultsSlice> = (set) => ({
     set((s) => {
       s.result = result;
       s.resultType = "Displacement (magnitude)";
+      s.legendRange = null;
     }),
+  // Switching the field changes both the quantity and its unit, so limits
+  // picked for the previous one no longer mean anything — back to auto.
   setResultType: (t) =>
     set((s) => {
       s.resultType = t;
+      s.legendRange = null;
     }),
   setRunning: (v) =>
     set((s) => {
@@ -79,6 +96,21 @@ export const createResultsSlice: SliceCreator<ResultsSlice> = (set) => ({
   setTieDistance: (distance) =>
     set((s) => {
       s.tieDistance = Math.max(0, distance);
+    }),
+  setLegendRange: (range) =>
+    set((s) => {
+      if (
+        range !== null &&
+        !(
+          Number.isFinite(range.min) &&
+          Number.isFinite(range.max) &&
+          range.max > range.min
+        )
+      )
+        throw new Error(
+          `legend range needs finite limits with min < max, got min=${range?.min}, max=${range?.max}`,
+        );
+      s.legendRange = range;
     }),
 
   setMode: (mode) =>

--- a/web/tests/legend-range.spec.ts
+++ b/web/tests/legend-range.spec.ts
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from "./coverage";
+
+// Manual colorbar limits (#390): a pre-solved example is enough to exercise the
+// whole path — pinning the limits, rejecting an inverted range, the "Auto"
+// reset, and the reset that switching result type performs.
+
+function readLegendRange(page: import("@playwright/test").Page) {
+  return page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __kofemStore: {
+            getState(): { legendRange: { min: number; max: number } | null };
+          };
+        }
+      ).__kofemStore.getState().legendRange,
+  );
+}
+
+async function tickValue(
+  page: import("@playwright/test").Page,
+  i: number,
+): Promise<number> {
+  const text = await page.getByTestId(`colorbar-tick-${i}`).innerText();
+  return Number(text.replace(/^[≥≤]\s*/, ""));
+}
+
+test("the colorbar limits can be pinned, rejected when inverted, and reset (#390)", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+
+  await page.goto("/app/?example=cantilever-beam");
+  await expect(page.locator("nav")).toBeVisible();
+  await expect(page.getByTestId("colorbar")).toBeVisible({ timeout: 20_000 });
+
+  // Auto: the ticks span the field's own min/max and nothing is clamped.
+  await expect(page.getByTestId("colorbar-manual")).toHaveCount(0);
+  expect(await readLegendRange(page)).toBeNull();
+  const fieldMax = await tickValue(page, 0);
+  expect(fieldMax).toBeGreaterThan(0);
+
+  // Pinning the top of the range to half the peak: the store carries the
+  // override, the colorbar says so, and the top tick reads as a clamp.
+  const pinnedMax = fieldMax / 2;
+  await page.getByTestId("legend-max").fill(String(pinnedMax));
+  await page.getByTestId("legend-max").press("Enter");
+
+  await expect(page.getByTestId("colorbar-manual")).toBeVisible();
+  const range = await readLegendRange(page);
+  expect(range).not.toBeNull();
+  expect(range!.max).toBeCloseTo(pinnedMax, 6);
+  await expect(page.getByTestId("colorbar-tick-0")).toContainText("≥");
+  expect(await tickValue(page, 0)).toBeCloseTo(pinnedMax, 6);
+
+  // An inverted range is refused loudly and leaves the applied limits alone.
+  await page.getByTestId("legend-min").fill(String(fieldMax));
+  await page.getByTestId("legend-min").press("Enter");
+  await expect(page.getByTestId("legend-error")).toContainText(
+    "Max must be greater than min",
+  );
+  expect((await readLegendRange(page))!.max).toBeCloseTo(pinnedMax, 6);
+
+  // "Auto" hands the range back to the field.
+  await page.getByTestId("legend-auto").click();
+  expect(await readLegendRange(page)).toBeNull();
+  await expect(page.getByTestId("colorbar-manual")).toHaveCount(0);
+  expect(await tickValue(page, 0)).toBeCloseTo(fieldMax, 6);
+
+  // Limits picked for one field mean nothing for the next one, so switching
+  // result type drops them.
+  await page.getByTestId("legend-max").fill(String(pinnedMax));
+  await page.getByTestId("legend-max").press("Enter");
+  expect(await readLegendRange(page)).not.toBeNull();
+
+  await page.getByRole("combobox").first().selectOption("Ux");
+  expect(await readLegendRange(page)).toBeNull();
+  await expect(page.getByTestId("colorbar-manual")).toHaveCount(0);
+});

--- a/web/tests/legend-range.spec.ts
+++ b/web/tests/legend-range.spec.ts
@@ -25,7 +25,7 @@ async function tickValue(
   i: number,
 ): Promise<number> {
   const text = await page.getByTestId(`colorbar-tick-${i}`).innerText();
-  return Number(text.replace(/^[≥≤]\s*/, ""));
+  return Number(text.replace(/^[≥≤]\s*/u, ""));
 }
 
 test("the colorbar limits can be pinned, rejected when inverted, and reset (#390)", async ({
@@ -51,8 +51,9 @@ test("the colorbar limits can be pinned, rejected when inverted, and reset (#390
 
   await expect(page.getByTestId("colorbar-manual")).toBeVisible();
   const range = await readLegendRange(page);
-  expect(range).not.toBeNull();
-  expect(range!.max).toBeCloseTo(pinnedMax, 6);
+  if (range === null)
+    throw new Error("the pinned limits did not reach the store");
+  expect(range.max).toBeCloseTo(pinnedMax, 6);
   await expect(page.getByTestId("colorbar-tick-0")).toContainText("≥");
   expect(await tickValue(page, 0)).toBeCloseTo(pinnedMax, 6);
 
@@ -62,7 +63,10 @@ test("the colorbar limits can be pinned, rejected when inverted, and reset (#390
   await expect(page.getByTestId("legend-error")).toContainText(
     "Max must be greater than min",
   );
-  expect((await readLegendRange(page))!.max).toBeCloseTo(pinnedMax, 6);
+  const afterReject = await readLegendRange(page);
+  if (afterReject === null)
+    throw new Error("the rejected edit dropped the applied limits");
+  expect(afterReject.max).toBeCloseTo(pinnedMax, 6);
 
   // "Auto" hands the range back to the field.
   await page.getByTestId("legend-auto").click();


### PR DESCRIPTION
## Summary

Fixes KOF-196

Adds UI controls to manually pin the colorbar range for result field visualization. When a single stress concentration dominates the field, it flattens the color map and hides secondary features. Manual limits allow users to clamp the visualization to a narrower range, bringing back detail in lower-valued regions while saturating the end colors for out-of-range values.

## Key Changes

**web/src/components/panel/LegendRangeControls.tsx** (new)
- New component with min/max input fields for manual colorbar limits
- Validates that both limits are finite numbers with min < max
- Applies on blur or Enter key; displays validation errors
- "Auto" button resets to the field's own min/max
- Inputs follow the active range when switching result types or receiving new solve results

**web/src/store/resultsSlice.ts**
- Added `LegendRange` interface (min/max pair in field units)
- Added `legendRange` state (null for auto, or user-chosen limits)
- Added `setLegendRange()` action with validation
- Clear `legendRange` when a new result arrives or result type changes

**web/src/components/viewport/ColorBar.tsx**
- Use `legendRange` if set, otherwise fall back to field's own min/max
- Display "manual range" label when limits are pinned
- Add "≥" / "≤" symbols to end ticks when clamping occurs (indicating saturation)
- Add test IDs for colorbar and individual ticks

**web/src/lib/resultField.ts**
- New `resultFraction()` function: maps a value to [0, 1] within [min, max], clamped
- Replaces inline division in colormap to handle manual limits consistently

**web/src/components/viewport/ResultsColormap.tsx**
- Use `legendRange` for color mapping if set, ensuring the mesh surface colors match the colorbar scale
- Apply `resultFraction()` to clamp node values to the manual range

**web/src/components/panel/ResultsPanel.tsx**
- Integrate `LegendRangeControls` into the Results panel under a "Legend range" section

**web/src/store/modelStore.ts**
- Export `LegendRange` type
- Clear `legendRange` on analysis load/reset

**web/tests/legend-range.spec.ts** (new)
- E2E test covering: pinning limits, rejecting inverted ranges, "Auto" reset, and automatic reset on result type change
- Verifies store state, colorbar visual indicators, and tick clamping symbols

## Notable Implementation Details

- **Validation at the boundary:** `setLegendRange()` throws on invalid input (non-finite or min ≥ max) rather than silently accepting it, ensuring the store never holds invalid state.
- **Automatic reset on context change:** Switching result type or receiving a new solve clears `legendRange` because limits are in the units of the previous field and are meaningless for a different quantity.
- **Clamping vs. wrapping:** `resultFraction()` clamps to [0, 1] so out-of-range values saturate at the end color instead of wrapping back through the map. This is essential for the colorbar to accurately annotate the clamped surface.
- **Visual feedback:** The "≥" / "≤" symbols on end ticks signal to the user that the colorbar is clamping, not showing the full field range.
- **Format precision:** The `format()` helper uses `toPrecision(4)` — short enough to edit by hand, precise enough that the limits don't visibly shift when re-applied.

## Checklist

- [x] **No silent fallbacks** — `setLegendRange()` validates and throws on invalid input; `resultFraction()` has a div-by-zero guard with a comment explaining the uniform-field case.
- [x] Every input accepted by the UI is consumed downstream — min/max inputs flow through `setLegendRange()` into the store, then into `ColorBar` and `ResultsColormap` for consistent visualization.

https://claude.ai/code/session_01QYEYKJCPRT1UPz19G9HEdF