### PR TITLE
Replace `mpc` bool with `CouplingKind` enum for coupling formulation

### DIFF
--- a/engine/cpp/shell_core.cpp
+++ b/engine/cpp/shell_core.cpp
@@ -807,7 +807,7 @@ Rbe3Constraints build_rbe3_constraints(const CoupledInput& in, int nDof,
         const size_t R6 = 6 * static_cast<size_t>(R);
         for (size_t k = 0; k < 6; ++k) out.dep[R6 + k] = 1;
 
-        if (cp.mpc) {
+        if (cp.kind == CouplingKind::RelaxedMpc) {
             // Relaxed shell-to-solid MPC (Lu, Zhang & Yang 2023), generalised to a
             // NON-CONFORMING seam. The paper ties the shell node to a solid node
             // coincident with it; an auto-detected seam has none, and tying to the

--- a/engine/cpp/shell_core.h
+++ b/engine/cpp/shell_core.h
@@ -74,7 +74,7 @@ ShellResult solve_shell_core(const ShellInput& in);
 //                   Adds no stiffness to the coupled set, so it idealises a
 //                   surface to a point without making the surface rigid — but
 //                   the point cannot be fixed or driven, only loaded.
-//   RelaxedMpc    — the shell-to-solid seam variant of Distributing (see below).
+//   RelaxedMpc    — the shell-to-solid seam variant of Distributing (see `kind`).
 //   Kinematic     — RBE2. The other way round: solid_nodes are DEPENDENT and
 //                   follow ref_node as a rigid body, u_i = u_R + θ_R × r_i. The
 //                   point is INDEPENDENT, so it can be fixed, loaded, or tied to
@@ -90,9 +90,11 @@ struct Coupling {
     int ref_node = -1;                   // shell node whose 6 DOFs are dependent
     std::vector<int> solid_nodes;        // solid nodes it distributes to
     std::vector<double> weights;         // per solid node (empty ⇒ equal weights)
-    // Relaxed shell-to-solid MPC (Lu, Zhang & Yang, "A Relaxed MPC Method for
-    // Non-rigid Shell to Solid Coupling", J. Phys.: Conf. Ser. 2528 012064, 2023).
-    // When true, the reference (shell) node's translations are tied to the
+    // Which formulation ties this coupling — the single source of truth for it.
+    //
+    // RelaxedMpc is the relaxed shell-to-solid MPC of Lu, Zhang & Yang ("A Relaxed
+    // MPC Method for Non-rigid Shell to Solid Coupling", J. Phys.: Conf. Ser. 2528
+    // 012064, 2023): the reference (shell) node's translations are tied to the
     // DISTANCE-WEIGHTED CENTROID of its solid patch, and its rotations follow the
     // relaxation-scaled least-squares rotation of that patch. The 1/(d²+ε²) weight
     // keeps the tie local, so it enforces displacement CONTINUITY at the junction —
@@ -110,12 +112,11 @@ struct Coupling {
     // and recovers the paper's tie.
     //
     // Appropriate for a continuous-material seam (a thin wall idealised as shell,
-    // tied back to the retained solid); the distributing coupling (mpc = false)
-    // stays for genuinely gapped, non-conforming interfaces (a pin in a hole).
-    bool mpc = false;
-    double relaxation = 1.0;  // ψ scaling the rotation transfer; paper uses [0.5, 1]
-
+    // tied back to the retained solid); Distributing stays for genuinely gapped,
+    // non-conforming interfaces (a pin in a hole).
     CouplingKind kind = CouplingKind::Distributing;
+    double relaxation = 1.0;  // RelaxedMpc only: ψ scaling the rotation transfer; paper uses [0.5, 1]
+
     // Kinematic only. A rotation bit ties θ_i = θ_R, which only exists where the
     // coupled node carries rotational stiffness — on a solid-only node there is
     // no rotation DOF to tie and the bit has no effect. Selecting the

--- a/engine/cpp/solve_coupled.cpp
+++ b/engine/cpp/solve_coupled.cpp
@@ -171,7 +171,6 @@ val solve_coupled(const val& mesh, const val& coupling, const val& bcs,
         const int kind = k < cmpc.size() ? cmpc[k] : 0;
         if (kind == 1) {
             cp.kind = kofem::shell::CouplingKind::RelaxedMpc;
-            cp.mpc = true;
             cp.relaxation = relaxation;
         } else if (kind == 2) {
             cp.kind = kofem::shell::CouplingKind::Kinematic;

--- a/engine/tests/shell_validation.cpp
+++ b/engine/tests/shell_validation.cpp
@@ -250,7 +250,7 @@ double coupled_mpc_clamped(double psi) {
     in.shell_young = E; in.shell_poisson = nu; in.thickness = t;
     for (int rn : root) {
         Coupling cp; cp.ref_node = rn; cp.solid_nodes = {aBase, aBase + 1, aBase + 2};
-        cp.mpc = true; cp.relaxation = psi;
+        cp.kind = CouplingKind::RelaxedMpc; cp.relaxation = psi;
         in.couplings.push_back(cp);
     }
     for (int aa = 0; aa < 3; ++aa) for (int c = 0; c < 3; ++c) in.fixed_dofs.push_back(6 * (aBase + aa) + c);
@@ -351,7 +351,7 @@ double mpc_seam_peak(int order) {
         });
         Coupling cp;
         cp.ref_node = rn; cp.solid_nodes = patch;
-        cp.kind = CouplingKind::RelaxedMpc; cp.mpc = true; cp.relaxation = 1.0;
+        cp.kind = CouplingKind::RelaxedMpc; cp.relaxation = 1.0;
         in.couplings.push_back(std::move(cp));
     }
     // Cantilever the block in its own plane so the seam sees a transverse


### PR DESCRIPTION
## Summary

Replaces the `Coupling::mpc` boolean flag with the existing `CouplingKind` enum as the single source of truth for which coupling formulation is active. This eliminates redundant state (previously both `mpc` and `kind` could be set) and makes the code more explicit and maintainable.

## Key Changes

**engine/cpp/shell_core.h**
- Removed `bool mpc` field from `Coupling` struct
- Added `CouplingKind kind` field (moved earlier in the struct for clarity)
- Rewrote coupling documentation to reference `kind` instead of `mpc`, and clarified that `RelaxedMpc` is the relaxed shell-to-solid MPC formulation
- Moved `relaxation` field comment to clarify it applies only to `RelaxedMpc`

**engine/cpp/shell_core.cpp**
- Changed condition from `if (cp.mpc)` to `if (cp.kind == CouplingKind::RelaxedMpc)` in `build_rbe3_constraints`

**engine/cpp/solve_coupled.cpp**
- Removed the line `cp.mpc = true` when setting `cp.kind = CouplingKind::RelaxedMpc`

**engine/tests/shell_validation.cpp**
- Updated `coupled_mpc_clamped()` to set `cp.kind = CouplingKind::RelaxedMpc` instead of `cp.mpc = true`
- Updated `mpc_seam_peak()` to remove redundant `cp.mpc = true` assignment

## Notable Implementation Details

The `CouplingKind` enum already existed with `Distributing`, `RelaxedMpc`, and `Kinematic` variants. Previously, the code used both `kind` and a separate `mpc` boolean, creating two ways to express the same information. This refactor consolidates to a single source of truth: `kind == CouplingKind::RelaxedMpc` replaces `mpc == true`.

The `relaxation` parameter is now documented as `RelaxedMpc` only, making its scope explicit in the code.

## Checklist

- [x] **No silent fallbacks** — the change is a straightforward enum-based dispatch replacing a boolean flag; no new fallback paths introduced.
- [x] Every input accepted by the API is consumed downstream — `kind` was already being read; this just removes the redundant `mpc` field.

https://claude.ai/code/session_01SPu9fJ5tUod6SFKMudewct