### PR TITLE
Keep the model visible when hovering a body, and list one row per CAD body

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "examples:generate": "bun ../examples/web-examples/generate.mjs",
     "examples:generate-crane-shell": "bun ../examples/web-examples/generate-crane-shell.mjs",
     "examples:generate-plate-hole-shell": "bun ../examples/web-examples/generate-plate-hole-shell.mjs",
-    "test": "bun ../examples/validation/run.mjs && bun ../examples/validation/dof-constraint.test.mjs && bun ../examples/validation/prescribed-displacement.test.mjs && bun tests/test_wall_bracket.mjs 20.0 && bun tests/test_multibody.mjs && bun tests/test_tie.mjs && bun tests/test_face_pick.mjs && bun tests/test_edge_pick.mjs && bun tests/test_moment_load.mjs && bun tests/test_shellize_mpc.mjs && bun tests/test_midsurface_junction.mjs && bun tests/test_coupled_materials.mjs && playwright test",
+    "test": "bun ../examples/validation/run.mjs && bun ../examples/validation/dof-constraint.test.mjs && bun ../examples/validation/prescribed-displacement.test.mjs && bun tests/test_wall_bracket.mjs 20.0 && bun tests/test_multibody.mjs && bun tests/test_tie.mjs && bun tests/test_face_pick.mjs && bun tests/test_edge_pick.mjs && bun tests/test_moment_load.mjs && bun tests/test_shellize_mpc.mjs && bun tests/test_body_highlight.mjs && bun tests/test_midsurface_junction.mjs && bun tests/test_coupled_materials.mjs && playwright test",
     "test:coverage": "rm -rf .nyc_output coverage && COVERAGE=1 playwright test && bun run coverage:report",
     "coverage:report": "nyc report && bun scripts/coverage-dead-code.ts",
     "test:ui": "playwright test --ui",

--- a/web/src/components/panel/GeometryPanel.tsx
+++ b/web/src/components/panel/GeometryPanel.tsx
@@ -3,7 +3,8 @@
 
 import { useState, useRef, type ChangeEvent } from "react";
 import { useModelStore } from "../../store/modelStore";
-import type { Material } from "../../store/modelStore";
+import type { Material, Property } from "../../store/modelStore";
+import { isCadBody, shellSectionsOf } from "../../store/geometrySlice";
 import { pickMaterialColor } from "../../store/materialSlice";
 import { fmt } from "../../lib/modelDisplay";
 import { useGeometry } from "../../hooks/useGeometry";
@@ -376,6 +377,19 @@ function AutoShellSection() {
   );
 }
 
