### PR TITLE
Update canonical URLs and add SEO metadata (robots.txt, sitemap)

### DIFF
--- a/web/examples/index.html
+++ b/web/examples/index.html
@@ -14,7 +14,7 @@
       name="description"
       content="A gallery of solved KoFEM examples — axial bar, cantilever beam, plate with a hole and Cook's membrane. Drag to rotate each solved result, then open it in KoFEM web."
     />
-    <link rel="canonical" href="https://solver.example.com/examples/" />
+    <link rel="canonical" href="https://kofem.org/examples/" />
     <meta name="robots" content="index, follow" />
 
     <!-- Open Graph / social -->
@@ -24,10 +24,10 @@
       property="og:description"
       content="Interactive, solved KoFEM examples you can rotate in the browser and open in the app."
     />
-    <meta property="og:url" content="https://solver.example.com/examples/" />
+    <meta property="og:url" content="https://kofem.org/examples/" />
     <meta
       property="og:image"
-      content="https://solver.example.com/kofem_logo.svg"
+      content="https://kofem.org/kofem_logo.svg"
     />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Examples — KoFEM" />
@@ -37,7 +37,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://solver.example.com/kofem_logo.svg"
+      content="https://kofem.org/kofem_logo.svg"
     />
 
     <!-- Self-hosted fonts (SIL OFL) — see public/fonts/README.md -->

--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,7 @@
       name="description"
       content="KoFEM is a free online finite element solver that runs entirely in your browser. Import STEP geometry, apply loads and boundary conditions, and run a direct static solve — no installation required."
     />
-    <link rel="canonical" href="https://solver.example.com/" />
+    <link rel="canonical" href="https://kofem.org/" />
     <meta name="robots" content="index, follow" />
 
     <!-- Open Graph / social -->
@@ -26,10 +26,10 @@
       property="og:description"
       content="Browser-based FEM analysis. Import STEP geometry and run a direct static solve in your browser. No installation required."
     />
-    <meta property="og:url" content="https://solver.example.com/" />
+    <meta property="og:url" content="https://kofem.org/" />
     <meta
       property="og:image"
-      content="https://solver.example.com/kofem_logo.svg"
+      content="https://kofem.org/kofem_logo.svg"
     />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Online Finite Element Solver — KoFEM" />
@@ -39,7 +39,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://solver.example.com/kofem_logo.svg"
+      content="https://kofem.org/kofem_logo.svg"
     />
 
     <!-- Self-hosted fonts (SIL OFL) — see public/fonts/README.md -->

--- a/web/privacy/index.html
+++ b/web/privacy/index.html
@@ -14,7 +14,7 @@
       name="description"
       content="How KoFEM handles data and cookies. KoFEM runs your FEM analysis entirely in the browser and uses Google Analytics only with your consent."
     />
-    <link rel="canonical" href="https://solver.example.com/privacy/" />
+    <link rel="canonical" href="https://kofem.org/privacy/" />
     <meta name="robots" content="index, follow" />
 
     <!-- Self-hosted fonts (SIL OFL) — see public/fonts/README.md -->

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://kofem.org/sitemap.xml

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://kofem.org/</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://kofem.org/examples/</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://kofem.org/privacy/</loc>
+    <priority>0.1</priority>
+  </url>
+</urlset>

--- a/web/tests/landing.spec.ts
+++ b/web/tests/landing.spec.ts
@@ -19,3 +19,22 @@ test("landing page renders and links to the solver app", async ({ page }) => {
   const launch = page.getByRole("link", { name: /Start Solver/i }).first();
   await expect(launch).toHaveAttribute("href", "/app/");
 });
+
+// A rel=canonical pointing at a domain we do not own tells Google the real page
+// lives elsewhere, so the page it sits on drops out of the index. These run
+// against `vite preview`, i.e. the same build output that ships.
+const SITE_ORIGIN = "https://kofem.org";
+
+for (const path of ["/", "/examples/", "/privacy/"]) {
+  test(`${path} declares its canonical URL on the production origin`, async ({
+    page,
+  }) => {
+    await page.goto(path);
+
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      `${SITE_ORIGIN}${path}`,
+    );
+    expect(await page.content()).not.toContain("example.com");
+  });
+}


### PR DESCRIPTION
## Summary

Updates all canonical URL references from `solver.example.com` to the production domain `kofem.org`, and adds SEO infrastructure (robots.txt and sitemap.xml) to improve search engine discoverability. This ensures Google indexes the correct domain and prevents duplicate content penalties.

Fixes KOF-

## Key Changes

**Web**
- Updated canonical URL in `web/index.html` from `https://solver.example.com/` to `https://kofem.org/`
- Updated canonical URL in `web/examples/index.html` from `https://solver.example.com/examples/` to `https://kofem.org/examples/`
- Updated canonical URL in `web/privacy/index.html` from `https://solver.example.com/privacy/` to `https://kofem.org/privacy/`
- Updated all Open Graph and Twitter Card meta tags to reference `https://kofem.org` instead of `solver.example.com`
- Added `web/public/robots.txt` with sitemap reference
- Added `web/public/sitemap.xml` with priority weights for the three main pages

**Tests**
- Added comprehensive test suite in `web/tests/landing.spec.ts` that verifies canonical URLs are correctly set to the production origin for `/`, `/examples/`, and `/privacy/` routes
- Tests also verify that no example.com references leak into the page content

## Notable Implementation Details

The canonical URL tests run against `vite preview` (the production build output), ensuring the checks validate what actually ships. The sitemap includes all three main pages with appropriate priority weights (1.0 for home, 0.8 for examples, 0.1 for privacy). The robots.txt explicitly allows all paths and points to the sitemap.

## Checklist

- [x] **No silent fallbacks** — N/A; this is configuration and metadata only
- [x] Every input accepted by the UI or an API is actually consumed downstream — N/A; these are static metadata files and test assertions

https://claude.ai/code/session_01VtvT6Mi6nM4BMUEvow1nqh