+// Tooltip for a body's name: what the last mesh made of its walls. Empty for a
+// body the mesh left solid, so only shelled bodies carry the hint.
+function sectionsTip(sections: Property[]): string | undefined {
+  if (sections.length === 0) return undefined;
+  const thicknesses = sections
+    .map((s) => (s.thickness === undefined ? "?" : `${s.thickness} mm`))
+    .join(", ");
+  return (
+    `Idealised as shells by the last mesh — ${sections.length} thickness ` +
+    `section(s): ${thicknesses}. Its walls carry this body's material.`
+  );
+}
+
 function BodiesSection() {
   const materials = useModelStore((s) => s.materials);
   const properties = useModelStore((s) => s.properties);
@@ -387,7 +401,14 @@ function BodiesSection() {
   const tieDistance = useModelStore((s) => s.tieDistance);
   const setTieDistance = useModelStore((s) => s.setTieDistance);
 
-  if (properties.length <= 1) return null;
+  // One row per CAD body. A mesh-time shell idealisation adds one PSHELL per
+  // wall thickness to `properties`; those are section properties OF a body, not
+  // bodies, and listing them put a second row — its own name, eye and material
+  // dropdown — on screen for a single physical part, and made single-body parts
+  // grow a Bodies list the moment they were shelled. The thickness they carry is
+  // surfaced on their body's row instead.
+  const bodies = properties.filter(isCadBody);
+  if (bodies.length <= 1) return null;
 
   const matColor = (materialId: number) =>
     // eslint-disable-next-line kofem/no-silent-fallback -- swatch colour for a body whose material carries none; display only, never reaches the solver
@@ -405,8 +426,9 @@ function BodiesSection() {
       <div className={styles.sectionLabel} title={BODIES_TIP}>
         Bodies
       </div>
-      {properties.map((prop) => {
+      {bodies.map((prop) => {
         const hidden = hiddenBodyIds.includes(prop.id);
+        const sections = shellSectionsOf(properties, prop.id);
         return (
           <div
             className={styles.bodyRow}
@@ -418,7 +440,9 @@ function BodiesSection() {
               className={styles.materialSwatch}
               style={{ background: matColor(prop.materialId) }}
             />
-            <span className={styles.bodyLabel}>Body {prop.id}</span>
+            <span className={styles.bodyLabel} title={sectionsTip(sections)}>
+              Body {prop.id}
+            </span>
             <button
               className={`${styles.visBtn}${hidden ? ` ${styles.visBtnOff}` : ""}`}
               data-testid={`body-visibility-${prop.id}`}

--- a/web/src/components/panel/GeometryPanel.tsx
+++ b/web/src/components/panel/GeometryPanel.tsx
@@ -386,8 +386,6 @@ function BodiesSection() {
   const toggleBodyVisibility = useModelStore((s) => s.toggleBodyVisibility);
   const tieDistance = useModelStore((s) => s.tieDistance);
   const setTieDistance = useModelStore((s) => s.setTieDistance);
-  const viewRepr = useModelStore((s) => s.viewRepr);
-  const setViewRepr = useModelStore((s) => s.setViewRepr);
 
   if (properties.length <= 1) return null;
 
@@ -395,15 +393,12 @@ function BodiesSection() {
     // eslint-disable-next-line kofem/no-silent-fallback -- swatch colour for a body whose material carries none; display only, never reaches the solver
     materials.find((mat) => mat.id === materialId)?.color ?? "#7a9bbf";
 
-  // Highlighting a body dims the others in the geometry (coloured-tessellation)
-  // view; the FEM mesh views are a single neutral colour and can't show it. So
-  // when the user reaches for a body, switch to the geometry view where the
-  // highlight is visible. (The FEM surface is suppressed there, so no overlap.)
-  const highlight = (id: number) => {
-    setHighlightBodyId(id);
-    if (viewRepr !== "geometry" && viewRepr !== "wireframe")
-      setViewRepr("geometry");
-  };
+  // Hover/focus only publishes which body is in question. Highlighting it dims
+  // the others in the geometry (coloured-tessellation) view, and the viewport
+  // falls back to that view while a highlight is live — MeshScene's call,
+  // derived from highlightBodyId. The panel must not write viewRepr itself, or
+  // a hover would permanently replace the representation the user picked and
+  // leave the mesh hidden long after the pointer moved on.
 
   return (
     <>
@@ -416,7 +411,7 @@ function BodiesSection() {
           <div
             className={styles.bodyRow}
             key={prop.id}
-            onMouseEnter={() => highlight(prop.id)}
+            onMouseEnter={() => setHighlightBodyId(prop.id)}
             onMouseLeave={() => setHighlightBodyId(null)}
           >
             <span
@@ -437,7 +432,7 @@ function BodiesSection() {
               className={styles.formSelect}
               data-testid={`body-material-${prop.id}`}
               value={prop.materialId}
-              onFocus={() => highlight(prop.id)}
+              onFocus={() => setHighlightBodyId(prop.id)}
               onBlur={() => setHighlightBodyId(null)}
               onChange={(e) =>
                 assignBodyMaterial(prop.id, Number(e.target.value))
@@ -455,7 +450,7 @@ function BodiesSection() {
               title={ELEMENT_TYPE_TIP}
               // eslint-disable-next-line kofem/no-silent-fallback -- selected option for a body left at the default discretization; absent means solid, matching how geometrySlice assigns it
               value={prop.discretization ?? "solid"}
-              onFocus={() => highlight(prop.id)}
+              onFocus={() => setHighlightBodyId(prop.id)}
               onBlur={() => setHighlightBodyId(null)}
               onChange={(e) =>
                 setBodyDiscretization(

--- a/web/src/components/viewport/FemMeshLayer.tsx
+++ b/web/src/components/viewport/FemMeshLayer.tsx
@@ -9,11 +9,16 @@ import { useMemo } from "react";
 import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useModelStore } from "../../store/modelStore";
+import type { ViewRepr } from "../../store/viewSlice";
 import { HEX_EDGES, TET_EDGES, TRI_EDGES } from "./useMeshTopology";
 import type { MeshTopology } from "./useMeshTopology";
 
 interface FemMeshLayerProps {
   topology: MeshTopology;
+  // Effective representation, as resolved by MeshScene — not necessarily the
+  // stored viewRepr: a body highlight overrides it while the pointer rests on
+  // a Bodies-panel row.
+  repr: ViewRepr;
   deformScale: number;
   showResult: boolean;
   onFacePick?: (e: ThreeEvent<MouseEvent>) => void;
@@ -21,12 +26,12 @@ interface FemMeshLayerProps {
 
 export function FemMeshLayer({
   topology,
+  repr,
   deformScale,
   showResult,
   onFacePick,
 }: FemMeshLayerProps) {
   const result = useModelStore((s) => s.result);
-  const viewRepr = useModelStore((s) => s.viewRepr);
   const showUndeformedOverlay = useModelStore((s) => s.showUndeformedOverlay);
 
   const {
@@ -224,15 +229,15 @@ export function FemMeshLayer({
 
   // Edge overlays per representation: Geometry → none, Surface → boundary edges,
   // Volume → every element edge, Wireframe → every element edge with no fill.
-  const showSolid = viewRepr !== "wireframe";
-  const showSurfaceEdges = viewRepr === "surface";
-  const showAllEdges = viewRepr === "volume" || viewRepr === "wireframe";
+  const showSolid = repr !== "wireframe";
+  const showSurfaceEdges = repr === "surface";
+  const showAllEdges = repr === "volume" || repr === "wireframe";
 
   // In the Geometry representation the CAD tessellation (GeometryLayer) stands
   // in for the part, so the FEM boundary surface must not also draw — otherwise
   // the two overlap and z-fight. The edge overlays are already representation-
   // gated below; this gates the solid fill to match.
-  const showFemSurface = viewRepr !== "geometry";
+  const showFemSurface = repr !== "geometry";
 
   return (
     <group>

--- a/web/src/components/viewport/GeometryLayer.tsx
+++ b/web/src/components/viewport/GeometryLayer.tsx
@@ -14,6 +14,11 @@ import { useModelStore } from "../../store/modelStore";
 
 interface GeometryLayerProps {
   wireframe: boolean;
+  // CAD body to highlight, already resolved against this tessellation by
+  // MeshScene (resolveHighlightedBody). null = highlight nothing, which is not
+  // the same as "dim everything": an id no body carries must leave the assembly
+  // fully lit, or the model reads as gone.
+  highlightBodyId: number | null;
 }
 
 // Fallback body colour when a body has no material assignment yet (or an
@@ -28,11 +33,13 @@ interface BodyGeometry {
   normals: Float32Array;
 }
 
-export function GeometryLayer({ wireframe }: GeometryLayerProps) {
+export function GeometryLayer({
+  wireframe,
+  highlightBodyId,
+}: GeometryLayerProps) {
   const stepSurface = useModelStore((s) => s.stepSurface);
   const properties = useModelStore((s) => s.properties);
   const materials = useModelStore((s) => s.materials);
-  const highlightBodyId = useModelStore((s) => s.highlightBodyId);
   const hiddenBodyIds = useModelStore((s) => s.hiddenBodyIds);
 
   // Build one flat position/normal buffer per body. Rebuilt only when the
@@ -118,7 +125,7 @@ export function GeometryLayer({ wireframe }: GeometryLayerProps) {
         if (hiddenBodyIds.includes(bodyId)) return null;
         // When a body is being assigned (highlightBodyId set), every other body
         // fades back so the one in question reads clearly against the assembly.
-        const dimmed = highlightBodyId != null && highlightBodyId !== bodyId;
+        const dimmed = highlightBodyId !== null && highlightBodyId !== bodyId;
         return (
           <mesh key={bodyId}>
             <bufferGeometry>

--- a/web/src/components/viewport/MeshScene.tsx
+++ b/web/src/components/viewport/MeshScene.tsx
@@ -11,6 +11,7 @@
 
 import { useMemo } from "react";
 import { useModelStore } from "../../store/modelStore";
+import { resolveHighlightedBody } from "../../lib/bodyHighlight";
 import { useMeshTopology } from "./useMeshTopology";
 import { useFacePick } from "./useFacePick";
 import { GeometryLayer } from "./GeometryLayer";
@@ -27,6 +28,8 @@ export function MeshScene() {
   const stepSurface = useModelStore((s) => s.stepSurface);
   const deformScaleFactor = useModelStore((s) => s.deformScale);
   const viewRepr = useModelStore((s) => s.viewRepr);
+  const highlightBodyId = useModelStore((s) => s.highlightBodyId);
+  const properties = useModelStore((s) => s.properties);
 
   const topology = useMeshTopology();
   const { modelSize, nodeMap } = topology;
@@ -71,16 +74,32 @@ export function MeshScene() {
   // even though the solved `result` is still held in the store.
   const showResult = !!result && mode === "results";
 
+  // Hovering a row in the Bodies panel highlights that body, which only the
+  // coloured CAD tessellation can show — the FEM surface is one neutral colour.
+  // So a live highlight overrides the representation for as long as the pointer
+  // rests on the row. The override is derived, never written to the store: the
+  // user's chosen representation is still what the status bar shows and what
+  // comes back the instant the highlight clears. A body the tessellation cannot
+  // draw resolves to null and overrides nothing (issue: hovering a derived
+  // PSHELL row dimmed every body and hid the mesh with it).
+  const highlightBody = resolveHighlightedBody(
+    highlightBodyId,
+    properties,
+    stepSurface,
+  );
+  const repr = highlightBody !== null && !showResult ? "geometry" : viewRepr;
+
   // The CAD tessellation stands in for the geometry representation (and is the
   // only thing to show before a mesh exists). It must never paint over a solved
   // result, so it is suppressed in results mode.
   const showStepSurface =
-    !showResult && (viewRepr === "geometry" || nodes.length === 0);
+    !showResult && (repr === "geometry" || nodes.length === 0);
 
   return (
     <group>
       <FemMeshLayer
         topology={topology}
+        repr={repr}
         deformScale={deformScale}
         showResult={showResult}
         onFacePick={onFacePick}
@@ -94,7 +113,10 @@ export function MeshScene() {
       )}
       <BoundaryConditionLayer topology={topology} showResult={showResult} />
       {showStepSurface && (
-        <GeometryLayer wireframe={viewRepr === "wireframe"} />
+        <GeometryLayer
+          wireframe={viewRepr === "wireframe"}
+          highlightBodyId={highlightBody}
+        />
       )}
     </group>
   );

--- a/web/src/components/viewport/useMeshTopology.ts
+++ b/web/src/components/viewport/useMeshTopology.ts
@@ -186,13 +186,26 @@ export function useMeshTopology(): MeshTopology {
   // mesh here, so the eye hides a body in the FEM surface / volume views just
   // as it does in the geometry tessellation. Nodes and modelSize stay whole
   // (fit-to-view and the deformed-result node count must not change).
+  //
+  // A shell-idealised body owns no elements of its own — its walls are PSHELLs
+  // derived from it — so hiding it has to reach those too, or the eye would
+  // leave the body's shell facets floating on screen.
   const hiddenBodyIds = useModelStore((s) => s.hiddenBodyIds);
+  const properties = useModelStore((s) => s.properties);
+  const hiddenPropertyIds = useMemo(() => {
+    if (hiddenBodyIds.length === 0) return null;
+    const hidden = new Set(hiddenBodyIds);
+    for (const prop of properties)
+      if (prop.sourceBodyId !== undefined && hidden.has(prop.sourceBodyId))
+        hidden.add(prop.id);
+    return hidden;
+  }, [hiddenBodyIds, properties]);
   const visibleElements = useMemo(
     () =>
-      hiddenBodyIds.length === 0
+      hiddenPropertyIds === null
         ? elements
-        : elements.filter((e) => !hiddenBodyIds.includes(e.propertyId)),
-    [elements, hiddenBodyIds],
+        : elements.filter((e) => !hiddenPropertyIds.has(e.propertyId)),
+    [elements, hiddenPropertyIds],
   );
 
   const hexElements = useMemo(

--- a/web/src/hooks/useMesh.ts
+++ b/web/src/hooks/useMesh.ts
@@ -4,6 +4,7 @@
 import { useState } from "react";
 import { useModelStore } from "../store/modelStore";
 import type { Node, Element, Property } from "../store/modelStore";
+import { isCadBody } from "../store/geometrySlice";
 import { sendToWorker, resetWorker } from "../workers/sharedWorker";
 import { useWorkerLogs } from "./useWorkerLogs";
 
@@ -58,9 +59,12 @@ export function useMesh() {
         minElementSize,
         // Bodies the user (or detectShellBodies at import) marked Shell, plus the
         // property table: meshing idealises their thin walls to a mid-surface
-        // shell mesh and returns the mixed CTRIA3 + CTETRA model (#397).
+        // shell mesh and returns the mixed CTRIA3 + CTETRA model (#397). Only CAD
+        // bodies can be idealised — the PSHELLs a previous mesh derived are
+        // shells already, and passing their ids would send the thin-wall
+        // extraction hunting for bodies the fresh mesh has never heard of.
         shellBodyIds: properties
-          .filter((p) => p.discretization === "shell")
+          .filter((p) => isCadBody(p) && p.discretization === "shell")
           .map((p) => p.id),
         properties,
       });

--- a/web/src/lib/bodyHighlight.ts
+++ b/web/src/lib/bodyHighlight.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Resolving a hovered Bodies-panel row to the CAD body the geometry view can
+// actually highlight.
+//
+// The rows are PROPERTIES, and after a mesh-time shell idealisation not every
+// property is a CAD body: buildMeshTimeShellModel emits one PSHELL per wall
+// thickness, each with a fresh id the STEP tessellation knows nothing about.
+// Highlighting is expressed as "dim every body except this one", so an id no
+// tessellated body carries dims the whole assembly to 15 % opacity — the model
+// appears to vanish. A PSHELL therefore resolves back to the CAD body it was
+// idealised from (Property.sourceBodyId), and anything still unmatched — a
+// mesh with no CAD geometry behind it, e.g. an imported .vtu — resolves to
+// nothing, leaving the viewport as it was.
+
+import type { Property, StepTessellation } from "../store/geometrySlice";
+
+// Body ids the tessellation actually draws.
+export function tessellationBodyIds(
+  tessellation: StepTessellation | null,
+): Set<number> {
+  if (!tessellation || tessellation.triangles.length === 0) return new Set();
+  // Analyses saved before per-body ids carry the whole tessellation as body 1
+  // (see StepTessellation.bodyIds).
+  if (!tessellation.bodyIds) return new Set([1]);
+  return new Set(tessellation.bodyIds);
+}
+
+// The CAD body to highlight for a hovered property id, or null when the
+// geometry view has nothing to highlight for it.
+export function resolveHighlightedBody(
+  highlightBodyId: number | null,
+  properties: Property[],
+  tessellation: StepTessellation | null,
+): number | null {
+  if (highlightBodyId === null) return null;
+  const drawn = tessellationBodyIds(tessellation);
+  if (drawn.size === 0) return null;
+  // sourceBodyId marks a derived PSHELL; a property without one IS a CAD body,
+  // so its own id already is the body id.
+  const prop = properties.find((p) => p.id === highlightBodyId);
+  const bodyId = prop?.sourceBodyId ?? highlightBodyId;
+  return drawn.has(bodyId) ? bodyId : null;
+}

--- a/web/src/store/geometrySlice.ts
+++ b/web/src/store/geometrySlice.ts
@@ -42,6 +42,11 @@ export interface Property {
   materialId: number;
   thickness?: number;
   discretization?: BodyDiscretization;
+  // Set only on the PSHELL properties the mesh-time shell idealisation derives:
+  // the id of the CAD body whose thin walls they replace. Absent on the CAD
+  // bodies themselves, whose own id already is the body id. The geometry view
+  // needs it because a derived PSHELL has no tessellation of its own.
+  sourceBodyId?: number;
 }
 
 export interface Element {

--- a/web/src/store/geometrySlice.ts
+++ b/web/src/store/geometrySlice.ts
@@ -49,6 +49,23 @@ export interface Property {
   sourceBodyId?: number;
 }
 
+// A property the user owns: one CAD body of the imported file. Everything else
+// in `properties` is a section property the mesh derived from such a body — one
+// PSHELL per wall thickness — which is part of the discretisation, not a body.
+// The Bodies list, the shell-body selection and thin-wall detection all speak
+// in CAD bodies; only the solver and the mesh see the derived properties.
+export function isCadBody(prop: Property): boolean {
+  return prop.sourceBodyId === undefined;
+}
+
+// The section properties the mesh derived from `bodyId`, in id order.
+export function shellSectionsOf(
+  properties: Property[],
+  bodyId: number,
+): Property[] {
+  return properties.filter((p) => p.sourceBodyId === bodyId);
+}
+
 export interface Element {
   id: number;
   type: ElementType;
@@ -191,10 +208,16 @@ export const createGeometrySlice: SliceCreator<GeometrySlice> = (set) => ({
   applyShellDetection: (shellBodyIds) =>
     set((s) => {
       const shell = new Set(shellBodyIds);
-      for (const prop of s.properties)
+      // Detection runs over the CAD bodies of the tessellation, so only they can
+      // be marked. A PSHELL the mesh derived is a shell by construction; letting
+      // this loop stamp it "solid" left a thickness-carrying shell property
+      // labelled solid, which then dropped out of the next mesh's shell bodies.
+      for (const prop of s.properties) {
+        if (!isCadBody(prop)) continue;
         prop.discretization = shell.has(prop.id)
           ? ("shell" as BodyDiscretization)
           : ("solid" as BodyDiscretization);
+      }
     }),
   setAutoShell: (enabled) =>
     set((s) => {
@@ -229,6 +252,12 @@ export const createGeometrySlice: SliceCreator<GeometrySlice> = (set) => ({
           `Cannot assign material: material ${materialId} does not exist`,
         );
       prop.materialId = materialId;
+      // A shell-idealised body owns no elements after meshing — its walls became
+      // PSHELLs, and the solve resolves their material through those. Assigning
+      // to the body alone would silently leave the shells on the old material.
+      for (const section of s.properties)
+        if (section.sourceBodyId === propertyId)
+          section.materialId = materialId;
     }),
   setStepBytes: (bytes) =>
     set((s) => {

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -448,14 +448,18 @@ function buildMeshTimeShellModel(
       z: model.pool[3 * i + 2],
     });
 
-  // Properties: solid bodies keep their own ids (materials stay assigned); one
+  // Properties: the CAD bodies keep their own ids (materials stay assigned); one
   // PSHELL per distinct wall thickness, inheriting the shelled body's material.
-  const nextId = properties.reduce((mx, p) => Math.max(mx, p.id), 0) + 1;
-  const shellProp = properties.find((p) => p.id === shells.shellBody);
+  // The PSHELLs of an earlier mesh are dropped first — they describe walls that
+  // no longer exist, and carrying them over made every re-mesh append another
+  // dead body to the list.
+  const cadBodies = properties.filter((p) => p.sourceBodyId === undefined);
+  const nextId = cadBodies.reduce((mx, p) => Math.max(mx, p.id), 0) + 1;
+  const shellProp = cadBodies.find((p) => p.id === shells.shellBody);
   const shellMaterialId = shellProp ? shellProp.materialId : 1;
   const thkKey = (t: number) => Number(t.toFixed(6));
   const propOfThk = new Map<number, number>();
-  const outProperties: Property[] = properties.map((p) => ({ ...p }));
+  const outProperties: Property[] = cadBodies.map((p) => ({ ...p }));
   for (const t of model.thicknesses) {
     const key = thkKey(t);
     if (propOfThk.has(key)) continue;

--- a/web/src/workers/solver.worker.ts
+++ b/web/src/workers/solver.worker.ts
@@ -128,6 +128,9 @@ interface Property {
   // thin walls as shells, "solid" keeps it as tets. Undefined on legacy models
   // (no per-body choice) — the auto-shell path then auto-detects thin bodies.
   discretization?: "shell" | "solid";
+  // On a mesh-time PSHELL: the CAD body whose thin walls it replaces. Lets the
+  // viewport map the derived property back to a body that has a tessellation.
+  sourceBodyId?: number;
 }
 interface Constraint {
   nodeId: number;
@@ -463,6 +466,7 @@ function buildMeshTimeShellModel(
       materialId: shellMaterialId,
       thickness: key,
       discretization: "shell",
+      sourceBodyId: shells.shellBody,
     });
   }
 

--- a/web/tests/multibody-materials.spec.ts
+++ b/web/tests/multibody-materials.spec.ts
@@ -14,6 +14,8 @@ interface Store {
     properties: {
       id: number;
       materialId: number;
+      thickness?: number;
+      discretization?: string;
       sourceBodyId?: number;
     }[];
     materials: { id: number; name: string; color: string }[];
@@ -28,6 +30,39 @@ const store = (page: import("@playwright/test").Page) =>
   page.evaluate(() =>
     (window as unknown as { __kofemStore: Store }).__kofemStore.getState(),
   );
+
+// Import the fin assembly and mesh it. Auto-shell idealises the 2 mm fin, so the
+// meshed model carries a derived PSHELL alongside the two CAD bodies.
+async function importAndMeshFin(page: import("@playwright/test").Page) {
+  await importStep(page, FIN_TWO_PARTS);
+  await meshOnce(page);
+}
+
+// applyMeshResult bumps fitViewTrigger, so waiting for it to advance pins the
+// moment a mesh lands — a re-mesh leaves the node count unchanged, and polling
+// "nodes exist" would pass on the mesh that is being replaced.
+const meshGeneration = (page: import("@playwright/test").Page) =>
+  page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __kofemStore: { getState(): { fitViewTrigger: number } };
+        }
+      ).__kofemStore.getState().fitViewTrigger,
+  );
+
+async function meshOnce(page: import("@playwright/test").Page) {
+  const before = await meshGeneration(page);
+  await page
+    .getByRole("button")
+    // "Mesh STEP volume" before the first mesh, "Re-mesh STEP volume" after.
+    .filter({ hasText: /(re-)?mesh STEP volume/i })
+    .click();
+  await expect
+    .poll(async () => meshGeneration(page), { timeout: 180_000 })
+    .toBeGreaterThan(before);
+  expect((await store(page)).nodes.length).toBeGreaterThan(0);
+}
 
 // Fraction of the viewport covered by opaquely drawn geometry. The WebGL canvas
 // clears to transparent (the light background is CSS), so alpha alone separates
@@ -100,15 +135,7 @@ test("hovering a body never blanks the viewport or changes the representation", 
   page,
 }) => {
   test.setTimeout(240_000);
-  await importStep(page, FIN_TWO_PARTS);
-
-  await page
-    .getByRole("button")
-    .filter({ hasText: "Mesh STEP volume" })
-    .click();
-  await expect
-    .poll(async () => (await store(page)).nodes.length, { timeout: 180_000 })
-    .toBeGreaterThan(0);
+  await importAndMeshFin(page);
 
   // Auto-shell replaced the fin's tets with a PSHELL carrying a fresh id; it
   // points back at the CAD body it was idealised from, which is what the
@@ -127,7 +154,7 @@ test("hovering a body never blanks the viewport or changes the representation", 
 
   const rows = page.locator('[data-testid^="body-material-"]');
   const rowCount = await rows.count();
-  expect(rowCount).toBe(meshed.properties.length);
+  expect(rowCount).toBe(2);
 
   for (let i = 0; i < rowCount; i++) {
     await rows.nth(i).locator("xpath=ancestor::div[1]").hover();
@@ -151,6 +178,89 @@ test("hovering a body never blanks the viewport or changes the representation", 
     .poll(async () => drawnFraction(page))
     .toBeGreaterThan(baseline * 0.95);
   expect((await store(page)).viewRepr).toBe(repr);
+});
+
+// The Bodies list is the CAD bodies of the imported file. Meshing a thin-walled
+// body replaces its tets with one PSHELL per wall thickness, and those derived
+// properties used to be listed as bodies of their own: the fin assembly grew a
+// third row for a part that has two, with a name, an eye and a material
+// dropdown that no longer reached the elements the body had become.
+test("a shell-idealised body stays one row that still owns its walls", async ({
+  page,
+}) => {
+  test.setTimeout(300_000);
+  await importAndMeshFin(page);
+
+  const meshed = await store(page);
+  const cadBodies = meshed.properties.filter(
+    (p) => p.sourceBodyId === undefined,
+  );
+  const sections = meshed.properties.filter((p) => p.sourceBodyId === 2);
+  expect(cadBodies.map((p) => p.id)).toEqual([1, 2]);
+  expect(sections).toHaveLength(1);
+  expect(sections[0].thickness).toBe(2);
+
+  // One row per CAD body — the PSHELL is a section of body 2, not a third body.
+  await expect(page.locator('[data-testid^="body-material-"]')).toHaveCount(2);
+  await expect(page.getByTestId(`body-material-${sections[0].id}`)).toHaveCount(
+    0,
+  );
+
+  // The material dropdown on the shelled body reaches the walls it became: the
+  // shell elements resolve their material through the derived PSHELL.
+  await page.getByTestId("add-material").click();
+  const colorInput = page.getByTestId("material-color");
+  await colorInput
+    .locator("xpath=ancestor::div[contains(@class,'inlineForm')]")
+    .getByRole("button", { name: "Save" })
+    .click();
+  const withTwo = await store(page);
+  expect(withTwo.materials).toHaveLength(2);
+  const aluminium = withTwo.materials[1].id;
+
+  await page.getByTestId("body-material-2").selectOption(String(aluminium));
+  const reassigned = await store(page);
+  expect(reassigned.properties.find((p) => p.id === 2)?.materialId).toBe(
+    aluminium,
+  );
+  expect(
+    reassigned.properties.find((p) => p.id === sections[0].id)?.materialId,
+  ).toBe(aluminium);
+
+  // Hiding the shelled body takes its shell facets with it — the body owns no
+  // elements of its own, so an eye that only matched its id hid nothing.
+  const shown = await drawnFraction(page);
+  await page.getByTestId("body-visibility-2").click();
+  await expect.poll(async () => drawnFraction(page)).toBeLessThan(shown * 0.95);
+  await page.getByTestId("body-visibility-2").click();
+  await expect.poll(async () => (await store(page)).hiddenBodyIds).toEqual([]);
+
+  // Re-meshing rebuilds the sections instead of appending a second set: the
+  // walls of the previous mesh no longer exist.
+  await meshOnce(page);
+  const remeshed = await store(page);
+  expect(
+    remeshed.properties.filter((p) => p.sourceBodyId === undefined),
+  ).toHaveLength(2);
+  expect(
+    remeshed.properties.filter((p) => p.sourceBodyId !== undefined),
+  ).toHaveLength(1);
+  await expect(page.locator('[data-testid^="body-material-"]')).toHaveCount(2);
+
+  // Thin-wall detection speaks in CAD bodies. Re-running it must not stamp the
+  // derived PSHELL "solid" — a shell property labelled solid drops out of the
+  // next mesh's shell bodies and quietly un-idealises the part.
+  const autoShell = page.getByTestId("auto-shell-detection");
+  await autoShell.uncheck();
+  await autoShell.check();
+  const redetected = await store(page);
+  expect(redetected.properties.find((p) => p.id === 2)?.discretization).toBe(
+    "shell",
+  );
+  for (const section of redetected.properties.filter(
+    (p) => p.sourceBodyId !== undefined,
+  ))
+    expect(section.discretization).toBe("shell");
 });
 
 test("the bonded tie distance is editable for multibody assemblies", async ({

--- a/web/tests/multibody-materials.spec.ts
+++ b/web/tests/multibody-materials.spec.ts
@@ -11,11 +11,17 @@ import { importStep } from "./fixtures/app";
 
 interface Store {
   getState(): {
-    properties: { id: number; materialId: number }[];
+    properties: {
+      id: number;
+      materialId: number;
+      sourceBodyId?: number;
+    }[];
     materials: { id: number; name: string; color: string }[];
     highlightBodyId: number | null;
     hiddenBodyIds: number[];
     tieDistance: number;
+    viewRepr: string;
+    nodes: unknown[];
   };
 }
 const store = (page: import("@playwright/test").Page) =>
@@ -23,8 +29,33 @@ const store = (page: import("@playwright/test").Page) =>
     (window as unknown as { __kofemStore: Store }).__kofemStore.getState(),
   );
 
+// Fraction of the viewport covered by opaquely drawn geometry. The WebGL canvas
+// clears to transparent (the light background is CSS), so alpha alone separates
+// what is drawn from what is not — and a body dimmed to DIMMED_OPACITY lands far
+// below the 0.5 cutoff. preserveDrawingBuffer is on (Viewport.tsx), so the
+// buffer is still readable after the frame.
+const drawnFraction = (page: import("@playwright/test").Page) =>
+  page.evaluate(() => {
+    const canvas = document.querySelector("canvas");
+    if (!canvas) throw new Error("viewport canvas not mounted");
+    const copy = document.createElement("canvas");
+    copy.width = canvas.width;
+    copy.height = canvas.height;
+    const ctx = copy.getContext("2d");
+    if (!ctx) throw new Error("2d context unavailable for canvas readback");
+    ctx.drawImage(canvas, 0, 0);
+    const { data } = ctx.getImageData(0, 0, copy.width, copy.height);
+    let opaque = 0;
+    for (let i = 3; i < data.length; i += 4) if (data[i] > 128) opaque++;
+    return opaque / (copy.width * copy.height);
+  });
+
 // Playwright runs from web/; test_files sits one level up (see screenshot.spec).
 const TWO_BOXES = path.resolve("..", "test_files", "two_boxes.stp");
+// A solid base plus a 2 mm fin: auto-shell idealises the fin at mesh time, so
+// the meshed model carries a derived PSHELL property alongside the two CAD
+// bodies — the case the highlight has to resolve back to a tessellated body.
+const FIN_TWO_PARTS = path.resolve("..", "test_files", "fin_two_parts.step");
 
 test("two-body assembly lists per-body materials with colours", async ({
   page,
@@ -57,6 +88,69 @@ test("hovering a body highlights it; the eye hides it", async ({ page }) => {
   await expect.poll(async () => (await store(page)).hiddenBodyIds).toEqual([2]);
   await page.getByTestId("body-visibility-2").click();
   await expect.poll(async () => (await store(page)).hiddenBodyIds).toEqual([]);
+});
+
+// Hovering a body row used to make the whole model disappear on an assembly
+// with a shell-idealised body. Two faults compounded: the panel wrote viewRepr
+// straight to the store, so the first hover permanently swapped the mesh for
+// the CAD tessellation; and the highlight ("dim every body except this one")
+// was handed the id of the derived PSHELL, which no tessellated body carries,
+// so every body dimmed to DIMMED_OPACITY and nothing was left to look at.
+test("hovering a body never blanks the viewport or changes the representation", async ({
+  page,
+}) => {
+  test.setTimeout(240_000);
+  await importStep(page, FIN_TWO_PARTS);
+
+  await page
+    .getByRole("button")
+    .filter({ hasText: "Mesh STEP volume" })
+    .click();
+  await expect
+    .poll(async () => (await store(page)).nodes.length, { timeout: 180_000 })
+    .toBeGreaterThan(0);
+
+  // Auto-shell replaced the fin's tets with a PSHELL carrying a fresh id; it
+  // points back at the CAD body it was idealised from, which is what the
+  // geometry view can actually highlight.
+  const meshed = await store(page);
+  const shellProp = meshed.properties.find((p) => p.sourceBodyId !== undefined);
+  if (!shellProp)
+    throw new Error(
+      `no derived PSHELL property after meshing the fin assembly: ${JSON.stringify(meshed.properties)}`,
+    );
+  expect(shellProp.sourceBodyId).toBe(2);
+
+  const repr = meshed.viewRepr;
+  const baseline = await drawnFraction(page);
+  expect(baseline).toBeGreaterThan(0.05);
+
+  const rows = page.locator('[data-testid^="body-material-"]');
+  const rowCount = await rows.count();
+  expect(rowCount).toBe(meshed.properties.length);
+
+  for (let i = 0; i < rowCount; i++) {
+    await rows.nth(i).locator("xpath=ancestor::div[1]").hover();
+    await expect
+      .poll(async () => (await store(page)).highlightBodyId)
+      .not.toBeNull();
+    // The highlight dims the bodies around the hovered one, so the drawn area
+    // shrinks — but the model stays plainly on screen. Before the fix the
+    // PSHELL row left under 2 % of the baseline: an empty viewport.
+    await expect
+      .poll(async () => drawnFraction(page))
+      .toBeGreaterThan(baseline * 0.2);
+    // The highlight is a transient override, never a stored preference.
+    expect((await store(page)).viewRepr).toBe(repr);
+  }
+
+  // Pointer off the list → the representation and the full model come back.
+  await page.mouse.move(0, 0);
+  await expect.poll(async () => (await store(page)).highlightBodyId).toBeNull();
+  await expect
+    .poll(async () => drawnFraction(page))
+    .toBeGreaterThan(baseline * 0.95);
+  expect((await store(page)).viewRepr).toBe(repr);
 });
 
 test("the bonded tie distance is editable for multibody assemblies", async ({

--- a/web/tests/test_body_highlight.mjs
+++ b/web/tests/test_body_highlight.mjs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Michael Kofler
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Unit tests for src/lib/bodyHighlight.ts — resolving a hovered Bodies-panel
+// row to the CAD body the geometry view can highlight.
+//
+// The viewport expresses a highlight as "dim every body except this one", so an
+// id that no tessellated body carries fades the whole assembly to 15 % opacity
+// and the model reads as gone. The resolver is what keeps that from happening:
+// a mesh-time PSHELL resolves back to the body it was idealised from, and
+// anything still unmatched resolves to null (highlight nothing) rather than to
+// an id nobody has.
+//
+// Run:  bun tests/test_body_highlight.mjs
+
+import {
+  resolveHighlightedBody,
+  tessellationBodyIds,
+} from "../src/lib/bodyHighlight.ts";
+
+let failures = 0;
+function check(name, cond, detail = "") {
+  if (cond) {
+    console.log(`  [PASS] ${name}`);
+  } else {
+    failures++;
+    console.log(`  [FAIL] ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+// Two CAD bodies; body 2 is thin-walled and was idealised at mesh time, which
+// appended PSHELL id 3 (the fin_two_parts.step shape of the model).
+const tessellation = {
+  points: [
+    [0, 0, 0],
+    [1, 0, 0],
+    [0, 1, 0],
+  ],
+  triangles: [
+    [0, 1, 2],
+    [0, 1, 2],
+  ],
+  bodyIds: [1, 2],
+};
+const properties = [
+  { id: 1, materialId: 1, discretization: "solid" },
+  { id: 2, materialId: 1, discretization: "shell" },
+  {
+    id: 3,
+    materialId: 1,
+    thickness: 2,
+    discretization: "shell",
+    sourceBodyId: 2,
+  },
+];
+
+check(
+  "tessellation body ids come from bodyIds",
+  [...tessellationBodyIds(tessellation)].sort().join(",") === "1,2",
+);
+check(
+  "a tessellation saved before per-body ids is all body 1",
+  [...tessellationBodyIds({ ...tessellation, bodyIds: undefined })].join(
+    ",",
+  ) === "1",
+);
+check("no tessellation → no bodies", tessellationBodyIds(null).size === 0);
+
+check(
+  "a CAD body resolves to itself",
+  resolveHighlightedBody(1, properties, tessellation) === 1,
+);
+check(
+  "a derived PSHELL resolves to the body it was idealised from",
+  resolveHighlightedBody(3, properties, tessellation) === 2,
+);
+check(
+  "nothing hovered → nothing highlighted",
+  resolveHighlightedBody(null, properties, tessellation) === null,
+);
+check(
+  "a property the tessellation has no body for highlights nothing",
+  resolveHighlightedBody(
+    3,
+    [...properties.slice(0, 2), { id: 3, materialId: 1, thickness: 2 }],
+    tessellation,
+  ) === null,
+  "without sourceBodyId the PSHELL id must not be treated as a body id",
+);
+check(
+  "a mesh with no CAD geometry behind it highlights nothing",
+  resolveHighlightedBody(1, properties, null) === null,
+);
+check(
+  "an empty tessellation highlights nothing",
+  resolveHighlightedBody(1, properties, {
+    ...tessellation,
+    triangles: [],
+    bodyIds: [],
+  }) === null,
+);
+
+console.log(
+  failures === 0 ? "\nAll checks passed" : `\n${failures} check(s) failed`,
+);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

In a multibody assembly, hovering a row in the Bodies panel — to read a body's material, or to reach its material / element-type dropdown — could empty the viewport of both the mesh and the geometry. Reproduced on `test_files/fin_two_parts.step` (solid base + 2 mm fin, so auto-shell applies): hovering the third row left **0.26 %** of the viewport drawn, i.e. the axis gizmo and nothing else.

Chasing it surfaced a second, related problem: the Bodies list was showing a row for something that is not a body. Meshing a thin-walled body replaces its tets with one PSHELL per wall thickness, those derived properties were appended to `properties`, and the panel listed everything in it — so a two-body assembly grew a third row whose name is not a body and whose dropdowns no longer reached the mesh.

Two commits, one per problem.

## Key Changes

### web — hover no longer blanks the viewport (`a4b5796`)

- **`components/panel/GeometryPanel.tsx`** — stop writing `viewRepr` to the store on hover. The panel switched to the geometry view so the highlight would be visible, but nothing ever wrote it back, so the first hover permanently replaced the representation the user had chosen and left the FEM mesh hidden.
- **`lib/bodyHighlight.ts`** (new) — `resolveHighlightedBody()` maps a hovered property to a body the tessellation actually draws. The highlight is drawn as "dim every body *except* this one", so an id no body carries dimmed the whole assembly to `DIMMED_OPACITY`.
- **`store/geometrySlice.ts`** — `Property.sourceBodyId`, set on a derived PSHELL, naming the CAD body it was idealised from; **`workers/solver.worker.ts`** sets it in `buildMeshTimeShellModel`. Hovering a shell section now highlights the body it came from.
- **`components/viewport/MeshScene.tsx`** — the representation override is derived here and lives exactly as long as the highlight, so the status bar keeps showing the user's choice and the mesh returns on mouse-out. `FemMeshLayer` takes `repr` as a prop and `GeometryLayer` takes the resolved body id, so both agree on one computation.

### web — one row per CAD body (`c0330de`)

- **`store/geometrySlice.ts`** — `isCadBody()` / `shellSectionsOf()` draw the line between a CAD body and a section property derived from one. `applyShellDetection` only marks CAD bodies; `assignBodyMaterial` propagates to a body's sections.
- **`components/panel/GeometryPanel.tsx`** — the Bodies list shows CAD bodies only, with wall thicknesses in the row's tooltip (`sectionsTip`).
- **`components/viewport/useMeshTopology.ts`** — hiding a body hides the PSHELLs derived from it.
- **`workers/solver.worker.ts`** — rebuild the section properties from the CAD bodies instead of appending to the previous mesh's; **`hooks/useMesh.ts`** sends only CAD bodies as `shellBodyIds`.

### tests

- **`tests/test_body_highlight.mjs`** (new, wired into `bun run test`) — unit coverage for the resolver.
- **`tests/multibody-materials.spec.ts`** — two end-to-end tests on the fin assembly, reading the canvas back to measure how much of the model is actually drawn.

## Notable Implementation Details

**The representation override is derived, not stored.** `MeshScene` computes `repr = highlightBody !== null && !showResult ? "geometry" : viewRepr`. Keeping it out of the store is what makes the hover transient — there is no restore path to get wrong, the status bar never lies about which representation is selected, and `viewRepr` stays a user preference. Results mode is excluded, so a hover can no longer strip the edges off a solved result.

**An unresolvable highlight highlights nothing, rather than everything-but-nothing.** `resolveHighlightedBody` returns `null` for a property the tessellation has no body for — including a mesh with no CAD geometry behind it, e.g. an imported `.vtu`, where the old code would have dimmed the entire model on any hover.

**Four bugs fell out of the CAD-body/section distinction**, all of them live before this PR:

- Assigning a material to a shell-idealised body was a **no-op after meshing** — the shell elements resolve their material through the derived PSHELL, and only the derived row's dropdown reached them.
- The **eye hid nothing** on a shell-idealised body: visibility filters elements by `propertyId`, and the body owns none once its walls became PSHELLs.
- **Every re-mesh appended a dead body.** A second mesh of the fin assembly produced properties `[1, 2, 3, 4]` with 3 orphaned, and fed phantom ids into the next mesh's `shellBodyIds`.
- **Thin-wall detection stamped derived PSHELLs `"solid"`**, leaving a thickness-carrying shell property labelled solid, which then dropped out of the following mesh's shell bodies and quietly un-idealised the part.

**A knock-on worth noting for review:** a single-body thin part no longer grows a Bodies list after meshing. Shelling it made `properties.length` 2, which passed the `<= 1` guard — contradicting the documented "hidden for single-body parts, where the sole material applies to the whole part."

**Measuring "is the model on screen".** The WebGL canvas clears to transparent (the light background is CSS) and `preserveDrawingBuffer` is on, so alpha alone separates drawn from not-drawn, and a body at `DIMMED_OPACITY` (0.15) lands far below a 0.5 cutoff. The test asserts the drawn area stays above a fifth of the un-hovered baseline; before the fix the shell row measured 1.2 % of it.

**No C++ changed**, so the committed `web/src/wasm/pkg/*.wasm` is untouched.

## Checklist

- [x] **No silent fallbacks** — the one `??` added (`prop?.sourceBodyId ?? highlightBodyId` in `bodyHighlight.ts`) is not a default: a property without `sourceBodyId` *is* a CAD body, so its own id is the body id. It carries a comment saying so. The unresolvable case raises no error because "nothing to highlight" is a legitimate state, and it is returned explicitly as `null` rather than papered over.
- [x] Every input accepted by the UI or an API is actually consumed downstream — this PR closes two cases where that had stopped being true: the material dropdown and the eye control on a shell-idealised body.

## Verification

Locally green: 69 Playwright tests, the validation suite, all ten `.mjs` tests (including `test_coupled_materials` and `test_shellize_mpc`, which cover the worker paths touched here), `bun run typecheck` / `lint` / `format:check`, `cargo fmt` / `clippy`, and `scripts/clang-tidy.sh`.